### PR TITLE
Enable agent prompt dispatch in macro CLI

### DIFF
--- a/macro_system/Macros/README.md
+++ b/macro_system/Macros/README.md
@@ -1,0 +1,209 @@
+# Macros Package
+
+## Overview
+The Macros package provides a modular way to turn concise macro invocations
+(for example `::frontendgen`) into fully fledged sets of instructions for
+building production-grade software. Each macro can expand into text as well as
+invoke additional macros, allowing complex scaffolds to be assembled from small
+reusable building blocks.
+
+## Key Capabilities
+- Pure JSON storage for macro definitions to guarantee auditability.
+- Recursive expansion with cycle detection, validation, strict auditing, and
+  traversal traces.
+- Memoised caching that can be inspected or cleared to accelerate repeated
+  expansions.
+- Catalogue analytics (roots, leaves, depth, branching factor) and structured
+  audit reports (missing references, cycles, unreachable macros).
+- Metadata tagging, filtering, and grouping for rapid macro discovery across
+  domains, pillars, and execution levels.
+- Hierarchical plans that render as outlines, Markdown documents, JSON payloads,
+  or flattened task lists.
+- Advanced CLI helpers for searching macros, exporting plans, listing tasks,
+  viewing traversal traces, running audits, explaining dependency paths, and
+  enumerating ancestor relationships.
+- Agent-oriented orchestration that groups plan steps by specialist roles for
+  multi-agent collaboration workflows.
+- Repository utilities for merging custom catalogues, reloading sources, and
+  exporting consolidated snapshots for audit trails.
+
+## Usage
+```python
+from macro_system import MacroEngine
+
+engine = MacroEngine.from_json("macro_system/Macros/macros.json")
+engine.validate()  # Optional integrity check
+print(engine.expand("::masterdev"))
+```
+
+### Advanced Introspection
+The engine exposes convenience utilities for sophisticated tooling:
+
+- `available_macros()` – discover macros alphabetically.
+- `describe(name)` – inspect the underlying `Macro` dataclass (including
+  metadata).
+- `dependencies(name, recursive=True)` – explore macro call chains.
+- `ancestors(name, recursive=True)` – list macros that depend on the given
+  macro.
+- `expand_many([...], use_cache=True)` – expand several macros while reusing
+  cached results.
+- `expand_with_trace(name)` – capture the traversal order alongside the
+  expansion result.
+- `search(query)` – find macros by name or expansion text.
+- `filter_by_metadata({"domain": "frontend"})` – return macros with matching
+  metadata.
+- `group_by_metadata("domain")` – cluster macros by metadata values for
+  reporting or dashboards.
+- `render(name, context)` – substitute `{{placeholders}}` using context
+  mappings for project-aware output.
+- `placeholders(name, recursive=True)` – list the placeholder tokens required by
+  a macro and optionally its dependencies.
+- `audit(entrypoints=None)` – produce a `MacroAudit` detailing undefined
+  references, cycles, unreachable macros, and statistics.
+- `validate_strict(entrypoints=None)` – raise on audit findings to enforce clean
+  catalogues.
+- `stats()` – return aggregated catalogue metrics via the `MacroStats` dataclass.
+- `clear_cache()` / `cache_info()` – manage memoised expansions.
+- `explain_path(source, target)` – report a dependency path between two macros.
+
+These helpers make it straightforward to embed the macro system into custom
+developer tooling, dashboards, or prompt authoring assistants.
+
+### Planning Utilities
+For agents that need structured steps rather than plain prose, the
+`MacroPlanner` converts macros into hierarchical plans. Plans support outline,
+Markdown, dictionary, and flattened task renderings:
+
+```python
+from macro_system import MacroEngine, MacroPlanner
+
+engine = MacroEngine.from_json("macro_system/Macros/macros.json")
+planner = MacroPlanner(engine)
+
+plan = planner.build("::masterdev")
+print(plan.to_outline())        # Human-readable outline
+print(plan.to_markdown())       # Markdown document
+print(plan.to_dict())           # Structured for programmatic consumption
+print(planner.tasks("::masterdev"))  # Leaf task summaries
+```
+
+### Agent-Oriented Orchestration
+Coordinate execution responsibilities across the U-DIG IT agent roster using the
+`MacroOrchestrator`. Tasks are automatically allocated using macro metadata, and
+domain-to-agent mappings can be customised when needed:
+
+```python
+from macro_system import MacroEngine, MacroOrchestrator
+
+engine = MacroEngine.from_json("macro_system/Macros/macros.json")
+orchestrator = MacroOrchestrator(engine)
+
+assignments = orchestrator.assign("::fullstacksuite")
+for assignment in assignments:
+    print(assignment.to_outline())
+```
+
+Override role mappings or combine multiple macros by calling
+`orchestrator.assign_many([...], include_non_leaf=True)`. Each
+`AgentAssignment` exposes helper methods for outlines, JSON-friendly dicts,
+conversational prompts, and raw instruction text, making it straightforward to
+feed agent-specific payloads into automation workflows.
+
+```python
+assignment.to_outline()        # Markdown brief for QA or design reviews
+assignment.instructions_text() # Concise bullet list for agent execution
+assignment.to_prompt()         # Conversational prompt packaged for LLM agents
+assignment.to_dict()           # JSON payload for downstream automation
+```
+
+CLI equivalents are available for rapid experimentation:
+
+```bash
+python -m macro_system.cli --assign-agents ::masterdev
+python -m macro_system.cli --assign-json ::frontendsuite --agent-map frontend="Design Agent"
+python -m macro_system.cli --assign-agents ::frontendsuite --assign-include-non-leaf
+python -m macro_system.cli --assign-prompts ::masterdev
+python -m macro_system.cli --assign-prompts-format outline --assign-prompts ::frontendsuite ::datasuite
+```
+
+### Catalogue Management
+Combine the bundled catalogue with organisation-specific JSON files using the
+`MacroRepository` or the CLI:
+
+```python
+from pathlib import Path
+
+from macro_system import MacroEngine, MacroRepository
+
+repository = MacroRepository([
+    Path("macro_system/Macros/macros.json"),
+    Path("~/team-catalog.json").expanduser(),
+])
+engine = repository.engine()
+print(engine.expand("::custom-suite"))
+
+repository.export(Path("merged-catalog.json"))  # Snapshot the merged view
+```
+
+Command-line equivalents:
+
+```bash
+python -m macro_system.cli --catalog ~/team-catalog.json --list-sources
+python -m macro_system.cli --catalog-dir ./catalogs --export-merged merged.json
+python -m macro_system.cli --no-default --catalog custom.json --list
+```
+
+### Contextual Rendering
+The engine also supports templated placeholders. Call
+`engine.render("::project-kickoff", {"project_name": "Atlas"})` to tailor
+expansions and run `engine.placeholders("::project-kickoff")` to discover the
+expected context keys. The CLI mirrors these capabilities through the
+`--context`, `--context-file`, `--allow-partial`, and `--placeholders` flags for
+fully automated workflows.
+
+### Command-Line Interface
+The enhanced CLI supports rapid experimentation and automation:
+
+```bash
+python -m macro_system.cli --list
+python -m macro_system.cli --search frontend
+python -m macro_system.cli --filter-meta domain=frontend
+python -m macro_system.cli --group-meta domain
+python -m macro_system.cli --stats
+python -m macro_system.cli --audit --entrypoint ::masterdev
+python -m macro_system.cli --describe ::frontendgen
+python -m macro_system.cli --deps ::masterdev
+python -m macro_system.cli --ancestors ::frontendgen
+python -m macro_system.cli --plan ::frontendsuite
+python -m macro_system.cli --plan-json ::fullstacksuite
+python -m macro_system.cli --markdown ::masterdev
+python -m macro_system.cli --tasks ::masterdev
+python -m macro_system.cli --trace ::datasuite
+python -m macro_system.cli --path ::masterdev ::frontendgen
+python -m macro_system.cli --catalog extra.json --list-sources
+python -m macro_system.cli --catalog-dir ./catalogs --export-merged merged.json
+python -m macro_system.cli ::frontendsuite ::backendsuite --output plan.txt
+```
+
+### Folder Layout
+All macro functionality now lives inside the `macro_system/Macros` directory:
+
+- `macros.json` – Plain JSON macro definitions.
+- `catalog.py` – Loading, validation, metadata parsing, and catalogue merging
+  utilities.
+- `engine.py` – Recursive macro expansion engine with caching and analytics.
+- `repository.py` – Repository for merging catalogues, refreshing sources, and
+  exporting merged JSON snapshots.
+- `planner.py` – Hierarchical plan construction helpers.
+- `types.py` – Dataclasses, exceptions, audits, and statistics utilities.
+- `cli.py` – Command-line tooling for expansion, planning, auditing, and graph
+  exploration.
+- `tests/` – Automated tests covering loading, expansion, planning, analytics,
+  and CLI behaviour.
+
+## Testing
+Run the unit tests with:
+
+```bash
+python -m pytest macro_system/Macros/tests
+```

--- a/macro_system/Macros/__init__.py
+++ b/macro_system/Macros/__init__.py
@@ -1,0 +1,62 @@
+"""Primary exports for the Macros package."""
+
+"""Header & Purpose: surface primary Macros package exports."""
+
+# === Imports / Dependencies ===
+from .catalog import load_catalogs, load_default_catalog, load_macros
+from .engine import MacroEngine
+from .orchestrator import DEFAULT_AGENT_MAP, MacroOrchestrator
+from .planner import MacroPlanner
+from .repository import MacroRepository
+from .types import (
+    AgentAssignment,
+    Macro,
+    MacroAudit,
+    MacroCycleError,
+    MacroDefinitionError,
+    MacroError,
+    MacroNotFoundError,
+    MacroRenderError,
+    MacroStats,
+    MacroValidationError,
+    PlanStep,
+)
+
+# === Types / Interfaces / Schemas ===
+# Exports include dataclasses, exceptions, and loader utilities.
+
+
+# === Core Logic / Implementation ===
+# Centralises exports to simplify consumers' import paths.
+
+
+# === Error & Edge Handling ===
+# Errors are defined within ``types`` and re-exported for package users.
+
+
+# === Performance Considerations ===
+# Central re-export adds no overhead; actual logic resides in submodules.
+
+
+# === Exports / Public API ===
+__all__ = [
+    "AgentAssignment",
+    "Macro",
+    "MacroAudit",
+    "MacroCycleError",
+    "MacroDefinitionError",
+    "MacroEngine",
+    "MacroError",
+    "MacroNotFoundError",
+    "MacroPlanner",
+    "MacroOrchestrator",
+    "MacroRenderError",
+    "MacroStats",
+    "MacroValidationError",
+    "PlanStep",
+    "MacroRepository",
+    "DEFAULT_AGENT_MAP",
+    "load_catalogs",
+    "load_default_catalog",
+    "load_macros",
+]

--- a/macro_system/Macros/catalog.py
+++ b/macro_system/Macros/catalog.py
@@ -1,0 +1,111 @@
+"""Header & Purpose: load macro catalogues from JSON definitions."""
+
+from __future__ import annotations
+
+# === Imports / Dependencies ===
+import json
+from pathlib import Path
+from typing import Dict, Iterable, Mapping, Sequence
+
+from .types import Macro, MacroDefinitionError
+
+# === Types / Interfaces / Schemas ===
+# Macros are represented by :class:`Macro` dataclasses defined in ``types``.
+
+CatalogSource = Mapping[str, object] | str | Path
+
+
+# === Core Logic / Implementation ===
+CATALOG_FILENAME = "macros.json"
+
+
+def load_macros(source: CatalogSource) -> Dict[str, Macro]:
+    """Load and validate macros from a JSON file path or in-memory mapping."""
+
+    if isinstance(source, (str, Path)):
+        data = _load_json(Path(source))
+    else:
+        data = dict(source)
+
+    macros: Dict[str, Macro] = {}
+    for name, payload in data.items():
+        macros[name] = _convert_macro(name, payload)
+    return macros
+
+
+def load_catalogs(sources: Sequence[CatalogSource]) -> Dict[str, Macro]:
+    """Merge multiple catalogues, ensuring definitions remain unique."""
+
+    merged: Dict[str, Macro] = {}
+    for raw_source in sources:
+        catalog = load_macros(raw_source)
+        for name, macro in catalog.items():
+            existing = merged.get(name)
+            if existing is not None and existing.describe() != macro.describe():
+                raise MacroDefinitionError(
+                    f"Duplicate definition detected for macro '{name}' across catalogues."
+                )
+            merged[name] = macro
+    return merged
+
+
+def load_default_catalog() -> Dict[str, Macro]:
+    """Load the bundled macro catalogue shipped with the package."""
+
+    default_path = Path(__file__).with_name(CATALOG_FILENAME)
+    return load_macros(default_path)
+
+
+# === Error & Edge Handling ===
+
+def _load_json(path: Path) -> Dict[str, object]:
+    """Read JSON file from disk with explicit error reporting."""
+
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:  # pragma: no cover - explicit error passthrough
+        raise MacroDefinitionError(f"Macro definition file not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise MacroDefinitionError(f"Invalid JSON in macro definition file: {path}") from exc
+
+
+def _convert_macro(name: str, payload: object) -> Macro:
+    """Validate and convert a raw payload into a :class:`Macro`."""
+
+    if not isinstance(payload, dict):
+        raise MacroDefinitionError(f"Macro '{name}' must be defined as an object.")
+
+    if not isinstance(name, str) or not name.startswith("::"):
+        raise MacroDefinitionError("Macro names must be strings prefixed with '::'.")
+
+    expansion = payload.get("expansion")
+    calls = payload.get("calls", [])
+    metadata = payload.get("metadata", {})
+
+    if not isinstance(expansion, str) or not expansion.strip():
+        raise MacroDefinitionError(f"Macro '{name}' must include a non-empty expansion string.")
+
+    if not isinstance(calls, list) or not _all_strings(calls):
+        raise MacroDefinitionError(f"Macro '{name}' calls must be a list of macro names.")
+
+    if metadata and not isinstance(metadata, dict):
+        raise MacroDefinitionError(f"Macro '{name}' metadata must be an object if provided.")
+
+    return Macro(name=name, expansion=expansion, calls=list(calls), metadata=dict(metadata))
+
+
+# === Performance Considerations ===
+
+def _all_strings(values: Iterable[object]) -> bool:
+    """Return ``True`` if all values are strings; short-circuits on first failure."""
+
+    return all(isinstance(item, str) for item in values)
+
+
+# === Exports / Public API ===
+__all__ = [
+    "CATALOG_FILENAME",
+    "load_catalogs",
+    "load_default_catalog",
+    "load_macros",
+]

--- a/macro_system/Macros/cli.py
+++ b/macro_system/Macros/cli.py
@@ -1,0 +1,658 @@
+"""Header & Purpose: ergonomic CLI gateway for the macro system."""
+
+from __future__ import annotations
+
+# === Imports / Dependencies ===
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+from .orchestrator import MacroOrchestrator
+from .planner import MacroPlanner
+from .repository import MacroRepository
+from .types import MacroError
+
+# === Types / Interfaces / Schemas ===
+# CLI arguments map to engine and planner operations.
+
+
+# === Core Logic / Implementation ===
+def build_parser() -> argparse.ArgumentParser:
+    """Create the CLI argument parser."""
+
+    parser = argparse.ArgumentParser(
+        description="Expand, audit, and plan macros from macros.json",
+        prog="macro-system",
+    )
+    parser.add_argument(
+        "macro",
+        nargs="*",
+        help="Macro names to expand. Accepts multiple values.",
+    )
+    parser.add_argument(
+        "-f",
+        "--file",
+        type=Path,
+        default=Path(__file__).resolve().with_name("macros.json"),
+        help="Path to macros.json (defaults to bundled file).",
+    )
+    parser.add_argument(
+        "--catalog",
+        dest="catalogs",
+        action="append",
+        type=Path,
+        metavar="PATH",
+        help="Additional macro catalogue JSON file(s) to merge.",
+    )
+    parser.add_argument(
+        "--catalog-dir",
+        dest="catalog_dirs",
+        action="append",
+        type=Path,
+        metavar="DIR",
+        help="Load all *.json catalogues from DIR and merge them.",
+    )
+    parser.add_argument(
+        "--no-default",
+        action="store_true",
+        help="Skip loading the bundled macros.json file.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        help="Optional file path to write the expansion output.",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List all available macros and exit.",
+    )
+    parser.add_argument(
+        "--describe",
+        metavar="MACRO",
+        help="Print the JSON definition for the specified macro.",
+    )
+    parser.add_argument(
+        "--deps",
+        metavar="MACRO",
+        help="Show the dependency chain for the specified macro.",
+    )
+    parser.add_argument(
+        "--ancestors",
+        metavar="MACRO",
+        help="Show macros that depend on the specified macro.",
+    )
+    parser.add_argument(
+        "--no-recursive",
+        action="store_true",
+        help="When used with --deps or --ancestors, only show direct relationships.",
+    )
+    parser.add_argument(
+        "--validate",
+        action="store_true",
+        help="Validate the macro graph before running other commands.",
+    )
+    parser.add_argument(
+        "--validate-strict",
+        action="store_true",
+        help="Run strict validation including entrypoint reachability checks.",
+    )
+    parser.add_argument(
+        "--entrypoint",
+        action="append",
+        dest="entrypoints",
+        metavar="MACRO",
+        help="Specify entrypoint(s) for auditing and strict validation.",
+    )
+    parser.add_argument(
+        "--plan",
+        metavar="MACRO",
+        help="Render the macro as a nested execution plan.",
+    )
+    parser.add_argument(
+        "--plan-json",
+        metavar="MACRO",
+        help="Render the macro plan as JSON for downstream tooling.",
+    )
+    parser.add_argument(
+        "--markdown",
+        metavar="MACRO",
+        help="Render the macro plan as Markdown.",
+    )
+    parser.add_argument(
+        "--tasks",
+        metavar="MACRO",
+        help="List the actionable tasks for the macro.",
+    )
+    parser.add_argument(
+        "--assign-agents",
+        metavar="MACRO",
+        help="Group MACRO's tasks by agent roles using metadata heuristics.",
+    )
+    parser.add_argument(
+        "--assign-json",
+        metavar="MACRO",
+        help="Output agent assignments for MACRO as JSON.",
+    )
+    parser.add_argument(
+        "--assign-prompts",
+        metavar="MACRO",
+        nargs="+",
+        help="Emit agent-specific prompts for the provided MACRO(s).",
+    )
+    parser.add_argument(
+        "--assign-prompts-format",
+        default="prompt",
+        choices=["prompt", "outline", "text"],
+        help="Select output style when using --assign-prompts (default: prompt).",
+    )
+    parser.add_argument(
+        "--assign-include-non-leaf",
+        action="store_true",
+        help="Include parent macros when generating agent assignments.",
+    )
+    parser.add_argument(
+        "--agent-map",
+        action="append",
+        metavar="DOMAIN=AGENT",
+        help="Override domain-to-agent mappings for orchestration.",
+    )
+    parser.add_argument(
+        "--search",
+        metavar="QUERY",
+        help="Search macros by name, expansion text, or metadata.",
+    )
+    parser.add_argument(
+        "--filter-meta",
+        action="append",
+        metavar="KEY=VALUE",
+        help=(
+            "Filter macros by metadata key/value pairs. Provide multiple values to "
+            "apply additional filters."
+        ),
+    )
+    parser.add_argument(
+        "--group-meta",
+        metavar="KEY",
+        help="Group macros by a metadata key and output JSON mapping values to macros.",
+    )
+    parser.add_argument(
+        "--match-any",
+        action="store_true",
+        help="When filtering metadata, match macros satisfying any filter instead of all.",
+    )
+    parser.add_argument(
+        "--case-sensitive",
+        action="store_true",
+        help="Treat metadata comparisons as case-sensitive.",
+    )
+    parser.add_argument(
+        "--stats",
+        action="store_true",
+        help="Show catalogue statistics and exit.",
+    )
+    parser.add_argument(
+        "--audit",
+        action="store_true",
+        help="Run a full audit and emit JSON describing catalogue health.",
+    )
+    parser.add_argument(
+        "--list-sources",
+        action="store_true",
+        help="List merged catalogue sources and exit.",
+    )
+    parser.add_argument(
+        "--export-merged",
+        type=Path,
+        metavar="DEST",
+        help="Write the merged catalogue to DEST as JSON.",
+    )
+    parser.add_argument(
+        "--path",
+        nargs=2,
+        metavar=("SOURCE", "TARGET"),
+        help="Explain the dependency path from SOURCE to TARGET if it exists.",
+    )
+    parser.add_argument(
+        "--trace",
+        metavar="MACRO",
+        help="Expand a macro while displaying the traversal trace.",
+    )
+    parser.add_argument(
+        "--context",
+        action="append",
+        metavar="KEY=VALUE",
+        help=(
+            "Provide placeholder substitution values using KEY=VALUE pairs. "
+            "Repeat for multiple entries."
+        ),
+    )
+    parser.add_argument(
+        "--context-file",
+        type=Path,
+        help="Load placeholder substitutions from a JSON object file.",
+    )
+    parser.add_argument(
+        "--allow-partial",
+        action="store_true",
+        help="Allow rendering to succeed when some placeholders remain unresolved.",
+    )
+    parser.add_argument(
+        "--placeholders",
+        metavar="MACRO",
+        help=(
+            "List placeholder tokens (e.g. {{name}}) referenced by the macro. "
+            "Includes dependencies by default."
+        ),
+    )
+    parser.add_argument(
+        "--placeholders-direct",
+        action="store_true",
+        help="When listing placeholders, only show those defined on the macro itself.",
+    )
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    """Entry point for the macro-system CLI."""
+
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    try:
+        repository = _build_repository(args, parser)
+        engine = repository.engine()
+        planner = MacroPlanner(engine)
+
+        try:
+            agent_overrides = (
+                _parse_agent_map(args.agent_map) if args.agent_map else None
+            )
+        except ValueError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 2
+
+        orchestrator = MacroOrchestrator(engine, agent_map=agent_overrides)
+
+        if args.validate:
+            engine.validate()
+
+        if args.validate_strict:
+            engine.validate_strict(entrypoints=args.entrypoints)
+
+        additional_flags: List[bool] = [
+            args.list,
+            bool(args.describe),
+            bool(args.deps),
+            bool(args.ancestors),
+            args.stats,
+            args.audit,
+            bool(args.search),
+            bool(args.filter_meta),
+            bool(args.group_meta),
+            bool(args.plan),
+            bool(args.plan_json),
+            bool(args.markdown),
+            bool(args.tasks),
+            bool(args.path),
+            bool(args.trace),
+            bool(args.placeholders),
+            bool(args.assign_agents),
+            bool(args.assign_json),
+            bool(args.assign_prompts),
+        ]
+        has_followup = bool(args.macro) or any(additional_flags)
+
+        if args.list_sources:
+            for source in repository.sources():
+                print(source)
+            if not has_followup and not args.export_merged:
+                return 0
+
+        if args.export_merged:
+            repository.export(args.export_merged)
+            print(
+                json.dumps(
+                    {
+                        "export": str(args.export_merged),
+                        "total_macros": len(repository),
+                        "sources": repository.sources(),
+                    },
+                    indent=2,
+                )
+            )
+            if not has_followup:
+                return 0
+
+        multi_plan_flags: List[str | None] = [
+            args.plan,
+            args.plan_json,
+            args.markdown,
+        ]
+        selected = [flag for flag in multi_plan_flags if flag]
+        if len(selected) > 1:
+            print(
+                "Error: only one of --plan, --plan-json, or --markdown may be used at a time.",
+                file=sys.stderr,
+            )
+            return 2
+
+        try:
+            context: Dict[str, object] = {}
+            if args.context_file:
+                context.update(_load_context_file(args.context_file))
+            if args.context:
+                context.update(_parse_context_pairs(args.context))
+        except ValueError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 2
+
+        if args.stats:
+            stats = engine.stats()
+            print(json.dumps(stats.to_dict(), indent=2))
+            return 0
+
+        if args.audit:
+            audit = engine.audit(entrypoints=args.entrypoints)
+            print(json.dumps(audit.to_dict(), indent=2))
+            return 0
+
+        if args.placeholders:
+            placeholders = engine.placeholders(
+                args.placeholders, recursive=not args.placeholders_direct
+            )
+            for name in placeholders:
+                print(name)
+            return 0
+
+        if args.group_meta:
+            grouped = engine.group_by_metadata(
+                args.group_meta, case_sensitive=args.case_sensitive
+            )
+            payload = {
+                value: [macro.name for macro in macros]
+                for value, macros in grouped.items()
+            }
+            print(json.dumps(payload, indent=2))
+            return 0
+
+        if args.filter_meta:
+            try:
+                filters = _parse_filters(args.filter_meta)
+            except ValueError as exc:
+                print(f"Error: {exc}", file=sys.stderr)
+                return 2
+            matches = engine.filter_by_metadata(
+                filters,
+                case_sensitive=args.case_sensitive,
+                match_all=not args.match_any,
+            )
+            for macro in matches:
+                print(macro.name)
+            return 0
+
+        if args.search:
+            matches = engine.search(args.search)
+            for macro in matches:
+                print(macro.name)
+            return 0
+
+        if args.list:
+            for name in engine.available_macros():
+                print(name)
+            return 0
+
+        if args.describe:
+            macro = engine.describe(args.describe)
+            print(json.dumps(macro.describe(), indent=2))
+            return 0
+
+        if args.deps:
+            deps = engine.dependencies(
+                args.deps, recursive=not args.no_recursive
+            )
+            for item in deps:
+                print(item)
+            return 0
+
+        if args.ancestors:
+            parents = engine.ancestors(
+                args.ancestors, recursive=not args.no_recursive
+            )
+            for parent in parents:
+                print(parent)
+            return 0
+
+        if args.path:
+            source, target = args.path
+            path = engine.explain_path(source, target)
+            if not path:
+                print(
+                    f"No dependency path found from {source} to {target}.",
+                    file=sys.stderr,
+                )
+                return 1
+            print(" -> ".join(path))
+            return 0
+
+        if args.plan_json:
+            print(planner.render_json(args.plan_json))
+            return 0
+
+        if args.plan:
+            print(planner.render_outline(args.plan))
+            return 0
+
+        if args.markdown:
+            print(planner.render_markdown(args.markdown))
+            return 0
+
+        if args.tasks:
+            for task in planner.tasks(args.tasks):
+                print(task)
+            return 0
+
+        include_non_leaf = args.assign_include_non_leaf
+        if args.assign_prompts:
+            try:
+                payload = orchestrator.dispatch(
+                    args.assign_prompts,
+                    include_non_leaf=include_non_leaf,
+                    format=args.assign_prompts_format,
+                )
+            except ValueError as exc:
+                print(f"Error: {exc}", file=sys.stderr)
+                return 2
+
+            formatter = args.assign_prompts_format.casefold()
+            for index, (agent, content) in enumerate(payload.items()):
+                if index:
+                    print()
+                if formatter in {"text", "instructions"}:
+                    print(f"## {agent}\n")
+                print(content)
+            return 0
+
+        if args.assign_json:
+            assignments = orchestrator.assign(
+                args.assign_json, include_non_leaf=include_non_leaf
+            )
+            payload = [assignment.to_dict() for assignment in assignments]
+            print(json.dumps(payload, indent=2))
+            return 0
+
+        if args.assign_agents:
+            assignments = orchestrator.assign(
+                args.assign_agents, include_non_leaf=include_non_leaf
+            )
+            for index, assignment in enumerate(assignments):
+                if index:
+                    print()
+                print(assignment.to_outline())
+            return 0
+
+        if args.trace:
+            expansion, trace = engine.expand_with_trace(args.trace)
+            print("# Trace")
+            for item in trace:
+                print(f"- {item}")
+            print("\n# Expansion\n")
+            if context:
+                try:
+                    expansion = engine.render_text(
+                        expansion, context, strict=not args.allow_partial
+                    )
+                except MacroError as exc:
+                    print(f"Error: {exc}", file=sys.stderr)
+                    return 1
+            print(expansion)
+            return 0
+
+        if not args.macro:
+            parser.print_help()
+            return 0
+
+        if context:
+            try:
+                result = engine.render_many(
+                    args.macro, context, strict=not args.allow_partial
+                )
+            except MacroError as exc:
+                print(f"Error: {exc}", file=sys.stderr)
+                return 1
+        else:
+            result = engine.expand_many(args.macro)
+        if args.output:
+            args.output.write_text(result, encoding="utf-8")
+        else:
+            print(result)
+        return 0
+    except MacroError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+# === Error & Edge Handling ===
+# Exceptions are surfaced with user-friendly messages via stderr.
+
+
+# === Performance Considerations ===
+# CLI delegates heavy lifting to the cached engine and planner implementations.
+
+
+# === Supporting Utilities ===
+def _parse_filters(pairs: Iterable[str]) -> Dict[str, str]:
+    """Parse ``KEY=VALUE`` strings into a dictionary of metadata filters."""
+
+    filters: Dict[str, str] = {}
+    for pair in pairs:
+        if "=" not in pair:
+            raise ValueError(
+                "Metadata filters must be provided as KEY=VALUE expressions."
+            )
+        key, value = pair.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key or not value:
+            raise ValueError("Metadata filter keys and values must be non-empty.")
+        if key in filters and filters[key] != value:
+            raise ValueError(
+                f"Metadata key '{key}' was provided more than once with different values."
+            )
+        filters[key] = value
+    return filters
+
+
+def _parse_context_pairs(pairs: Iterable[str]) -> Dict[str, object]:
+    """Parse KEY=VALUE pairs into a context mapping."""
+
+    context: Dict[str, object] = {}
+    for pair in pairs:
+        if "=" not in pair:
+            raise ValueError("Context values must be provided as KEY=VALUE pairs.")
+        key, value = pair.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError("Context keys must be non-empty strings.")
+        context[key] = value.strip()
+    return context
+
+
+def _parse_agent_map(pairs: Iterable[str]) -> Dict[str, str]:
+    """Parse DOMAIN=AGENT expressions for orchestrator overrides."""
+
+    mapping: Dict[str, str] = {}
+    for pair in pairs:
+        if "=" not in pair:
+            raise ValueError("Agent mappings must use the form DOMAIN=AGENT.")
+        domain, agent = pair.split("=", 1)
+        domain = domain.strip().casefold()
+        agent = agent.strip()
+        if not domain or not agent:
+            raise ValueError("Agent mapping domains and agents must be non-empty.")
+        mapping[domain] = agent
+    return mapping
+
+
+def _load_context_file(path: Path) -> Dict[str, object]:
+    """Load context substitutions from a JSON file containing an object."""
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:  # pragma: no cover - user-supplied path
+        raise ValueError(f"Context file not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Context file contains invalid JSON: {path}") from exc
+
+    if not isinstance(payload, dict):
+        raise ValueError("Context file must define a JSON object mapping names to values.")
+
+    context: Dict[str, object] = {}
+    for key, value in payload.items():
+        if not isinstance(key, str):
+            raise ValueError("Context file keys must be strings.")
+        context[key] = value
+    return context
+
+
+def _build_repository(
+    args: argparse.Namespace, parser: argparse.ArgumentParser
+) -> MacroRepository:
+    """Construct a macro repository from CLI arguments."""
+
+    sources: List[Path | Dict[str, object]] = []
+    if not args.no_default:
+        sources.append(args.file)
+    if args.catalogs:
+        sources.extend(args.catalogs)
+    if args.catalog_dirs:
+        for directory in args.catalog_dirs:
+            if not directory.exists():
+                parser.error(f"Catalogue directory not found: {directory}")
+            if not directory.is_dir():
+                parser.error(f"Catalogue directory must be a directory: {directory}")
+            sources.extend(
+                sorted(
+                    candidate
+                    for candidate in directory.glob("*.json")
+                    if candidate.is_file()
+                )
+            )
+
+    if not sources:
+        parser.error(
+            "No macro catalogues supplied. Provide --catalog/--catalog-dir or remove --no-default."
+        )
+
+    return MacroRepository(sources=sources)
+
+
+# === Exports / Public API ===
+__all__ = ["main", "build_parser"]
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/macro_system/Macros/engine.py
+++ b/macro_system/Macros/engine.py
@@ -1,0 +1,605 @@
+"""Header & Purpose: macro expansion engine with analytics and auditing."""
+
+from __future__ import annotations
+
+# === Imports / Dependencies ===
+import re
+from collections import deque
+from pathlib import Path
+from typing import Deque, Dict, Iterable, List, Mapping, MutableMapping, Sequence, Set, Tuple
+
+from .catalog import load_macros
+from .types import (
+    Macro,
+    MacroAudit,
+    MacroCycleError,
+    MacroNotFoundError,
+    MacroRenderError,
+    MacroStats,
+    MacroValidationError,
+)
+
+# === Types / Interfaces / Schemas ===
+# ``MacroEngine`` consumes :class:`Macro` instances and emits audit dataclasses.
+
+
+_PLACEHOLDER_PATTERN = re.compile(r"\{\{\s*([a-zA-Z0-9_.-]+)\s*\}\}")
+
+
+# === Core Logic / Implementation ===
+class MacroEngine:
+    """Expand macros, analyse dependency graphs, and surface catalogue insights."""
+
+    def __init__(self, macros: Mapping[str, Macro]):
+        self._macros: Dict[str, Macro] = dict(macros)
+        self._graph: Dict[str, Tuple[str, ...]] = {
+            name: tuple(macro.calls) for name, macro in self._macros.items()
+        }
+        self._reverse_graph: Dict[str, List[str]] = self._build_reverse_graph()
+        self._cache: Dict[str, str] = {}
+        self._depth_cache: Dict[str, int] = {}
+
+    @classmethod
+    def from_json(cls, path: str | Path) -> "MacroEngine":
+        """Instantiate the engine from a JSON file."""
+
+        return cls(load_macros(path))
+
+    # --- Expansion --------------------------------------------------
+    def expand(self, macro_name: str, *, use_cache: bool = True) -> str:
+        """Return the fully expanded text for ``macro_name``."""
+
+        if macro_name not in self._macros:
+            raise MacroNotFoundError(f"Macro '{macro_name}' is not defined.")
+
+        memo = self._cache if use_cache else {}
+        return self._expand_recursive(macro_name, [], memo, trace=None)
+
+    def expand_many(self, macro_names: Iterable[str], *, use_cache: bool = True) -> str:
+        """Expand multiple macros, reusing memoized expansions where possible."""
+
+        memo = self._cache if use_cache else {}
+        sections: List[str] = []
+        for name in macro_names:
+            if name not in self._macros:
+                raise MacroNotFoundError(f"Macro '{name}' is not defined.")
+            sections.append(self._expand_recursive(name, [], memo, trace=None))
+        return "\n\n".join(sections)
+
+    def expand_with_trace(
+        self, macro_name: str, *, use_cache: bool = True
+    ) -> Tuple[str, List[str]]:
+        """Expand ``macro_name`` and return the expansion with a traversal trace."""
+
+        if macro_name not in self._macros:
+            raise MacroNotFoundError(f"Macro '{macro_name}' is not defined.")
+
+        memo = self._cache if use_cache else {}
+        trace: List[str] = []
+        result = self._expand_recursive(macro_name, [], memo, trace)
+        return result, trace
+
+    def clear_cache(self) -> None:
+        """Clear memoized expansions."""
+
+        self._cache.clear()
+
+    def cache_info(self) -> Dict[str, int]:
+        """Return information about cached macro expansions."""
+
+        return {"cached_macros": len(self._cache)}
+
+    def render(
+        self,
+        macro_name: str,
+        context: Mapping[str, object],
+        *,
+        use_cache: bool = True,
+        strict: bool = True,
+    ) -> str:
+        """Expand ``macro_name`` and apply ``context`` placeholder substitutions."""
+
+        expansion = self.expand(macro_name, use_cache=use_cache)
+        return self.render_text(expansion, context, strict=strict)
+
+    def render_many(
+        self,
+        macro_names: Iterable[str],
+        context: Mapping[str, object],
+        *,
+        use_cache: bool = True,
+        strict: bool = True,
+    ) -> str:
+        """Render multiple macros with shared placeholder substitutions."""
+
+        sections: List[str] = []
+        for name in macro_names:
+            sections.append(
+                self.render(name, context, use_cache=use_cache, strict=strict)
+            )
+        return "\n\n".join(sections)
+
+    @staticmethod
+    def render_text(
+        text: str, context: Mapping[str, object], *, strict: bool = True
+    ) -> str:
+        """Apply ``context`` substitutions to ``text`` containing ``{{placeholder}}`` tokens."""
+
+        placeholders = {match.group(1).strip() for match in _PLACEHOLDER_PATTERN.finditer(text)}
+        missing = sorted(name for name in placeholders if name not in context)
+        if missing and strict:
+            joined = ", ".join(missing)
+            raise MacroRenderError(
+                f"Missing values for placeholders: {joined}. Provide context mappings."
+            )
+
+        def _replace(match: re.Match[str]) -> str:
+            key = match.group(1).strip()
+            if key in context:
+                value = context[key]
+                return str(value)
+            return match.group(0)
+
+        return _PLACEHOLDER_PATTERN.sub(_replace, text)
+
+    # --- Discovery --------------------------------------------------
+    def available_macros(self) -> List[str]:
+        """Return a sorted list of available macro names."""
+
+        return sorted(self._macros)
+
+    def search(
+        self,
+        query: str,
+        *,
+        include_expansions: bool = True,
+        include_metadata: bool = True,
+    ) -> List[Macro]:
+        """Search macros by name, expansion text, and optionally metadata values."""
+
+        lowered = query.casefold()
+        matches: List[Macro] = []
+        for macro in self._macros.values():
+            if lowered in macro.name.casefold():
+                matches.append(macro)
+                continue
+            if include_expansions and lowered in macro.expansion.casefold():
+                matches.append(macro)
+                continue
+            if include_metadata:
+                metadata_blob = " ".join(str(value) for value in macro.metadata.values())
+                if lowered in metadata_blob.casefold():
+                    matches.append(macro)
+        return sorted(matches, key=lambda item: item.name)
+
+    def placeholders(self, macro_name: str, *, recursive: bool = True) -> List[str]:
+        """Return placeholders referenced by ``macro_name`` and optionally its dependencies."""
+
+        if macro_name not in self._macros:
+            raise MacroNotFoundError(f"Macro '{macro_name}' is not defined.")
+
+        collected: Set[str] = set()
+        visited: Set[str] = set()
+        stack: List[str] = []
+
+        def _walk(name: str) -> None:
+            if name in stack:
+                cycle = stack[stack.index(name) :] + [name]
+                raise MacroCycleError(" -> ".join(cycle))
+            if name in visited:
+                return
+
+            macro = self._macros.get(name)
+            if macro is None:
+                raise MacroNotFoundError(f"Macro '{name}' is not defined.")
+
+            stack.append(name)
+            collected.update(self._extract_placeholders(macro.expansion))
+            if recursive:
+                for child in macro.calls:
+                    if child not in self._macros:
+                        raise MacroNotFoundError(
+                            f"Macro '{name}' references undefined macro '{child}'."
+                        )
+                    _walk(child)
+            stack.pop()
+            visited.add(name)
+
+        _walk(macro_name)
+        return sorted(collected)
+
+    def filter_by_metadata(
+        self,
+        filters: Mapping[str, str],
+        *,
+        case_sensitive: bool = False,
+        match_all: bool = True,
+    ) -> List[Macro]:
+        """Return macros whose metadata matches ``filters``.
+
+        Parameters
+        ----------
+        filters:
+            Mapping of metadata key/value pairs to match. Keys are matched exactly
+            while values use string comparison. When ``filters`` is empty, the
+            method returns all macros sorted alphabetically.
+        case_sensitive:
+            When ``True`` perform case-sensitive comparisons; otherwise the
+            comparisons are case-insensitive.
+        match_all:
+            Require all filters to match (logical AND). When ``False`` the method
+            returns macros that satisfy any filter (logical OR).
+        """
+
+        if not filters:
+            return sorted(self._macros.values(), key=lambda macro: macro.name)
+
+        prepared = {
+            key: value if case_sensitive else value.casefold()
+            for key, value in filters.items()
+        }
+
+        matches: List[Macro] = []
+        for macro in self._macros.values():
+            metadata = macro.metadata or {}
+            if not metadata:
+                continue
+
+            comparisons: List[bool] = []
+            for key, expected in prepared.items():
+                raw_value = metadata.get(key)
+                if raw_value is None:
+                    comparisons.append(False)
+                    continue
+                values = (
+                    [str(item) for item in raw_value]
+                    if isinstance(raw_value, (list, tuple, set))
+                    else [str(raw_value)]
+                )
+                if not case_sensitive:
+                    values = [value.casefold() for value in values]
+                comparisons.append(expected in values)
+
+            if match_all and all(comparisons):
+                matches.append(macro)
+            elif not match_all and any(comparisons):
+                matches.append(macro)
+
+        return sorted(matches, key=lambda macro: macro.name)
+
+    def group_by_metadata(
+        self, key: str, *, case_sensitive: bool = False
+    ) -> Dict[str, List[Macro]]:
+        """Group macros by the value stored under ``key`` in their metadata."""
+
+        if not key:
+            raise ValueError("Metadata key must be a non-empty string.")
+
+        grouped: Dict[str, List[Macro]] = {}
+        display_labels: Dict[str, str] = {}
+
+        for macro in self._macros.values():
+            metadata = macro.metadata or {}
+            raw_value = metadata.get(key)
+            if raw_value is None:
+                continue
+
+            values = (
+                [str(item) for item in raw_value]
+                if isinstance(raw_value, (list, tuple, set))
+                else [str(raw_value)]
+            )
+
+            for value in values:
+                normalised = value if case_sensitive else value.casefold()
+                display_labels.setdefault(normalised, value)
+                grouped.setdefault(normalised, []).append(macro)
+
+        ordered: Dict[str, List[Macro]] = {}
+        for normalised in sorted(grouped):
+            label = display_labels[normalised]
+            ordered[label] = sorted(grouped[normalised], key=lambda macro: macro.name)
+        return ordered
+
+    def describe(self, macro_name: str) -> Macro:
+        """Return the :class:`Macro` definition for ``macro_name``."""
+
+        try:
+            return self._macros[macro_name]
+        except KeyError as exc:  # pragma: no cover - simple passthrough
+            raise MacroNotFoundError(f"Macro '{macro_name}' is not defined.") from exc
+
+    def dependencies(self, macro_name: str, *, recursive: bool = True) -> List[str]:
+        """Return direct or transitive dependencies for ``macro_name``."""
+
+        if macro_name not in self._macros:
+            raise MacroNotFoundError(f"Macro '{macro_name}' is not defined.")
+
+        if not recursive:
+            return list(self._graph[macro_name])
+
+        ordered: List[str] = []
+        seen: Set[str] = set()
+
+        def _walk(name: str) -> None:
+            for called in self._graph[name]:
+                if called not in self._macros:
+                    raise MacroNotFoundError(
+                        f"Macro '{macro_name}' references undefined macro '{called}'."
+                    )
+                if called not in seen:
+                    seen.add(called)
+                    ordered.append(called)
+                    _walk(called)
+
+        _walk(macro_name)
+        return ordered
+
+    def ancestors(self, macro_name: str, *, recursive: bool = True) -> List[str]:
+        """Return macros that reference ``macro_name`` directly or transitively."""
+
+        if macro_name not in self._macros:
+            raise MacroNotFoundError(f"Macro '{macro_name}' is not defined.")
+
+        if not recursive:
+            return list(self._reverse_graph.get(macro_name, []))
+
+        ordered: List[str] = []
+        seen: Set[str] = set()
+
+        def _walk(name: str) -> None:
+            for parent in self._reverse_graph.get(name, []):
+                if parent not in seen:
+                    seen.add(parent)
+                    ordered.append(parent)
+                    _walk(parent)
+
+        _walk(macro_name)
+        return ordered
+
+    def dependency_graph(self) -> Dict[str, List[str]]:
+        """Return a copy of the macro dependency graph."""
+
+        return {name: list(children) for name, children in self._graph.items()}
+
+    def reverse_dependency_graph(self) -> Dict[str, List[str]]:
+        """Return the reverse dependency graph mapping macros to parents."""
+
+        return {name: list(parents) for name, parents in self._reverse_graph.items()}
+
+    def stats(self) -> MacroStats:
+        """Return structural statistics about the macro catalogue."""
+
+        total = len(self._macros)
+        roots = sorted(name for name, parents in self._reverse_graph.items() if not parents)
+        leaves = sorted(name for name, macro in self._macros.items() if not macro.calls)
+        depths = [self._compute_depth(name) for name in self._macros]
+        max_depth = max(depths) if depths else 0
+        avg_branching = (
+            sum(len(macro.calls) for macro in self._macros.values()) / total if total else 0.0
+        )
+        return MacroStats(
+            total_macros=total,
+            root_macros=roots,
+            leaf_macros=leaves,
+            max_depth=max_depth,
+            average_branching_factor=avg_branching,
+        )
+
+    # --- Validation & Auditing --------------------------------------
+    def validate(self) -> None:
+        """Ensure all macros can expand without missing references or cycles."""
+
+        visiting: List[str] = []
+        resolved: Dict[str, bool] = {}
+
+        def _dfs(name: str) -> None:
+            if name in resolved:
+                return
+            if name in visiting:
+                cycle = visiting[visiting.index(name) :] + [name]
+                raise MacroCycleError(" -> ".join(cycle))
+            if name not in self._macros:
+                raise MacroNotFoundError(f"Macro '{name}' is not defined.")
+
+            visiting.append(name)
+            for called in self._graph[name]:
+                if called not in self._macros:
+                    raise MacroNotFoundError(
+                        f"Macro '{name}' references undefined macro '{called}'."
+                    )
+                _dfs(called)
+            visiting.pop()
+            resolved[name] = True
+
+        for macro_name in self._macros:
+            _dfs(macro_name)
+
+    def validate_strict(self, entrypoints: Iterable[str] | None = None) -> None:
+        """Raise :class:`MacroValidationError` if auditing finds any anomalies."""
+
+        audit = self.audit(entrypoints=entrypoints)
+        problems: List[str] = []
+        if audit.undefined_references:
+            details = ", ".join(
+                f"{macro}->{missing}" for macro, missing in audit.undefined_references.items()
+            )
+            problems.append(f"Undefined macro references detected: {details}.")
+        if audit.cycles:
+            rendered = ", ".join(" -> ".join(path) for path in audit.cycles)
+            problems.append(f"Cycles detected: {rendered}.")
+        if entrypoints and audit.unreachable_macros:
+            problems.append(
+                "Unreachable macros from entrypoints: " + ", ".join(audit.unreachable_macros)
+            )
+        if problems:
+            raise MacroValidationError(" ".join(problems))
+
+    def audit(self, entrypoints: Iterable[str] | None = None) -> MacroAudit:
+        """Return a catalogue audit without raising, highlighting potential issues."""
+
+        if entrypoints is not None:
+            entry_list = list(dict.fromkeys(entrypoints))
+            for macro_name in entry_list:
+                if macro_name not in self._macros:
+                    raise MacroNotFoundError(f"Entry macro '{macro_name}' is not defined.")
+        else:
+            entry_list = sorted(name for name, parents in self._reverse_graph.items() if not parents)
+
+        undefined: Dict[str, List[str]] = {}
+        for name, macro in self._macros.items():
+            missing = sorted({child for child in macro.calls if child not in self._macros})
+            if missing:
+                undefined[name] = missing
+
+        cycles = self._find_cycles()
+        reachable = self._reachable(entry_list) if entry_list else set(self._macros)
+        unreachable = sorted(set(self._macros) - reachable)
+
+        return MacroAudit(
+            undefined_references=undefined,
+            cycles=cycles,
+            unreachable_macros=unreachable,
+            entrypoints=entry_list,
+            stats=self.stats(),
+        )
+
+    def explain_path(self, source: str, target: str) -> List[str]:
+        """Return a dependency path from ``source`` to ``target`` if one exists."""
+
+        if source not in self._macros:
+            raise MacroNotFoundError(f"Macro '{source}' is not defined.")
+        if target not in self._macros:
+            raise MacroNotFoundError(f"Macro '{target}' is not defined.")
+
+        queue: Deque[Tuple[str, List[str]]] = deque([(source, [source])])
+        seen: Set[str] = {source}
+        while queue:
+            node, path = queue.popleft()
+            if node == target:
+                return path
+            for child in self._graph.get(node, ()):  # type: ignore[arg-type]
+                if child not in self._macros:
+                    continue
+                if child not in seen:
+                    seen.add(child)
+                    queue.append((child, path + [child]))
+        return []
+
+    # --- Internal Helpers -------------------------------------------
+    def _expand_recursive(
+        self,
+        name: str,
+        stack: List[str],
+        memo: MutableMapping[str, str],
+        trace: List[str] | None,
+    ) -> str:
+        if name in memo:
+            if trace is not None:
+                trace.append(f"{name} (cached)")
+            return memo[name]
+
+        if name in stack:
+            cycle = stack[stack.index(name) :] + [name]
+            raise MacroCycleError(" -> ".join(cycle))
+
+        macro = self._macros.get(name)
+        if macro is None:
+            raise MacroNotFoundError(f"Macro '{name}' is not defined.")
+
+        stack.append(name)
+        if trace is not None:
+            trace.append(name)
+
+        sections = [macro.expansion]
+        for called in macro.calls:
+            sections.append(self._expand_recursive(called, stack, memo, trace))
+        stack.pop()
+
+        result = "\n\n".join(sections)
+        memo[name] = result
+        return result
+
+    @staticmethod
+    def _extract_placeholders(text: str) -> Set[str]:
+        """Extract placeholder tokens from ``text`` without duplicates."""
+
+        return {
+            match.group(1).strip()
+            for match in _PLACEHOLDER_PATTERN.finditer(text)
+        }
+
+    def _build_reverse_graph(self) -> Dict[str, List[str]]:
+        reverse: Dict[str, List[str]] = {name: [] for name in self._macros}
+        for parent, macro in self._macros.items():
+            for child in macro.calls:
+                reverse.setdefault(child, []).append(parent)
+        return reverse
+
+    def _compute_depth(self, name: str) -> int:
+        if name in self._depth_cache:
+            return self._depth_cache[name]
+
+        children = self._graph.get(name, ())
+        depth = 1
+        if children:
+            depth += max(self._compute_depth(child) for child in children if child in self._macros)
+        self._depth_cache[name] = depth
+        return depth
+
+    def _find_cycles(self) -> List[List[str]]:
+        cycles: Set[Tuple[str, ...]] = set()
+        visiting: List[str] = []
+        visited: Set[str] = set()
+
+        def _dfs(node: str) -> None:
+            if node in visited:
+                return
+            if node in visiting:
+                cycle = visiting[visiting.index(node) :] + [node]
+                cycles.add(self._canonical_cycle(tuple(cycle)))
+                return
+            visiting.append(node)
+            for child in self._graph.get(node, ()):  # type: ignore[arg-type]
+                if child in self._macros:
+                    _dfs(child)
+            visiting.pop()
+            visited.add(node)
+
+        for name in self._macros:
+            _dfs(name)
+        return [list(cycle) for cycle in sorted(cycles)]
+
+    def _canonical_cycle(self, cycle: Tuple[str, ...]) -> Tuple[str, ...]:
+        if len(cycle) <= 1:
+            return cycle
+        base = list(cycle[:-1]) if cycle[0] == cycle[-1] else list(cycle)
+        if not base:
+            return cycle
+        min_index = min(range(len(base)), key=lambda idx: base[idx])
+        rotated = base[min_index:] + base[:min_index]
+        return tuple(rotated + [rotated[0]])
+
+    def _reachable(self, entrypoints: Sequence[str]) -> Set[str]:
+        reachable: Set[str] = set()
+        stack: List[str] = list(entrypoints)
+        while stack:
+            node = stack.pop()
+            if node in reachable or node not in self._macros:
+                continue
+            reachable.add(node)
+            for child in self._graph.get(node, ()):  # type: ignore[arg-type]
+                stack.append(child)
+        return reachable
+
+
+# === Error & Edge Handling ===
+# Dedicated exceptions signal missing macros, cycles, and aggregate validation issues.
+
+
+# === Performance Considerations ===
+# Memoisation caches expansions and depth computations to maintain O(N + E) traversal.
+
+
+# === Exports / Public API ===
+__all__ = ["MacroEngine"]

--- a/macro_system/Macros/macros.json
+++ b/macro_system/Macros/macros.json
@@ -1,0 +1,1412 @@
+{
+  "::analytics-abtest": {
+    "calls": [],
+    "expansion": "Creates instrumentation for A/B testing of variants and features.",
+    "metadata": {
+      "category": "analytics",
+      "domain": "analytics",
+      "level": "task",
+      "pillar": "insights"
+    }
+  },
+  "::analytics-events": {
+    "calls": [],
+    "expansion": "Tracks page views, clicks and custom events across the application.",
+    "metadata": {
+      "category": "analytics",
+      "domain": "analytics",
+      "level": "task",
+      "pillar": "insights"
+    }
+  },
+  "::analytics-performance": {
+    "calls": [],
+    "expansion": "Measures load times, rendering performance and resource usage for analytics.",
+    "metadata": {
+      "category": "analytics",
+      "domain": "analytics",
+      "level": "task",
+      "pillar": "insights"
+    }
+  },
+  "::analytics-userflow": {
+    "calls": [],
+    "expansion": "Collects funnel and conversion metrics to understand user behaviour.",
+    "metadata": {
+      "category": "analytics",
+      "domain": "analytics",
+      "level": "task",
+      "pillar": "insights"
+    }
+  },
+  "::analyticsinject": {
+    "calls": [
+      "::analytics-events",
+      "::analytics-performance",
+      "::analytics-userflow",
+      "::analytics-abtest"
+    ],
+    "expansion": "Inserts analytics instrumentation with probabilistic sampling for event tracking and performance metrics.",
+    "metadata": {
+      "category": "analyticsinject",
+      "domain": "analytics",
+      "level": "macro",
+      "pillar": "insights"
+    }
+  },
+  "::apidocgen": {
+    "calls": [
+      "::apidocgen-swagger",
+      "::apidocgen-code",
+      "::apidocgen-errors",
+      "::apidocgen-tests"
+    ],
+    "expansion": "Generates comprehensive API documentation including endpoints, request/response examples and error codes.",
+    "metadata": {
+      "category": "apidocgen",
+      "domain": "documentation",
+      "level": "macro",
+      "pillar": "documentation"
+    }
+  },
+  "::apidocgen-code": {
+    "calls": [],
+    "expansion": "Provides example code snippets (curl, Python, JS) demonstrating API usage.",
+    "metadata": {
+      "category": "apidocgen",
+      "domain": "documentation",
+      "level": "task",
+      "pillar": "documentation"
+    }
+  },
+  "::apidocgen-errors": {
+    "calls": [],
+    "expansion": "Documents standardised error codes and messages with causes and solutions.",
+    "metadata": {
+      "category": "apidocgen",
+      "domain": "documentation",
+      "level": "task",
+      "pillar": "documentation"
+    }
+  },
+  "::apidocgen-swagger": {
+    "calls": [],
+    "expansion": "Creates an OpenAPI/Swagger specification for the API.",
+    "metadata": {
+      "category": "apidocgen",
+      "domain": "documentation",
+      "level": "task",
+      "pillar": "documentation"
+    }
+  },
+  "::apidocgen-tests": {
+    "calls": [],
+    "expansion": "Creates tests to validate that the API documentation matches the actual implementation.",
+    "metadata": {
+      "category": "apidocgen",
+      "domain": "documentation",
+      "level": "task",
+      "pillar": "documentation"
+    }
+  },
+  "::backendgen": {
+    "calls": [
+      "::backendgen-api",
+      "::backendgen-auth",
+      "::backendgen-models",
+      "::backendgen-security",
+      "::backendgen-migrations",
+      "::backendgen-logging",
+      "::backendgen-tests",
+      "::backendgen-docs"
+    ],
+    "expansion": "Creates a robust RESTful API scaffold using FastAPI (or chosen framework), including database connection, models and security primitives.",
+    "metadata": {
+      "category": "backendgen",
+      "domain": "backend",
+      "level": "macro",
+      "pillar": "services"
+    }
+  },
+  "::backendgen-api": {
+    "calls": [],
+    "expansion": "Scaffolds CRUD endpoints with pagination and filtering on the chosen framework.",
+    "metadata": {
+      "category": "backendgen",
+      "domain": "backend",
+      "level": "task",
+      "pillar": "services"
+    }
+  },
+  "::backendgen-auth": {
+    "calls": [],
+    "expansion": "Implements authentication and authorization mechanisms (JWT or OAuth2).",
+    "metadata": {
+      "category": "backendgen",
+      "domain": "backend",
+      "level": "task",
+      "pillar": "services"
+    }
+  },
+  "::backendgen-docs": {
+    "calls": [],
+    "expansion": "Auto-generates API documentation (OpenAPI/Swagger) and example usages.",
+    "metadata": {
+      "category": "backendgen",
+      "domain": "backend",
+      "level": "task",
+      "pillar": "services"
+    }
+  },
+  "::backendgen-logging": {
+    "calls": [],
+    "expansion": "Sets up structured logging and monitoring hooks to trace API behaviour and performance.",
+    "metadata": {
+      "category": "backendgen",
+      "domain": "backend",
+      "level": "task",
+      "pillar": "services"
+    }
+  },
+  "::backendgen-migrations": {
+    "calls": [],
+    "expansion": "Creates database migration scripts to manage schema evolution (Alembic or equivalent).",
+    "metadata": {
+      "category": "backendgen",
+      "domain": "backend",
+      "level": "task",
+      "pillar": "services"
+    }
+  },
+  "::backendgen-models": {
+    "calls": [],
+    "expansion": "Defines ORM models and Pydantic schemas based on the database schema.",
+    "metadata": {
+      "category": "backendgen",
+      "domain": "backend",
+      "level": "task",
+      "pillar": "services"
+    }
+  },
+  "::backendgen-security": {
+    "calls": [],
+    "expansion": "Adds security measures such as input sanitization, CSRF protection and rate limiting.",
+    "metadata": {
+      "category": "backendgen",
+      "domain": "backend",
+      "level": "task",
+      "pillar": "services"
+    }
+  },
+  "::backendgen-tests": {
+    "calls": [],
+    "expansion": "Generates API unit and integration tests to ensure endpoint correctness and error handling.",
+    "metadata": {
+      "category": "backendgen",
+      "domain": "backend",
+      "level": "task",
+      "pillar": "services"
+    }
+  },
+  "::backendsuite": {
+    "calls": [
+      "::backendgen",
+      "::dbdesign",
+      "::apidocgen"
+    ],
+    "expansion": "Runs back-end scaffolding, DB design and API documentation macros.",
+    "metadata": {
+      "category": "backendsuite",
+      "domain": "backend",
+      "level": "suite",
+      "pillar": "suite"
+    }
+  },
+  "::cicd-build": {
+    "calls": [],
+    "expansion": "Builds and bundles the application (e.g., Webpack/Vite bundling or Docker image creation).",
+    "metadata": {
+      "category": "cicd",
+      "domain": "delivery",
+      "level": "task",
+      "pillar": "cicd"
+    }
+  },
+  "::cicd-deploy": {
+    "calls": [],
+    "expansion": "Deploys the application to the target environment (Docker, Render, Kubernetes) and performs environment configuration.",
+    "metadata": {
+      "category": "cicd",
+      "domain": "delivery",
+      "level": "task",
+      "pillar": "cicd"
+    }
+  },
+  "::cicd-lint": {
+    "calls": [],
+    "expansion": "Runs linting tools (ESLint, PEP8, Prettier) and applies automatic fixes to formatting issues.",
+    "metadata": {
+      "category": "cicd",
+      "domain": "delivery",
+      "level": "task",
+      "pillar": "cicd"
+    }
+  },
+  "::cicd-monitor": {
+    "calls": [],
+    "expansion": "Monitors deployed applications with health checks and alerts to detect failures or performance degradations.",
+    "metadata": {
+      "category": "cicd",
+      "domain": "delivery",
+      "level": "task",
+      "pillar": "cicd"
+    }
+  },
+  "::cicd-notify": {
+    "calls": [],
+    "expansion": "Sends notifications (Slack, email) about pipeline status and deployment outcomes.",
+    "metadata": {
+      "category": "cicd",
+      "domain": "delivery",
+      "level": "task",
+      "pillar": "cicd"
+    }
+  },
+  "::cicd-rollback": {
+    "calls": [],
+    "expansion": "Provides automated rollback procedures when deployments fail or regress.",
+    "metadata": {
+      "category": "cicd",
+      "domain": "delivery",
+      "level": "task",
+      "pillar": "cicd"
+    }
+  },
+  "::cicd-test": {
+    "calls": [],
+    "expansion": "Executes unit, integration and end-to-end tests during the pipeline.",
+    "metadata": {
+      "category": "cicd",
+      "domain": "delivery",
+      "level": "task",
+      "pillar": "cicd"
+    }
+  },
+  "::cicdsetup": {
+    "calls": [
+      "::cicd-lint",
+      "::cicd-test",
+      "::cicd-build",
+      "::cicd-deploy",
+      "::cicd-monitor",
+      "::cicd-notify",
+      "::cicd-rollback"
+    ],
+    "expansion": "Sets up continuous integration and deployment pipelines with linting, testing, building, deployment and monitoring stages.",
+    "metadata": {
+      "category": "cicdsetup",
+      "domain": "delivery",
+      "level": "macro",
+      "pillar": "cicd"
+    }
+  },
+  "::cicdsuite": {
+    "calls": [
+      "::cicdsetup",
+      "::securityaudit",
+      "::perfprofile"
+    ],
+    "expansion": "Runs the CI/CD setup including linting, testing, building, deploying, monitoring and notifications, along with security and performance profiling.",
+    "metadata": {
+      "category": "cicdsuite",
+      "domain": "delivery",
+      "level": "suite",
+      "pillar": "suite"
+    }
+  },
+  "::codequality": {
+    "calls": [
+      "::codequality-read",
+      "::codequality-maintain",
+      "::codequality-architecture",
+      "::codequality-standards"
+    ],
+    "expansion": "Evaluates code readability, maintainability, architecture and adherence to standards.",
+    "metadata": {
+      "category": "codequality",
+      "domain": "quality",
+      "level": "macro",
+      "pillar": "analysis"
+    }
+  },
+  "::codequality-architecture": {
+    "calls": [],
+    "expansion": "Evaluates overall architecture coherence and alignment with best practices.",
+    "metadata": {
+      "category": "codequality",
+      "domain": "quality",
+      "level": "task",
+      "pillar": "analysis"
+    }
+  },
+  "::codequality-maintain": {
+    "calls": [],
+    "expansion": "Identifies maintainability issues such as tight coupling and poor separation of concerns.",
+    "metadata": {
+      "category": "codequality",
+      "domain": "quality",
+      "level": "task",
+      "pillar": "analysis"
+    }
+  },
+  "::codequality-read": {
+    "calls": [],
+    "expansion": "Assesses variable naming, code clarity and documentation quality.",
+    "metadata": {
+      "category": "codequality",
+      "domain": "quality",
+      "level": "task",
+      "pillar": "analysis"
+    }
+  },
+  "::codequality-standards": {
+    "calls": [],
+    "expansion": "Ensures adherence to organisational coding standards and style guides.",
+    "metadata": {
+      "category": "codequality",
+      "domain": "quality",
+      "level": "task",
+      "pillar": "analysis"
+    }
+  },
+  "::coderefactor": {
+    "calls": [
+      "::refactor-smells",
+      "::refactor-patterns",
+      "::refactor-modular",
+      "::refactor-complexity",
+      "::refactor-docs"
+    ],
+    "expansion": "Refactors code to improve maintainability and architecture using design patterns and modularisation.",
+    "metadata": {
+      "category": "coderefactor",
+      "domain": "architecture",
+      "level": "macro",
+      "pillar": "refactoring"
+    }
+  },
+  "::datasuite": {
+    "calls": [
+      "::typegen",
+      "::mockdata"
+    ],
+    "expansion": "Generates data schemas, type definitions and mock data.",
+    "metadata": {
+      "category": "datasuite",
+      "domain": "data",
+      "level": "suite",
+      "pillar": "suite"
+    }
+  },
+  "::dbdesign": {
+    "calls": [
+      "::dbdesign-schema",
+      "::dbdesign-normalize",
+      "::dbdesign-index",
+      "::dbdesign-seed",
+      "::dbdesign-migrate"
+    ],
+    "expansion": "Designs a database schema (relational or NoSQL) from business requirements.",
+    "metadata": {
+      "category": "dbdesign",
+      "domain": "database",
+      "level": "macro",
+      "pillar": "design"
+    }
+  },
+  "::dbdesign-index": {
+    "calls": [],
+    "expansion": "Suggests indexes and partitioning strategies to optimise query performance.",
+    "metadata": {
+      "category": "dbdesign",
+      "domain": "database",
+      "level": "task",
+      "pillar": "design"
+    }
+  },
+  "::dbdesign-migrate": {
+    "calls": [],
+    "expansion": "Writes migration scripts to evolve the database schema safely across versions.",
+    "metadata": {
+      "category": "dbdesign",
+      "domain": "database",
+      "level": "task",
+      "pillar": "design"
+    }
+  },
+  "::dbdesign-normalize": {
+    "calls": [],
+    "expansion": "Normalises the schema to third normal form while balancing denormalization for performance.",
+    "metadata": {
+      "category": "dbdesign",
+      "domain": "database",
+      "level": "task",
+      "pillar": "design"
+    }
+  },
+  "::dbdesign-schema": {
+    "calls": [],
+    "expansion": "Produces entity\u2013relationship diagrams and table/collection definitions with keys and constraints.",
+    "metadata": {
+      "category": "dbdesign",
+      "domain": "database",
+      "level": "task",
+      "pillar": "design"
+    }
+  },
+  "::dbdesign-seed": {
+    "calls": [],
+    "expansion": "Generates seed data aligned with schema definitions for development and testing.",
+    "metadata": {
+      "category": "dbdesign",
+      "domain": "database",
+      "level": "task",
+      "pillar": "design"
+    }
+  },
+  "::deploy-docker": {
+    "calls": [],
+    "expansion": "Generates Dockerfile and docker-compose configurations with best practices.",
+    "metadata": {
+      "category": "deploy",
+      "domain": "deployment",
+      "level": "task",
+      "pillar": "automation"
+    }
+  },
+  "::deploy-env": {
+    "calls": [],
+    "expansion": "Creates environment variable templates and secrets management guidelines.",
+    "metadata": {
+      "category": "deploy",
+      "domain": "deployment",
+      "level": "task",
+      "pillar": "automation"
+    }
+  },
+  "::deploy-monitor": {
+    "calls": [],
+    "expansion": "Integrates logging and monitoring agents for observability after deployment.",
+    "metadata": {
+      "category": "deploy",
+      "domain": "deployment",
+      "level": "task",
+      "pillar": "automation"
+    }
+  },
+  "::deploy-scaling": {
+    "calls": [],
+    "expansion": "Produces configuration for autoscaling clusters (Kubernetes, Render) with resource limits and health probes.",
+    "metadata": {
+      "category": "deploy",
+      "domain": "deployment",
+      "level": "task",
+      "pillar": "automation"
+    }
+  },
+  "::deployscript": {
+    "calls": [
+      "::deploy-docker",
+      "::deploy-env",
+      "::deploy-scaling",
+      "::deploy-monitor"
+    ],
+    "expansion": "Creates deployment scripts and configuration for various environments (Docker, Kubernetes, Render).",
+    "metadata": {
+      "category": "deployscript",
+      "domain": "deployment",
+      "level": "macro",
+      "pillar": "automation"
+    }
+  },
+  "::deploysuite": {
+    "calls": [
+      "::deployscript"
+    ],
+    "expansion": "Generates deployment scripts and configures scaling and monitoring.",
+    "metadata": {
+      "category": "deploysuite",
+      "domain": "deployment",
+      "level": "suite",
+      "pillar": "suite"
+    }
+  },
+  "::error-fixsuggest": {
+    "calls": [],
+    "expansion": "Suggests code changes or configuration adjustments to fix identified issues.",
+    "metadata": {
+      "category": "error",
+      "domain": "observability",
+      "level": "task",
+      "pillar": "stability"
+    }
+  },
+  "::error-logparser": {
+    "calls": [],
+    "expansion": "Parses application logs and extracts error events, stack traces and context.",
+    "metadata": {
+      "category": "error",
+      "domain": "observability",
+      "level": "task",
+      "pillar": "stability"
+    }
+  },
+  "::error-report": {
+    "calls": [],
+    "expansion": "Summarizes the error analysis in a clear report for developers and stakeholders.",
+    "metadata": {
+      "category": "error",
+      "domain": "observability",
+      "level": "task",
+      "pillar": "stability"
+    }
+  },
+  "::error-reproduce": {
+    "calls": [],
+    "expansion": "Generates reproducible test cases to trigger the observed error.",
+    "metadata": {
+      "category": "error",
+      "domain": "observability",
+      "level": "task",
+      "pillar": "stability"
+    }
+  },
+  "::error-rootcause": {
+    "calls": [],
+    "expansion": "Identifies the root cause of errors by analysing call stacks and dependencies.",
+    "metadata": {
+      "category": "error",
+      "domain": "observability",
+      "level": "task",
+      "pillar": "stability"
+    }
+  },
+  "::erroranalysis": {
+    "calls": [
+      "::error-logparser",
+      "::error-rootcause",
+      "::error-fixsuggest",
+      "::error-reproduce",
+      "::error-report"
+    ],
+    "expansion": "Parses logs and diagnostics to identify root causes of errors and suggest fixes.",
+    "metadata": {
+      "category": "erroranalysis",
+      "domain": "observability",
+      "level": "macro",
+      "pillar": "stability"
+    }
+  },
+  "::frontendgen": {
+    "calls": [
+      "::frontendgen-layout",
+      "::frontendgen-state",
+      "::frontendgen-forms",
+      "::frontendgen-access",
+      "::frontendgen-motion",
+      "::frontendgen-tests",
+      "::frontendgen-docs"
+    ],
+    "expansion": "Generates a full front-end scaffold using React/Vite/Tailwind/Shadcn UI/Motion with proper component structure, responsive design, accessibility checks and styling best practices.",
+    "metadata": {
+      "category": "frontendgen",
+      "domain": "frontend",
+      "level": "macro",
+      "pillar": "experience"
+    }
+  },
+  "::frontendgen-access": {
+    "calls": [],
+    "expansion": "Performs accessibility audits including contrast ratio checks, ARIA attributes and keyboard navigation.",
+    "metadata": {
+      "category": "frontendgen",
+      "domain": "frontend",
+      "level": "task",
+      "pillar": "experience"
+    }
+  },
+  "::frontendgen-docs": {
+    "calls": [],
+    "expansion": "Produces UI documentation with Storybook or equivalent to showcase components and usage.",
+    "metadata": {
+      "category": "frontendgen",
+      "domain": "frontend",
+      "level": "task",
+      "pillar": "experience"
+    }
+  },
+  "::frontendgen-forms": {
+    "calls": [],
+    "expansion": "Creates form components with validation, error handling and user friendly UX guidelines.",
+    "metadata": {
+      "category": "frontendgen",
+      "domain": "frontend",
+      "level": "task",
+      "pillar": "experience"
+    }
+  },
+  "::frontendgen-layout": {
+    "calls": [],
+    "expansion": "Designs grid layouts using patterns such as cinematic Z, modular cockpit, F-pattern or gallery spotlight to organise the UI.",
+    "metadata": {
+      "category": "frontendgen",
+      "domain": "frontend",
+      "level": "task",
+      "pillar": "experience"
+    }
+  },
+  "::frontendgen-motion": {
+    "calls": [],
+    "expansion": "Integrates Framer Motion to add subtle animations following motion grammar for natural interactions.",
+    "metadata": {
+      "category": "frontendgen",
+      "domain": "frontend",
+      "level": "task",
+      "pillar": "experience"
+    }
+  },
+  "::frontendgen-state": {
+    "calls": [],
+    "expansion": "Sets up state management (Context API or Redux) and data flow for components, ensuring unidirectional data and predictable updates.",
+    "metadata": {
+      "category": "frontendgen",
+      "domain": "frontend",
+      "level": "task",
+      "pillar": "experience"
+    }
+  },
+  "::frontendgen-tests": {
+    "calls": [],
+    "expansion": "Generates front-end unit tests using React Testing Library with high coverage.",
+    "metadata": {
+      "category": "frontendgen",
+      "domain": "frontend",
+      "level": "task",
+      "pillar": "experience"
+    }
+  },
+  "::frontendsuite": {
+    "calls": [
+      "::frontendgen",
+      "::frontendgen-layout",
+      "::frontendgen-state",
+      "::frontendgen-forms",
+      "::frontendgen-access",
+      "::frontendgen-motion",
+      "::frontendgen-tests",
+      "::frontendgen-docs"
+    ],
+    "expansion": "Executes all front-end related macros including layout, state, forms, access, motion, tests and docs.",
+    "metadata": {
+      "category": "frontendsuite",
+      "domain": "frontend",
+      "level": "suite",
+      "pillar": "suite"
+    }
+  },
+  "::fulldeveloper": {
+    "calls": [
+      "::prototype-scaffold",
+      "::prototype-tests",
+      "::prototype-deploy",
+      "::prototype-docs"
+    ],
+    "expansion": "Orchestrates the rapid creation of an end-to-end prototype by combining front-end, back-end, database, testing and deployment tasks.",
+    "metadata": {
+      "category": "fulldeveloper",
+      "domain": "orchestration",
+      "level": "suite",
+      "pillar": "execution"
+    }
+  },
+  "::fullstacksuite": {
+    "calls": [
+      "::frontendsuite",
+      "::backendsuite",
+      "::testsuite",
+      "::cicdsuite",
+      "::deploysuite"
+    ],
+    "expansion": "Builds a cohesive stack by orchestrating front-end, back-end, testing, CI/CD and deployment macros.",
+    "metadata": {
+      "category": "fullstacksuite",
+      "domain": "orchestration",
+      "level": "suite",
+      "pillar": "suite"
+    }
+  },
+  "::integration-call": {
+    "calls": [],
+    "expansion": "Sends requests to APIs and services with various payloads during integration tests.",
+    "metadata": {
+      "category": "integration",
+      "domain": "testing",
+      "level": "task",
+      "pillar": "integration"
+    }
+  },
+  "::integration-setup": {
+    "calls": [],
+    "expansion": "Sets up the testing environment and any required test data for integration tests.",
+    "metadata": {
+      "category": "integration",
+      "domain": "testing",
+      "level": "task",
+      "pillar": "integration"
+    }
+  },
+  "::integration-teardown": {
+    "calls": [],
+    "expansion": "Cleans up the environment after integration tests are executed.",
+    "metadata": {
+      "category": "integration",
+      "domain": "testing",
+      "level": "task",
+      "pillar": "integration"
+    }
+  },
+  "::integration-validate": {
+    "calls": [],
+    "expansion": "Validates responses and side effects from integration tests against expected outcomes.",
+    "metadata": {
+      "category": "integration",
+      "domain": "testing",
+      "level": "task",
+      "pillar": "integration"
+    }
+  },
+  "::integrationtest": {
+    "calls": [
+      "::integration-setup",
+      "::integration-call",
+      "::integration-validate",
+      "::integration-teardown"
+    ],
+    "expansion": "Builds automated integration test scripts for third-party APIs and services.",
+    "metadata": {
+      "category": "integrationtest",
+      "domain": "testing",
+      "level": "macro",
+      "pillar": "integration"
+    }
+  },
+  "::lintfix": {
+    "calls": [],
+    "expansion": "Applies linting and formatting rules to all project files and reports violations.",
+    "metadata": {
+      "category": "lintfix",
+      "domain": "quality",
+      "level": "macro",
+      "pillar": "linting"
+    }
+  },
+  "::masterdev": {
+    "calls": [
+      "::fullstacksuite",
+      "::datasuite",
+      "::securesuite",
+      "::optimizsuite",
+      "::uxsuite"
+    ],
+    "expansion": "Coordinates the entire macro system by constructing belief structures, calibrating uncertainty and executing all relevant suites to produce a complete production-grade software package with ethical, secure and performant characteristics.",
+    "metadata": {
+      "category": "masterdev",
+      "domain": "orchestration",
+      "level": "suite",
+      "pillar": "command"
+    }
+  },
+  "::mockdata": {
+    "calls": [
+      "::mockdata-sample",
+      "::mockdata-distrib",
+      "::mockdata-edge",
+      "::mockdata-sensitive"
+    ],
+    "expansion": "Generates realistic test data for development, testing and demonstration purposes.",
+    "metadata": {
+      "category": "mockdata",
+      "domain": "data",
+      "level": "macro",
+      "pillar": "testing"
+    }
+  },
+  "::mockdata-distrib": {
+    "calls": [],
+    "expansion": "Samples data from statistical distributions to mimic real-world values.",
+    "metadata": {
+      "category": "mockdata",
+      "domain": "data",
+      "level": "task",
+      "pillar": "testing"
+    }
+  },
+  "::mockdata-edge": {
+    "calls": [],
+    "expansion": "Produces edge-case data to test boundary conditions.",
+    "metadata": {
+      "category": "mockdata",
+      "domain": "data",
+      "level": "task",
+      "pillar": "testing"
+    }
+  },
+  "::mockdata-sample": {
+    "calls": [],
+    "expansion": "Creates standard dummy data consistent with given types and constraints.",
+    "metadata": {
+      "category": "mockdata",
+      "domain": "data",
+      "level": "task",
+      "pillar": "testing"
+    }
+  },
+  "::mockdata-sensitive": {
+    "calls": [],
+    "expansion": "Generates anonymised versions of sensitive data to preserve privacy while testing.",
+    "metadata": {
+      "category": "mockdata",
+      "domain": "data",
+      "level": "task",
+      "pillar": "testing"
+    }
+  },
+  "::optimizsuite": {
+    "calls": [
+      "::perfprofile",
+      "::coderefactor",
+      "::codequality"
+    ],
+    "expansion": "Runs performance profiling, refactoring and code quality evaluation macros.",
+    "metadata": {
+      "category": "optimizsuite",
+      "domain": "performance",
+      "level": "suite",
+      "pillar": "suite"
+    }
+  },
+  "::perf-benchmark": {
+    "calls": [],
+    "expansion": "Provides comparative benchmarks across different implementations or configurations.",
+    "metadata": {
+      "category": "perf",
+      "domain": "performance",
+      "level": "task",
+      "pillar": "optimisation"
+    }
+  },
+  "::perf-cpu": {
+    "calls": [],
+    "expansion": "Measures CPU usage and identifies hot spots in the code.",
+    "metadata": {
+      "category": "perf",
+      "domain": "performance",
+      "level": "task",
+      "pillar": "optimisation"
+    }
+  },
+  "::perf-io": {
+    "calls": [],
+    "expansion": "Profiles disk and network I/O patterns to detect bottlenecks.",
+    "metadata": {
+      "category": "perf",
+      "domain": "performance",
+      "level": "task",
+      "pillar": "optimisation"
+    }
+  },
+  "::perf-memory": {
+    "calls": [],
+    "expansion": "Analyzes memory allocations and detects leaks.",
+    "metadata": {
+      "category": "perf",
+      "domain": "performance",
+      "level": "task",
+      "pillar": "optimisation"
+    }
+  },
+  "::perf-network": {
+    "calls": [],
+    "expansion": "Measures network latency, throughput and concurrency for API endpoints.",
+    "metadata": {
+      "category": "perf",
+      "domain": "performance",
+      "level": "task",
+      "pillar": "optimisation"
+    }
+  },
+  "::perfprofile": {
+    "calls": [
+      "::perf-cpu",
+      "::perf-memory",
+      "::perf-io",
+      "::perf-network",
+      "::perf-benchmark"
+    ],
+    "expansion": "Profiles code performance (CPU, memory, I/O, network) and recommends optimisations.",
+    "metadata": {
+      "category": "perfprofile",
+      "domain": "performance",
+      "level": "macro",
+      "pillar": "optimisation"
+    }
+  },
+  "::project-brief": {
+    "calls": [],
+    "expansion": "Drafts a concise delivery brief for {{project_name}} prioritising {{primary_goal}} outcomes and stakeholder clarity.",
+    "metadata": {
+      "category": "strategy",
+      "domain": "strategy",
+      "level": "task",
+      "pillar": "planning"
+    }
+  },
+  "::project-kickoff": {
+    "calls": [
+      "::project-brief"
+    ],
+    "expansion": "Organises the initial kickoff workflow for {{project_name}}, aligning roles, cadences, and risk mitigations before execution begins.",
+    "metadata": {
+      "category": "strategy",
+      "domain": "strategy",
+      "level": "macro",
+      "pillar": "planning"
+    }
+  },
+  "::prototype-deploy": {
+    "calls": [],
+    "expansion": "Packages the prototype for deployment, creating necessary scripts and configuration.",
+    "metadata": {
+      "category": "prototype",
+      "domain": "orchestration",
+      "level": "task",
+      "pillar": "prototype"
+    }
+  },
+  "::prototype-docs": {
+    "calls": [],
+    "expansion": "Generates basic documentation describing the prototype\u2019s architecture and usage.",
+    "metadata": {
+      "category": "prototype",
+      "domain": "orchestration",
+      "level": "task",
+      "pillar": "prototype"
+    }
+  },
+  "::prototype-scaffold": {
+    "calls": [],
+    "expansion": "Quickly builds a working UI, API and database skeleton for prototyping.",
+    "metadata": {
+      "category": "prototype",
+      "domain": "orchestration",
+      "level": "task",
+      "pillar": "prototype"
+    }
+  },
+  "::prototype-tests": {
+    "calls": [],
+    "expansion": "Sets up a minimal testing harness for the prototype to ensure basic functionality.",
+    "metadata": {
+      "category": "prototype",
+      "domain": "orchestration",
+      "level": "task",
+      "pillar": "prototype"
+    }
+  },
+  "::refactor-complexity": {
+    "calls": [],
+    "expansion": "Reduces cyclomatic complexity by simplifying logic and improving cohesion.",
+    "metadata": {
+      "category": "refactor",
+      "domain": "architecture",
+      "level": "task",
+      "pillar": "refactoring"
+    }
+  },
+  "::refactor-docs": {
+    "calls": [],
+    "expansion": "Updates docstrings and comments to reflect refactored code structure.",
+    "metadata": {
+      "category": "refactor",
+      "domain": "architecture",
+      "level": "task",
+      "pillar": "refactoring"
+    }
+  },
+  "::refactor-modular": {
+    "calls": [],
+    "expansion": "Splits monoliths into modular components and services.",
+    "metadata": {
+      "category": "refactor",
+      "domain": "architecture",
+      "level": "task",
+      "pillar": "refactoring"
+    }
+  },
+  "::refactor-patterns": {
+    "calls": [],
+    "expansion": "Suggests design patterns and architecture improvements to enhance flexibility and extensibility.",
+    "metadata": {
+      "category": "refactor",
+      "domain": "architecture",
+      "level": "task",
+      "pillar": "refactoring"
+    }
+  },
+  "::refactor-smells": {
+    "calls": [],
+    "expansion": "Detects and resolves code smells such as duplication, large methods and long parameter lists.",
+    "metadata": {
+      "category": "refactor",
+      "domain": "architecture",
+      "level": "task",
+      "pillar": "refactoring"
+    }
+  },
+  "::securesuite": {
+    "calls": [
+      "::securityaudit"
+    ],
+    "expansion": "Combines security analysis, fairness and ethical review macros.",
+    "metadata": {
+      "category": "securesuite",
+      "domain": "security",
+      "level": "suite",
+      "pillar": "suite"
+    }
+  },
+  "::security-authz": {
+    "calls": [],
+    "expansion": "Audits roles, permissions and secrets management for proper authorization enforcement.",
+    "metadata": {
+      "category": "security",
+      "domain": "security",
+      "level": "task",
+      "pillar": "assurance"
+    }
+  },
+  "::security-deps": {
+    "calls": [],
+    "expansion": "Scans dependencies for known CVEs and insecure versions.",
+    "metadata": {
+      "category": "security",
+      "domain": "security",
+      "level": "task",
+      "pillar": "assurance"
+    }
+  },
+  "::security-ethics": {
+    "calls": [],
+    "expansion": "Evaluates ethical compliance including privacy, diversity and inclusion considerations.",
+    "metadata": {
+      "category": "security",
+      "domain": "security",
+      "level": "task",
+      "pillar": "assurance"
+    }
+  },
+  "::security-fairness": {
+    "calls": [],
+    "expansion": "Assesses algorithmic bias and fairness metrics across demographic groups.",
+    "metadata": {
+      "category": "security",
+      "domain": "security",
+      "level": "task",
+      "pillar": "assurance"
+    }
+  },
+  "::security-injection": {
+    "calls": [],
+    "expansion": "Identifies injection vulnerabilities in code paths accepting external input.",
+    "metadata": {
+      "category": "security",
+      "domain": "security",
+      "level": "task",
+      "pillar": "assurance"
+    }
+  },
+  "::security-report": {
+    "calls": [],
+    "expansion": "Generates a risk report with severity scores and remediation advice.",
+    "metadata": {
+      "category": "security",
+      "domain": "security",
+      "level": "task",
+      "pillar": "assurance"
+    }
+  },
+  "::security-static": {
+    "calls": [],
+    "expansion": "Performs static analysis (SAST) to detect vulnerabilities such as SQL injection or XSS.",
+    "metadata": {
+      "category": "security",
+      "domain": "security",
+      "level": "task",
+      "pillar": "assurance"
+    }
+  },
+  "::securityaudit": {
+    "calls": [
+      "::security-static",
+      "::security-deps",
+      "::security-injection",
+      "::security-authz",
+      "::security-report",
+      "::security-fairness",
+      "::security-ethics"
+    ],
+    "expansion": "Runs a comprehensive security audit, scanning source code, dependencies and configurations for vulnerabilities and ethics issues.",
+    "metadata": {
+      "category": "securityaudit",
+      "domain": "security",
+      "level": "macro",
+      "pillar": "assurance"
+    }
+  },
+  "::testgen": {
+    "calls": [
+      "::testgen-unit",
+      "::testgen-integration",
+      "::testgen-e2e",
+      "::testgen-coverage",
+      "::testgen-performance",
+      "::testgen-security"
+    ],
+    "expansion": "Constructs a suite of tests across units, integrations, end-to-end scenarios, coverage analysis and performance.",
+    "metadata": {
+      "category": "testgen",
+      "domain": "testing",
+      "level": "macro",
+      "pillar": "quality"
+    }
+  },
+  "::testgen-coverage": {
+    "calls": [],
+    "expansion": "Measures code coverage and identifies untested paths.",
+    "metadata": {
+      "category": "testgen",
+      "domain": "testing",
+      "level": "task",
+      "pillar": "quality"
+    }
+  },
+  "::testgen-e2e": {
+    "calls": [],
+    "expansion": "Creates end-to-end tests with headless browsers or API calls to simulate real user flows.",
+    "metadata": {
+      "category": "testgen",
+      "domain": "testing",
+      "level": "task",
+      "pillar": "quality"
+    }
+  },
+  "::testgen-integration": {
+    "calls": [],
+    "expansion": "Produces integration tests to verify interactions between components and external services.",
+    "metadata": {
+      "category": "testgen",
+      "domain": "testing",
+      "level": "task",
+      "pillar": "quality"
+    }
+  },
+  "::testgen-performance": {
+    "calls": [],
+    "expansion": "Implements performance stress tests and benchmarks to assess throughput and latency.",
+    "metadata": {
+      "category": "testgen",
+      "domain": "testing",
+      "level": "task",
+      "pillar": "quality"
+    }
+  },
+  "::testgen-security": {
+    "calls": [],
+    "expansion": "Creates security tests to check for vulnerabilities such as injection, authentication bypass and misconfigurations.",
+    "metadata": {
+      "category": "testgen",
+      "domain": "testing",
+      "level": "task",
+      "pillar": "quality"
+    }
+  },
+  "::testgen-unit": {
+    "calls": [],
+    "expansion": "Generates unit tests for individual functions or modules, covering nominal and edge cases.",
+    "metadata": {
+      "category": "testgen",
+      "domain": "testing",
+      "level": "task",
+      "pillar": "quality"
+    }
+  },
+  "::testsuite": {
+    "calls": [
+      "::testgen",
+      "::integrationtest",
+      "::erroranalysis"
+    ],
+    "expansion": "Executes unit, integration, end-to-end, coverage, performance, security and error analysis macros.",
+    "metadata": {
+      "category": "testsuite",
+      "domain": "testing",
+      "level": "suite",
+      "pillar": "suite"
+    }
+  },
+  "::typegen": {
+    "calls": [
+      "::typegen-pydantic",
+      "::typegen-ts",
+      "::typegen-jsonschema",
+      "::typegen-proto",
+      "::typegen-orm"
+    ],
+    "expansion": "Generates type definitions and schemas (Pydantic, TypeScript, JSON Schema, Protobuf, ORM models) from data samples or schemas.",
+    "metadata": {
+      "category": "typegen",
+      "domain": "data",
+      "level": "macro",
+      "pillar": "modelling"
+    }
+  },
+  "::typegen-jsonschema": {
+    "calls": [],
+    "expansion": "Produces JSON Schema definitions for data validation and documentation.",
+    "metadata": {
+      "category": "typegen",
+      "domain": "data",
+      "level": "task",
+      "pillar": "modelling"
+    }
+  },
+  "::typegen-orm": {
+    "calls": [],
+    "expansion": "Generates ORM models (SQLAlchemy, TypeORM) based on schema definitions.",
+    "metadata": {
+      "category": "typegen",
+      "domain": "data",
+      "level": "task",
+      "pillar": "modelling"
+    }
+  },
+  "::typegen-proto": {
+    "calls": [],
+    "expansion": "Creates Protocol Buffer definitions for gRPC services.",
+    "metadata": {
+      "category": "typegen",
+      "domain": "data",
+      "level": "task",
+      "pillar": "modelling"
+    }
+  },
+  "::typegen-pydantic": {
+    "calls": [],
+    "expansion": "Creates Pydantic models from JSON or Python dictionaries.",
+    "metadata": {
+      "category": "typegen",
+      "domain": "data",
+      "level": "task",
+      "pillar": "modelling"
+    }
+  },
+  "::typegen-ts": {
+    "calls": [],
+    "expansion": "Generates TypeScript interfaces from API responses or schemas.",
+    "metadata": {
+      "category": "typegen",
+      "domain": "data",
+      "level": "task",
+      "pillar": "modelling"
+    }
+  },
+  "::uiux-color": {
+    "calls": [],
+    "expansion": "Checks colour palettes for harmony and sufficient contrast ratios.",
+    "metadata": {
+      "category": "uiux",
+      "domain": "ux",
+      "level": "task",
+      "pillar": "experience"
+    }
+  },
+  "::uiux-emotion": {
+    "calls": [],
+    "expansion": "Reviews emotional tone and resonance of the user interface.",
+    "metadata": {
+      "category": "uiux",
+      "domain": "ux",
+      "level": "task",
+      "pillar": "experience"
+    }
+  },
+  "::uiux-layout": {
+    "calls": [],
+    "expansion": "Analyzes spatial rhythm, grid balance and alignment.",
+    "metadata": {
+      "category": "uiux",
+      "domain": "ux",
+      "level": "task",
+      "pillar": "experience"
+    }
+  },
+  "::uiux-motion": {
+    "calls": [],
+    "expansion": "Assesses animation usage for naturalness, timing and context.",
+    "metadata": {
+      "category": "uiux",
+      "domain": "ux",
+      "level": "task",
+      "pillar": "experience"
+    }
+  },
+  "::uiux-typography": {
+    "calls": [],
+    "expansion": "Evaluates typography flow, font choices and legibility across devices.",
+    "metadata": {
+      "category": "uiux",
+      "domain": "ux",
+      "level": "task",
+      "pillar": "experience"
+    }
+  },
+  "::uiuxaudit": {
+    "calls": [
+      "::uiux-color",
+      "::uiux-typography",
+      "::uiux-layout",
+      "::uiux-motion",
+      "::uiux-emotion"
+    ],
+    "expansion": "Conducts UI/UX audits covering colour harmony, typography, layout, motion and emotional resonance.",
+    "metadata": {
+      "category": "uiuxaudit",
+      "domain": "ux",
+      "level": "macro",
+      "pillar": "experience"
+    }
+  },
+  "::uxsuite": {
+    "calls": [
+      "::uiuxaudit",
+      "::analyticsinject"
+    ],
+    "expansion": "Performs a UI/UX audit and injects analytics instrumentation for better product insights.",
+    "metadata": {
+      "category": "uxsuite",
+      "domain": "ux",
+      "level": "suite",
+      "pillar": "suite"
+    }
+  }
+}

--- a/macro_system/Macros/orchestrator.py
+++ b/macro_system/Macros/orchestrator.py
@@ -1,0 +1,166 @@
+"""Header & Purpose: agent orchestration utilities for macro execution."""
+
+from __future__ import annotations
+
+# === Imports / Dependencies ===
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Sequence
+
+from .engine import MacroEngine
+from .planner import MacroPlanner
+from .types import AgentAssignment, PlanStep
+
+# === Types / Interfaces / Schemas ===
+AgentMap = Mapping[str, str]
+
+
+# === Core Logic / Implementation ===
+DEFAULT_AGENT_MAP: Dict[str, str] = {
+    "analytics": "Knowledge Agent",
+    "architecture": "Architect Agent",
+    "backend": "Backend Agent",
+    "data": "Knowledge Agent",
+    "database": "Backend Agent",
+    "delivery": "CI/CD Agent",
+    "deployment": "CI/CD Agent",
+    "documentation": "Knowledge Agent",
+    "frontend": "Frontend Agent",
+    "observability": "CI/CD Agent",
+    "orchestration": "Meta Agent",
+    "performance": "Backend Agent",
+    "quality": "QA Agent",
+    "security": "CI/CD Agent",
+    "strategy": "Architect Agent",
+    "testing": "QA Agent",
+    "ux": "QA Agent",
+}
+
+
+class MacroOrchestrator:
+    """Coordinate macro plans across agent roles using metadata heuristics."""
+
+    def __init__(
+        self,
+        engine: MacroEngine,
+        *,
+        agent_map: AgentMap | None = None,
+        default_agent: str = "Meta Agent",
+    ) -> None:
+        self._engine = engine
+        self._planner = MacroPlanner(engine)
+        self._default_agent = default_agent
+        merged_map: Dict[str, str] = {
+            key.casefold(): value for key, value in DEFAULT_AGENT_MAP.items()
+        }
+        if agent_map:
+            for domain, agent in agent_map.items():
+                domain_key = domain.casefold()
+                merged_map[domain_key] = agent
+        self._agent_map = merged_map
+
+    def agent_map(self) -> Dict[str, str]:
+        """Return a copy of the active domain-to-agent mapping."""
+
+        return dict(self._agent_map)
+
+    def available_agents(self) -> Sequence[str]:
+        """Return the set of agents referenced by the orchestrator."""
+
+        agents: Dict[str, None] = {}
+        for agent in self._agent_map.values():
+            agents.setdefault(agent, None)
+        agents.setdefault(self._default_agent, None)
+        return list(agents.keys())
+
+    def assign(
+        self, macro_name: str, *, include_non_leaf: bool = False
+    ) -> List[AgentAssignment]:
+        """Return agent assignments for the specified macro."""
+
+        plan = self._planner.build(macro_name)
+        steps = plan.flatten() if include_non_leaf else plan.leaf_tasks()
+        return self._build_assignments(steps)
+
+    def assign_many(
+        self, macro_names: Iterable[str], *, include_non_leaf: bool = False
+    ) -> List[AgentAssignment]:
+        """Return agent assignments spanning multiple macros."""
+
+        collected: List[PlanStep] = []
+        for name in macro_names:
+            plan = self._planner.build(name)
+            if include_non_leaf:
+                collected.extend(plan.flatten())
+            else:
+                collected.extend(plan.leaf_tasks())
+        return self._build_assignments(collected)
+
+    def dispatch(
+        self,
+        macro_names: Iterable[str] | str,
+        *,
+        include_non_leaf: bool = False,
+        format: str = "prompt",
+    ) -> Dict[str, str]:
+        """Return formatted instructions per agent for the given macros."""
+
+        if isinstance(macro_names, str):
+            names = [macro_names]
+        else:
+            names = list(macro_names)
+
+        if not names:
+            return {}
+
+        assignments = self.assign_many(names, include_non_leaf=include_non_leaf)
+        return self._format_assignments(assignments, format=format)
+
+    def _build_assignments(self, steps: Sequence[PlanStep]) -> List[AgentAssignment]:
+        buckets: MutableMapping[str, List[PlanStep]] = {}
+        for step in steps:
+            agent = self._resolve_agent(step.macro)
+            buckets.setdefault(agent, []).append(step)
+        return [AgentAssignment(agent=agent, steps=items) for agent, items in buckets.items()]
+
+    def _format_assignments(
+        self, assignments: Sequence[AgentAssignment], *, format: str
+    ) -> Dict[str, str]:
+        formatter = format.casefold()
+        formatted: Dict[str, str] = {}
+        for assignment in assignments:
+            if formatter == "prompt":
+                formatted[assignment.agent] = assignment.to_prompt()
+            elif formatter == "outline":
+                formatted[assignment.agent] = assignment.to_outline()
+            elif formatter in {"text", "instructions"}:
+                formatted[assignment.agent] = assignment.instructions_text()
+            else:
+                raise ValueError(
+                    "Unknown assignment format. Expected 'prompt', 'outline', or 'text'."
+                )
+        return formatted
+
+    def _resolve_agent(self, macro_name: str) -> str:
+        macro = self._engine.describe(macro_name)
+        metadata_agent = macro.metadata.get("agent")
+        if isinstance(metadata_agent, str) and metadata_agent.strip():
+            return metadata_agent.strip()
+        domain = str(macro.metadata.get("domain", "")).casefold()
+        if domain in self._agent_map:
+            return self._agent_map[domain]
+        return self._default_agent
+
+
+# === Error & Edge Handling ===
+# ``MacroPlanner.build`` propagates ``MacroNotFoundError`` and ``MacroCycleError``
+# for invalid macro graphs; agent resolution defaults to ``default_agent`` when
+# metadata is absent or unrecognised.
+
+
+# === Performance Considerations ===
+# Plans are built once per requested macro; assignments reuse lightweight
+# :class:`PlanStep` instances to avoid duplicate expansion work.
+
+
+# === Exports / Public API ===
+__all__ = ["MacroOrchestrator", "DEFAULT_AGENT_MAP"]
+

--- a/macro_system/Macros/planner.py
+++ b/macro_system/Macros/planner.py
@@ -1,0 +1,79 @@
+"""Header & Purpose: planning utilities for macro execution roadmaps."""
+
+from __future__ import annotations
+
+# === Imports / Dependencies ===
+import json
+from typing import Iterable, List
+
+from .engine import MacroEngine
+from .types import MacroCycleError, PlanStep
+
+# === Types / Interfaces / Schemas ===
+# Plans reuse :class:`PlanStep` dataclasses for hierarchical structures.
+
+
+# === Core Logic / Implementation ===
+class MacroPlanner:
+    """Construct hierarchical plans from macros for practical execution."""
+
+    def __init__(self, engine: MacroEngine):
+        self._engine = engine
+
+    def build(self, macro_name: str) -> PlanStep:
+        """Build a :class:`PlanStep` tree for ``macro_name``."""
+
+        return self._build_recursive(macro_name, [])
+
+    def build_many(self, macro_names: Iterable[str]) -> List[PlanStep]:
+        """Build plan trees for several macros."""
+
+        return [self.build(name) for name in macro_names]
+
+    def render_outline(self, macro_name: str) -> str:
+        """Return a formatted outline for ``macro_name`` suitable for prompts."""
+
+        plan = self.build(macro_name)
+        return plan.to_outline()
+
+    def render_markdown(self, macro_name: str) -> str:
+        """Render a Markdown document describing the macro execution plan."""
+
+        plan = self.build(macro_name)
+        return plan.to_markdown()
+
+    def render_json(self, macro_name: str, *, indent: int = 2) -> str:
+        """Return a JSON string representing the macro plan tree."""
+
+        plan = self.build(macro_name)
+        return json.dumps(plan.to_dict(), indent=indent)
+
+    def tasks(self, macro_name: str) -> List[str]:
+        """Return leaf tasks for ``macro_name`` as human-readable strings."""
+
+        plan = self.build(macro_name)
+        return [f"{step.macro}: {step.description}" for step in plan.leaf_tasks()]
+
+    def _build_recursive(self, name: str, stack: List[str]) -> PlanStep:
+        if name in stack:
+            cycle = stack[stack.index(name) :] + [name]
+            raise MacroCycleError(" -> ".join(cycle))
+
+        macro = self._engine.describe(name)
+        stack.append(name)
+        children = [self._build_recursive(child, stack) for child in macro.calls]
+        stack.pop()
+
+        return PlanStep(macro=name, description=macro.expansion, children=children)
+
+
+# === Error & Edge Handling ===
+# Cycles detected during planning raise ``MacroCycleError`` for clarity.
+
+
+# === Performance Considerations ===
+# Plan construction reuses engine caching implicitly through ``describe`` lookups.
+
+
+# === Exports / Public API ===
+__all__ = ["MacroPlanner"]

--- a/macro_system/Macros/repository.py
+++ b/macro_system/Macros/repository.py
@@ -1,0 +1,122 @@
+"""Header & Purpose: macro catalogue repository with merge and export utilities."""
+
+from __future__ import annotations
+
+# === Imports / Dependencies ===
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+from .catalog import CatalogSource, load_catalogs
+from .engine import MacroEngine
+from .types import Macro, MacroDefinitionError
+
+
+# === Types / Interfaces / Schemas ===
+
+
+@dataclass(frozen=True)
+class CatalogDescriptor:
+    """Lightweight description of a macro catalogue source."""
+
+    label: str
+    source: CatalogSource
+
+
+# === Core Logic / Implementation ===
+class MacroRepository:
+    """Manage macro catalogues, provide merged views, and export snapshots."""
+
+    def __init__(
+        self,
+        sources: Sequence[CatalogSource],
+    ) -> None:
+        if not sources:
+            raise MacroDefinitionError(
+                "MacroRepository requires at least one catalogue source."
+            )
+        self._descriptors: List[CatalogDescriptor] = [
+            CatalogDescriptor(label=self._describe_source(raw), source=raw)
+            for raw in self._deduplicate_sources(sources)
+        ]
+        self._macros: dict[str, Macro] = {}
+        self.refresh()
+
+    # --- Repository Maintenance ------------------------------------
+    def refresh(self) -> dict[str, Macro]:
+        """Reload catalogue data from all registered sources."""
+
+        merged = load_catalogs([descriptor.source for descriptor in self._descriptors])
+        self._macros = merged
+        return dict(self._macros)
+
+    def add_source(self, source: CatalogSource) -> dict[str, Macro]:
+        """Register an additional catalogue source and refresh immediately."""
+
+        descriptor = CatalogDescriptor(
+            label=self._describe_source(source),
+            source=source,
+        )
+        self._descriptors.append(descriptor)
+        return self.refresh()
+
+    def sources(self) -> List[str]:
+        """Return human-readable descriptions of catalogue sources."""
+
+        return [descriptor.label for descriptor in self._descriptors]
+
+    def macros(self) -> dict[str, Macro]:
+        """Return a copy of the merged macros mapping."""
+
+        return dict(self._macros)
+
+    def engine(self) -> MacroEngine:
+        """Instantiate a :class:`MacroEngine` backed by the merged macros."""
+
+        return MacroEngine(self._macros)
+
+    def export(self, destination: Path, *, indent: int = 2) -> None:
+        """Write the merged catalogue to ``destination`` in deterministic order."""
+
+        payload = {
+            name: macro.describe() for name, macro in sorted(self._macros.items())
+        }
+        destination.write_text(json.dumps(payload, indent=indent), encoding="utf-8")
+
+    def __len__(self) -> int:  # pragma: no cover - trivial proxy
+        return len(self._macros)
+
+    # --- Internal Helpers ------------------------------------------
+    @staticmethod
+    def _describe_source(source: CatalogSource) -> str:
+        if isinstance(source, Path):
+            return str(source)
+        if isinstance(source, str):
+            return str(Path(source))
+        return "<in-memory-catalog>"
+
+    @staticmethod
+    def _deduplicate_sources(sources: Iterable[CatalogSource]) -> List[CatalogSource]:
+        seen: dict[str, CatalogSource] = {}
+        for source in sources:
+            if isinstance(source, (Path, str)):
+                key = str(source)
+            else:
+                key = repr(source)
+            seen[key] = source
+        return list(seen.values())
+
+
+# === Error & Edge Handling ===
+# ``load_catalogs`` raises :class:`MacroDefinitionError` for invalid catalogue data.
+
+
+# === Performance Considerations ===
+# Repository operations reuse ``load_catalogs`` which performs linear merges across
+# catalogue sources; deduplication avoids reprocessing duplicate paths.
+
+
+# === Exports / Public API ===
+__all__ = ["CatalogDescriptor", "MacroRepository"]
+

--- a/macro_system/Macros/tests/__init__.py
+++ b/macro_system/Macros/tests/__init__.py
@@ -1,0 +1,10 @@
+"""Test package initialisation for macro_system."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/macro_system/Macros/tests/test_macros.py
+++ b/macro_system/Macros/tests/test_macros.py
@@ -1,0 +1,378 @@
+"""Header & Purpose: integration tests for macro engine, planner, and CLI."""
+
+from __future__ import annotations
+
+# === Imports / Dependencies ===
+import json
+from pathlib import Path
+
+import pytest
+
+from macro_system.cli import main as cli_main
+from macro_system.engine import MacroEngine
+from macro_system.macros import load_catalogs, load_default_catalog, load_macros
+from macro_system.types import (
+    Macro,
+    MacroCycleError,
+    MacroNotFoundError,
+    MacroRenderError,
+    MacroValidationError,
+)
+
+# === Types / Interfaces / Schemas ===
+# Tests manipulate :class:`Macro` dataclasses for targeted scenarios.
+
+
+# === Core Logic / Implementation ===
+CATALOG_PATH = Path("macro_system/Macros/macros.json")
+
+
+def test_loads_minimum_macro_count():
+    macros = load_macros(CATALOG_PATH)
+    assert len(macros) >= 80
+
+
+def test_load_macros_supports_metadata_and_merge():
+    catalog_a = {
+        "::root": {
+            "expansion": "root",
+            "calls": ["::child"],
+            "metadata": {"domain": "test"},
+        },
+        "::child": {"expansion": "child", "calls": []},
+    }
+    catalog_b = {"::extra": {"expansion": "extra", "calls": []}}
+    macros = load_macros(catalog_a)
+    assert macros["::root"].metadata["domain"] == "test"
+
+    merged = load_catalogs([catalog_a, catalog_b])
+    assert "::extra" in merged
+
+
+def test_frontend_macro_expansion_includes_dependencies():
+    engine = MacroEngine.from_json(CATALOG_PATH)
+    expansion = engine.expand("::frontendgen")
+    assert "Generates a full front-end scaffold" in expansion
+    assert "Designs grid layouts" in expansion
+    assert "Generates front-end unit tests" in expansion
+
+
+def test_missing_macro_reference_raises():
+    macros = {
+        "::root": Macro(name="::root", expansion="root", calls=["::missing"])
+    }
+    engine = MacroEngine(macros)
+    with pytest.raises(MacroNotFoundError):
+        engine.expand("::root")
+
+
+def test_cycle_detection_reports_cycle():
+    macros = {
+        "::a": Macro(name="::a", expansion="A", calls=["::b"]),
+        "::b": Macro(name="::b", expansion="B", calls=["::a"]),
+    }
+    engine = MacroEngine(macros)
+    with pytest.raises(MacroCycleError):
+        engine.expand("::a")
+
+
+def test_available_macros_sorted_listing():
+    engine = MacroEngine.from_json(CATALOG_PATH)
+    macros = engine.available_macros()
+    assert macros == sorted(macros)
+    assert "::frontendgen" in macros
+
+
+def test_dependency_and_ancestor_introspection():
+    engine = MacroEngine.from_json(CATALOG_PATH)
+    deps = engine.dependencies("::frontendsuite")
+    assert "::frontendgen" in deps
+    assert "::frontendgen-tests" in deps
+
+    parents = engine.ancestors("::frontendgen")
+    assert "::frontendsuite" in parents
+    assert "::fullstacksuite" in parents
+
+
+def test_validate_detects_missing_reference():
+    macros = {
+        "::a": Macro(name="::a", expansion="A", calls=["::missing"]),
+        "::b": Macro(name="::b", expansion="B", calls=[]),
+    }
+    engine = MacroEngine(macros)
+    with pytest.raises(MacroNotFoundError):
+        engine.validate()
+
+
+def test_validate_strict_raises_on_unreachable():
+    macros = {
+        "::root": Macro(name="::root", expansion="root", calls=["::child"]),
+        "::child": Macro(name="::child", expansion="child", calls=[]),
+        "::orphan": Macro(name="::orphan", expansion="orphan", calls=[]),
+    }
+    engine = MacroEngine(macros)
+    with pytest.raises(MacroValidationError):
+        engine.validate_strict(entrypoints=["::root"])
+
+
+def test_engine_cache_and_trace_behaviour():
+    engine = MacroEngine.from_json(CATALOG_PATH)
+    engine.clear_cache()
+    initial_expansion, trace = engine.expand_with_trace("::frontendgen")
+    assert initial_expansion.startswith("Generates a full front-end scaffold")
+    assert trace[0] == "::frontendgen"
+
+    _, cached_trace = engine.expand_with_trace("::frontendgen")
+    assert cached_trace[0].endswith("(cached)")
+    assert engine.cache_info()["cached_macros"] >= 1
+
+
+def test_render_with_context_and_placeholders():
+    macros = {
+        "::brief": Macro(
+            name="::brief",
+            expansion="Focus on {{primary_goal}} outcomes and success metrics.",
+            calls=[],
+        ),
+        "::combo": Macro(
+            name="::combo",
+            expansion="Launch {{project_name}} initiative with stellar positioning.",
+            calls=["::brief"],
+        ),
+    }
+    engine = MacroEngine(macros)
+    context = {"project_name": "Atlas", "primary_goal": "automation"}
+
+    rendered = engine.render("::combo", context)
+    assert "Atlas" in rendered
+    assert "automation" in rendered
+
+    placeholders = engine.placeholders("::combo")
+    assert placeholders == ["primary_goal", "project_name"]
+
+    direct_only = engine.placeholders("::combo", recursive=False)
+    assert direct_only == ["project_name"]
+
+    with pytest.raises(MacroRenderError):
+        engine.render("::combo", {"project_name": "Atlas"})
+
+    partial = engine.render("::combo", {"project_name": "Atlas"}, strict=False)
+    assert "{{primary_goal}}" in partial
+
+
+def test_engine_stats_search_audit_and_path():
+    engine = MacroEngine(load_default_catalog())
+    stats = engine.stats()
+    assert stats.total_macros >= 80
+    assert "::masterdev" in stats.root_macros
+    assert stats.max_depth >= 2
+
+    matches = engine.search("frontend")
+    names = {macro.name for macro in matches}
+    assert "::frontendgen" in names
+
+    audit = engine.audit(entrypoints=["::masterdev"])
+    assert "::masterdev" in audit.entrypoints
+    assert audit.stats.total_macros == stats.total_macros
+
+    path = engine.explain_path("::masterdev", "::frontendgen-tests")
+    assert path[0] == "::masterdev"
+    assert path[-1] == "::frontendgen-tests"
+
+
+def test_cli_plan_command_outputs_outline(capsys):
+    exit_code = cli_main(["--plan", "::frontendgen"])
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "::frontendgen" in captured.out
+    assert "::frontendgen-tests" in captured.out
+
+
+def test_cli_audit_and_path_commands(capsys):
+    assert cli_main(["--audit"]) == 0
+    audit_output = capsys.readouterr().out
+    assert "undefined_references" in audit_output
+
+
+def test_engine_metadata_filter_and_grouping():
+    engine = MacroEngine.from_json(CATALOG_PATH)
+    frontend_macros = engine.filter_by_metadata({"domain": "frontend"})
+    names = {macro.name for macro in frontend_macros}
+    assert "::frontendgen" in names
+    assert any(name.startswith("::frontendgen-") for name in names)
+
+    grouped = engine.group_by_metadata("domain")
+    assert "frontend" in grouped
+    assert any(macro.name == "::frontendgen" for macro in grouped["frontend"])
+
+
+def test_cli_metadata_filtering_and_grouping(capsys):
+    exit_code = cli_main(["--filter-meta", "domain=frontend"])
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "::frontendgen" in output
+    assert "::frontendgen-docs" in output
+
+    exit_code = cli_main(["--group-meta", "domain"])
+    assert exit_code == 0
+    grouped_output = capsys.readouterr().out
+    payload = json.loads(grouped_output)
+    assert "frontend" in payload
+    assert any(name == "::frontendgen" for name in payload["frontend"])
+
+
+def test_cli_metadata_filter_validation(capsys):
+    exit_code = cli_main(["--filter-meta", "invalidpair"])
+    assert exit_code == 2
+    err = capsys.readouterr().err
+    assert "Metadata filters must be provided" in err
+
+    assert cli_main(["--path", "::masterdev", "::frontendgen"]) == 0
+    path_output = capsys.readouterr().out.strip()
+    assert path_output.startswith("::masterdev")
+
+
+def test_cli_context_render_and_placeholders(capsys, tmp_path):
+    assert cli_main(["--placeholders", "::project-kickoff"]) == 0
+    placeholder_output = capsys.readouterr().out.splitlines()
+    assert "project_name" in placeholder_output
+    assert "primary_goal" in placeholder_output
+
+    exit_code = cli_main(
+        [
+            "--context",
+            "project_name=Atlas",
+            "--context",
+            "primary_goal=automation",
+            "::project-kickoff",
+        ]
+    )
+    assert exit_code == 0
+    rendered = capsys.readouterr().out
+    assert "Atlas" in rendered
+    assert "automation" in rendered
+
+    exit_code = cli_main(["--context", "project_name=Atlas", "::project-kickoff"])
+    assert exit_code == 1
+    failure = capsys.readouterr()
+    assert "Missing values for placeholders" in failure.err
+
+    context_file = tmp_path / "context.json"
+    context_file.write_text(
+        json.dumps({"project_name": "Nova", "primary_goal": "expansion"}),
+        encoding="utf-8",
+    )
+    exit_code = cli_main(["--context-file", str(context_file), "::project-kickoff"])
+    assert exit_code == 0
+    rendered_file = capsys.readouterr().out
+    assert "Nova" in rendered_file
+    assert "expansion" in rendered_file
+
+    exit_code = cli_main(
+        ["--context", "project_name=Atlas", "--allow-partial", "::project-kickoff"]
+    )
+    assert exit_code == 0
+    partial = capsys.readouterr().out
+    assert "{{primary_goal}}" in partial
+
+
+def test_cli_assign_agents_outputs_outline(capsys):
+    exit_code = cli_main(["--assign-agents", "::frontendsuite"])
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "Frontend Agent" in output
+    assert "::frontendgen" in output
+
+
+def test_cli_assign_agents_json_with_overrides(capsys):
+    exit_code = cli_main(
+        ["--agent-map", "frontend=Design Agent", "--assign-json", "::frontendsuite"]
+    )
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert any(entry["agent"] == "Design Agent" for entry in payload)
+
+
+def test_cli_assign_prompts_outputs_agent_prompts(capsys):
+    exit_code = cli_main(["--assign-prompts", "::frontendsuite"])
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "You are Frontend Agent" in output
+    assert "::frontendgen" in output
+
+
+def test_cli_assign_prompts_respects_format(capsys):
+    exit_code = cli_main(
+        ["--assign-prompts-format", "outline", "--assign-prompts", "::frontendsuite"]
+    )
+    assert exit_code == 0
+    outline_output = capsys.readouterr().out
+    assert "## Frontend Agent" in outline_output
+
+    exit_code = cli_main(
+        ["--assign-prompts-format", "text", "--assign-prompts", "::backendsuite"]
+    )
+    assert exit_code == 0
+    text_output = capsys.readouterr().out
+    assert "## Backend Agent" in text_output
+    assert "Scaffolds CRUD endpoints" in text_output
+
+
+def test_cli_stats_search_and_strict_validation(capsys):
+    assert cli_main(["--stats"]) == 0
+    stats_output = capsys.readouterr().out
+    assert "total_macros" in stats_output
+
+    assert cli_main(["--search", "frontend"]) == 0
+    search_output = capsys.readouterr().out
+    assert "::frontendgen" in search_output
+
+    assert cli_main(["--ancestors", "::frontendgen"]) == 0
+    ancestor_output = capsys.readouterr().out
+    assert "::frontendsuite" in ancestor_output
+
+    assert cli_main(["--validate-strict"]) == 0
+
+
+def test_cli_catalog_sources_and_export(tmp_path, capsys):
+    custom_dir = tmp_path / "catalogs"
+    custom_dir.mkdir()
+    custom_macro = {
+        "::custom": {"expansion": "Custom expansion", "calls": []},
+    }
+    custom_path = custom_dir / "custom.json"
+    custom_path.write_text(json.dumps(custom_macro), encoding="utf-8")
+
+    exit_code = cli_main([
+        "--no-default",
+        "--catalog-dir",
+        str(custom_dir),
+        "--list-sources",
+    ])
+    assert exit_code == 0
+    sources_output = capsys.readouterr().out.splitlines()
+    assert str(custom_path) in sources_output
+
+    export_path = tmp_path / "merged.json"
+    exit_code = cli_main(
+        [
+            "--no-default",
+            "--catalog",
+            str(custom_path),
+            "--export-merged",
+            str(export_path),
+        ]
+    )
+    assert exit_code == 0
+    export_summary = json.loads(capsys.readouterr().out)
+    assert export_summary["total_macros"] == 1
+    payload = json.loads(export_path.read_text(encoding="utf-8"))
+    assert payload["::custom"]["expansion"] == "Custom expansion"
+
+
+# === Error & Edge Handling ===
+# Negative tests ensure exceptions propagate for invalid macro definitions.
+
+
+# === Performance Considerations ===
+# Tests reuse shared catalogue path to avoid redundant JSON loading overhead.

--- a/macro_system/Macros/tests/test_orchestrator.py
+++ b/macro_system/Macros/tests/test_orchestrator.py
@@ -1,0 +1,93 @@
+"""Header & Purpose: regression tests for agent-oriented orchestration."""
+
+from __future__ import annotations
+
+# === Imports / Dependencies ===
+from pathlib import Path
+
+from macro_system import MacroEngine, MacroOrchestrator
+
+# === Types / Interfaces / Schemas ===
+# Tests leverage the default macro catalogue for realistic scenarios.
+
+
+# === Core Logic / Implementation ===
+CATALOG_PATH = Path("macro_system/Macros/macros.json")
+
+
+def test_orchestrator_assigns_specialist_agents():
+    engine = MacroEngine.from_json(CATALOG_PATH)
+    orchestrator = MacroOrchestrator(engine)
+
+    assignments = orchestrator.assign("::fullstacksuite")
+    mapping = {assignment.agent: assignment.macros() for assignment in assignments}
+
+    assert "Frontend Agent" in mapping
+    assert any(name.startswith("::frontend") for name in mapping["Frontend Agent"])
+
+    assert "Backend Agent" in mapping
+    backend_macros = mapping["Backend Agent"]
+    assert any(name.startswith("::backend") for name in backend_macros)
+    assert any(name.startswith("::dbdesign") for name in backend_macros)
+
+    assert "CI/CD Agent" in mapping
+    cicd_macros = mapping["CI/CD Agent"]
+    assert any(name.startswith("::cicd") for name in cicd_macros)
+    assert any(name.startswith("::deploy") for name in cicd_macros)
+
+
+def test_orchestrator_respects_overrides_and_includes_parents():
+    engine = MacroEngine.from_json(CATALOG_PATH)
+    orchestrator = MacroOrchestrator(engine, agent_map={"frontend": "Design Agent"})
+
+    assignments = orchestrator.assign("::frontendsuite", include_non_leaf=True)
+    agents = {assignment.agent for assignment in assignments}
+    assert "Design Agent" in agents
+
+    macros = {macro for assignment in assignments for macro in assignment.macros()}
+    assert "::frontendsuite" in macros
+
+    payload = assignments[0].to_dict()
+    assert payload["agent"]
+    assert payload["steps"]
+    assert payload["instructions_text"]
+
+
+def test_orchestrator_assign_many_combines_results():
+    engine = MacroEngine.from_json(CATALOG_PATH)
+    orchestrator = MacroOrchestrator(engine)
+
+    assignments = orchestrator.assign_many(["::frontendsuite", "::backendsuite"])
+    mapping = {assignment.agent: assignment.macros() for assignment in assignments}
+
+    assert "Frontend Agent" in mapping
+    assert any(name.startswith("::frontend") for name in mapping["Frontend Agent"])
+
+    assert "Backend Agent" in mapping
+    assert any(name.startswith("::backend") for name in mapping["Backend Agent"])
+
+
+def test_orchestrator_dispatch_formats_prompts_and_outlines():
+    engine = MacroEngine.from_json(CATALOG_PATH)
+    orchestrator = MacroOrchestrator(engine)
+
+    prompts = orchestrator.dispatch(["::frontendsuite", "::datasuite"], format="prompt")
+    assert "Frontend Agent" in prompts
+    assert prompts["Frontend Agent"].startswith("You are Frontend Agent")
+    assert "::frontendgen" in prompts["Frontend Agent"]
+
+    outlines = orchestrator.dispatch("::frontendsuite", format="outline")
+    assert outlines["Frontend Agent"].startswith("## Frontend Agent")
+
+    instructions = orchestrator.dispatch("::backendsuite", format="text")
+    assert "Scaffolds CRUD endpoints" in instructions["Backend Agent"]
+
+
+# === Error & Edge Handling ===
+# Defaults ensure missing metadata falls back to the Meta Agent; tests cover
+# overrides and combined macro execution to validate behaviour.
+
+
+# === Performance Considerations ===
+# Orchestrator reuses cached planner results implicitly; tests focus on
+# functional correctness rather than benchmarks.

--- a/macro_system/Macros/tests/test_package_aliases.py
+++ b/macro_system/Macros/tests/test_package_aliases.py
@@ -1,0 +1,58 @@
+"""Header & Purpose: verify macro_system routes through the Macros package."""
+
+from __future__ import annotations
+
+# === Imports / Dependencies ===
+import importlib
+from typing import Dict
+
+import pytest
+
+# === Types / Interfaces / Schemas ===
+AliasExpectation = Dict[str, str]
+
+
+# === Core Logic / Implementation ===
+ALIASES: AliasExpectation = {
+    "macro_system.cli": "macro_system.Macros.cli",
+    "macro_system.engine": "macro_system.Macros.engine",
+    "macro_system.macros": "macro_system.Macros.catalog",
+    "macro_system.orchestrator": "macro_system.Macros.orchestrator",
+    "macro_system.planner": "macro_system.Macros.planner",
+    "macro_system.types": "macro_system.Macros.types",
+}
+
+
+@pytest.mark.parametrize("alias,target", sorted(ALIASES.items()))
+def test_alias_modules_match_macros_package(alias: str, target: str) -> None:
+    """Ensure each legacy module points to the consolidated Macros module."""
+
+    alias_module = importlib.import_module(alias)
+    target_module = importlib.import_module(target)
+    assert alias_module is target_module
+
+
+def test_public_api_reexports_under_single_package() -> None:
+    """Confirm dataclass exports reference the canonical Macros implementations."""
+
+    from macro_system import MacroEngine as package_engine
+    from macro_system import MacroOrchestrator as package_orchestrator
+    from macro_system.Macros.engine import MacroEngine as macros_engine
+    from macro_system.Macros.orchestrator import (
+        MacroOrchestrator as macros_orchestrator,
+    )
+
+    assert package_engine is macros_engine
+    assert package_orchestrator is macros_orchestrator
+
+
+# === Error & Edge Handling ===
+# Alias lookups rely on importlib; failures would surface as ImportError to flag regressions.
+
+
+# === Performance Considerations ===
+# Tests import modules once each; execution cost is negligible relative to suite runtime.
+
+
+# === Exports / Public API ===
+__all__ = ["ALIASES", "test_alias_modules_match_macros_package", "test_public_api_reexports_under_single_package"]

--- a/macro_system/Macros/tests/test_planner.py
+++ b/macro_system/Macros/tests/test_planner.py
@@ -1,0 +1,72 @@
+"""Header & Purpose: planner-focused regression tests for macro workflows."""
+
+from __future__ import annotations
+
+# === Imports / Dependencies ===
+import json
+from pathlib import Path
+
+from macro_system.engine import MacroEngine
+from macro_system.planner import MacroPlanner
+
+# === Types / Interfaces / Schemas ===
+# Tests operate on the ``MacroPlanner`` abstraction.
+
+
+# === Core Logic / Implementation ===
+def build_planner() -> MacroPlanner:
+    engine = MacroEngine.from_json(Path("macro_system/Macros/macros.json"))
+    return MacroPlanner(engine)
+
+
+def test_planner_builds_hierarchical_structure():
+    planner = build_planner()
+    plan = planner.build("::frontendgen")
+
+    assert plan.macro == "::frontendgen"
+    child_names = {child.macro for child in plan.children}
+    assert "::frontendgen-layout" in child_names
+    assert "::frontendgen-tests" in child_names
+    # leaf tasks should correspond to macros without further calls
+    leaf_macros = {leaf.macro for leaf in plan.leaf_tasks()}
+    assert "::frontendgen-docs" in leaf_macros
+    assert "::frontendgen-motion" in leaf_macros
+
+
+def test_outline_contains_nested_steps():
+    planner = build_planner()
+    outline = planner.render_outline("::frontendsuite")
+
+    assert "- ::frontendsuite" in outline
+    assert "  - ::frontendgen" in outline
+    assert "    - ::frontendgen-tests" in outline
+
+
+def test_markdown_json_and_task_rendering():
+    planner = build_planner()
+    markdown = planner.render_markdown("::datasuite")
+    assert markdown.startswith("## ::datasuite")
+    assert "### ::mockdata" in markdown
+
+    json_payload = planner.render_json("::datasuite")
+    payload = json.loads(json_payload)
+    assert payload["macro"] == "::datasuite"
+
+    tasks = planner.tasks("::datasuite")
+    assert any(task.startswith("::mockdata-sample") for task in tasks)
+
+
+def test_plan_flatten_preserves_preorder():
+    planner = build_planner()
+    plan = planner.build("::frontendsuite")
+    ordered = plan.flatten()
+    assert ordered[0].macro == "::frontendsuite"
+    assert any(step.macro == "::frontendgen-tests" for step in ordered)
+
+
+# === Error & Edge Handling ===
+# Planner relies on the engine to surface cycle detection via exceptions.
+
+
+# === Performance Considerations ===
+# Planner fixture reuses a shared engine instance to minimise file I/O.

--- a/macro_system/Macros/tests/test_repository.py
+++ b/macro_system/Macros/tests/test_repository.py
@@ -1,0 +1,55 @@
+"""Header & Purpose: tests for macro repository catalogue management."""
+
+from __future__ import annotations
+
+# === Imports / Dependencies ===
+import json
+from pathlib import Path
+
+import pytest
+
+from macro_system.Macros.repository import MacroRepository
+from macro_system.Macros.types import MacroDefinitionError
+
+
+# === Types / Interfaces / Schemas ===
+# Tests operate on dictionaries and paths compatible with CatalogSource alias.
+
+
+# === Core Logic / Implementation ===
+def test_repository_merges_sources_and_exports(tmp_path: Path) -> None:
+    """Repository merges in-memory and file-backed catalogues."""
+
+    base_catalog = {
+        "::alpha": {"expansion": "Alpha", "calls": []},
+    }
+    extra_path = tmp_path / "extra.json"
+    extra_path.write_text(
+        json.dumps({"::beta": {"expansion": "Beta", "calls": []}}),
+        encoding="utf-8",
+    )
+
+    repository = MacroRepository([base_catalog, extra_path])
+    macros = repository.macros()
+    assert set(macros) == {"::alpha", "::beta"}
+
+    export_path = tmp_path / "merged.json"
+    repository.export(export_path)
+    payload = json.loads(export_path.read_text(encoding="utf-8"))
+    assert payload["::alpha"]["expansion"] == "Alpha"
+    assert payload["::beta"]["expansion"] == "Beta"
+
+
+def test_repository_rejects_empty_sources() -> None:
+    """Constructing without sources raises a definition error."""
+
+    with pytest.raises(MacroDefinitionError):
+        MacroRepository([])
+
+
+# === Error & Edge Handling ===
+# Export writes deterministic JSON; empty sources raise immediately.
+
+
+# === Performance Considerations ===
+# Temporary files ensure test isolation and avoid repeated catalogue parsing.

--- a/macro_system/Macros/types.py
+++ b/macro_system/Macros/types.py
@@ -1,0 +1,261 @@
+"""Core domain types, schemas, and error classes for the macro system."""
+
+from __future__ import annotations
+"""Header & Purpose: strongly-typed domain models for macro catalogues."""
+
+# === Imports / Dependencies ===
+from dataclasses import dataclass, field
+from typing import Dict, List, Mapping, Sequence
+
+# === Types / Interfaces / Schemas ===
+
+
+@dataclass(frozen=True)
+class Macro:
+    """Immutable representation of a macro definition loaded from JSON."""
+
+    name: str
+    expansion: str
+    calls: List[str]
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    # === Core Logic / Implementation ===
+    def describe(self) -> Dict[str, object]:
+        """Return a serialisable dictionary for inspection and auditing."""
+
+        return {
+            "name": self.name,
+            "expansion": self.expansion,
+            "calls": list(self.calls),
+            "metadata": dict(self.metadata),
+        }
+
+
+class MacroError(Exception):
+    """Base class for macro-related failures."""
+
+
+class MacroNotFoundError(MacroError):
+    """Raised when attempting to expand or inspect an undefined macro."""
+
+
+class MacroCycleError(MacroError):
+    """Raised when a cycle is detected during macro expansion or planning."""
+
+
+class MacroDefinitionError(MacroError):
+    """Raised when macro definitions are invalid, malformed, or inconsistent."""
+
+
+class MacroRenderError(MacroError):
+    """Raised when applying context to macro expansions fails."""
+
+
+class MacroValidationError(MacroError):
+    """Raised when catalogue-wide validation fails during audits."""
+
+
+@dataclass(frozen=True)
+class MacroStats:
+    """Aggregate statistics describing the structure of a macro catalogue."""
+
+    total_macros: int
+    root_macros: Sequence[str]
+    leaf_macros: Sequence[str]
+    max_depth: int
+    average_branching_factor: float
+
+    # === Core Logic / Implementation ===
+    def to_dict(self) -> Dict[str, object]:
+        """Represent the statistics as a dictionary for JSON emission."""
+
+        return {
+            "total_macros": self.total_macros,
+            "root_macros": list(self.root_macros),
+            "leaf_macros": list(self.leaf_macros),
+            "max_depth": self.max_depth,
+            "average_branching_factor": self.average_branching_factor,
+        }
+
+
+@dataclass(frozen=True)
+class MacroAudit:
+    """Structured summary describing catalogue health and anomalies."""
+
+    undefined_references: Mapping[str, Sequence[str]]
+    cycles: Sequence[Sequence[str]]
+    unreachable_macros: Sequence[str]
+    entrypoints: Sequence[str]
+    stats: MacroStats
+
+    # === Core Logic / Implementation ===
+    def to_dict(self) -> Dict[str, object]:
+        """Return a JSON-serialisable representation of the audit result."""
+
+        return {
+            "undefined_references": {
+                macro: list(missing) for macro, missing in self.undefined_references.items()
+            },
+            "cycles": [list(cycle) for cycle in self.cycles],
+            "unreachable_macros": list(self.unreachable_macros),
+            "entrypoints": list(self.entrypoints),
+            "stats": self.stats.to_dict(),
+        }
+
+
+@dataclass
+class PlanStep:
+    """Represents an actionable plan node derived from macro expansion."""
+
+    macro: str
+    description: str
+    children: List["PlanStep"] = field(default_factory=list)
+
+    # === Core Logic / Implementation ===
+    def to_outline(self) -> str:
+        """Return a human-readable outline of this plan and its children."""
+
+        lines: List[str] = []
+
+        def _walk(step: "PlanStep", depth: int) -> None:
+            indent = "  " * depth
+            lines.append(f"{indent}- {step.macro}: {step.description}")
+            for child in step.children:
+                _walk(child, depth + 1)
+
+        _walk(self, 0)
+        return "\n".join(lines)
+
+    def to_dict(self) -> Dict[str, object]:
+        """Serialise the plan hierarchy into a JSON-friendly dictionary."""
+
+        return {
+            "macro": self.macro,
+            "description": self.description,
+            "children": [child.to_dict() for child in self.children],
+        }
+
+    def to_markdown(self, heading_level: int = 2) -> str:
+        """Render the plan tree as a Markdown document."""
+
+        lines: List[str] = []
+
+        def _walk(step: "PlanStep", depth: int) -> None:
+            heading = "#" * max(1, heading_level + depth)
+            lines.append(f"{heading} {step.macro}\n\n{step.description}\n")
+            for child in step.children:
+                _walk(child, depth + 1)
+
+        _walk(self, 0)
+        return "\n".join(lines).strip()
+
+    def leaf_tasks(self) -> List["PlanStep"]:
+        """Return the leaves of the plan tree as actionable tasks."""
+
+        tasks: List[PlanStep] = []
+
+        def _gather(step: "PlanStep") -> None:
+            if not step.children:
+                tasks.append(step)
+            else:
+                for child in step.children:
+                    _gather(child)
+
+        _gather(self)
+        return tasks
+
+    def flatten(self) -> List["PlanStep"]:
+        """Return the plan nodes in preorder traversal."""
+
+        ordered: List[PlanStep] = []
+
+        def _walk(step: "PlanStep") -> None:
+            ordered.append(step)
+            for child in step.children:
+                _walk(child)
+
+        _walk(self)
+        return ordered
+
+
+@dataclass
+class AgentAssignment:
+    """Group of plan steps allocated to a specific agent role."""
+
+    agent: str
+    steps: List[PlanStep] = field(default_factory=list)
+
+    # === Core Logic / Implementation ===
+    def macros(self) -> List[str]:
+        """Return the macro identifiers associated with this assignment."""
+
+        return [step.macro for step in self.steps]
+
+    def instructions(self) -> List[str]:
+        """Return the textual instructions for each assigned plan step."""
+
+        return [step.description for step in self.steps]
+
+    def instructions_text(self) -> str:
+        """Return concatenated instructions suitable for prompting agents."""
+
+        return "\n\n".join(self.instructions())
+
+    def to_prompt(self, include_header: bool = True) -> str:
+        """Render a conversational prompt tailored for the assigned agent."""
+
+        lines: List[str] = []
+        if include_header:
+            lines.append(
+                f"You are {self.agent}. Execute the following tasks with precision:"
+            )
+        for step in self.steps:
+            lines.append(f"- {step.macro}: {step.description}")
+        return "\n".join(lines)
+
+    def to_outline(self) -> str:
+        """Render a Markdown outline listing this agent's responsibilities."""
+
+        lines: List[str] = [f"## {self.agent}"]
+        for step in self.steps:
+            lines.append(f"- {step.macro}: {step.description}")
+        return "\n".join(lines)
+
+    def to_dict(self) -> Dict[str, object]:
+        """Serialise the assignment into a JSON-friendly dictionary."""
+
+        return {
+            "agent": self.agent,
+            "macros": self.macros(),
+            "steps": [
+                {"macro": step.macro, "description": step.description}
+                for step in self.steps
+            ],
+            "instructions": self.instructions(),
+            "instructions_text": self.instructions_text(),
+            "prompt": self.to_prompt(),
+        }
+
+
+# === Error & Edge Handling ===
+# Error classes defined above provide specific failure modes for catalogue issues.
+
+
+# === Performance Considerations ===
+# Dataclasses are lightweight and immutable where appropriate to support caching.
+
+
+# === Exports / Public API ===
+__all__ = [
+    "Macro",
+    "MacroAudit",
+    "MacroCycleError",
+    "MacroDefinitionError",
+    "MacroError",
+    "MacroNotFoundError",
+    "MacroRenderError",
+    "MacroStats",
+    "MacroValidationError",
+    "PlanStep",
+    "AgentAssignment",
+]

--- a/macro_system/__init__.py
+++ b/macro_system/__init__.py
@@ -1,0 +1,107 @@
+"""Header & Purpose: macro system package entry point with Macros aliases."""
+
+from __future__ import annotations
+
+# === Imports / Dependencies ===
+import importlib
+import sys
+from types import ModuleType
+from typing import Dict, Mapping
+
+from .Macros import (
+    AgentAssignment,
+    DEFAULT_AGENT_MAP,
+    Macro,
+    MacroAudit,
+    MacroCycleError,
+    MacroDefinitionError,
+    MacroEngine,
+    MacroError,
+    MacroNotFoundError,
+    MacroOrchestrator,
+    MacroPlanner,
+    MacroRenderError,
+    MacroRepository,
+    MacroStats,
+    MacroValidationError,
+    PlanStep,
+)
+
+# === Types / Interfaces / Schemas ===
+AliasMap = Mapping[str, str]
+AliasRegistry = Dict[str, ModuleType]
+
+
+# === Core Logic / Implementation ===
+def _register_alias_modules(alias_map: AliasMap) -> AliasRegistry:
+    """Import Macros submodules and register legacy alias modules."""
+
+    registered: AliasRegistry = {}
+    for alias, target in alias_map.items():
+        full_name = f"{__name__}.{alias}"
+        try:
+            module = importlib.import_module(target)
+        except ImportError as exc:  # pragma: no cover - defensive guard
+            raise RuntimeError(
+                f"Failed to import legacy macro module alias '{target}'."
+            ) from exc
+        sys.modules.setdefault(full_name, module)
+        registered[alias] = module
+    return registered
+
+
+_ALIAS_MODULES: AliasMap = {
+    "cli": "macro_system.Macros.cli",
+    "engine": "macro_system.Macros.engine",
+    "macros": "macro_system.Macros.catalog",
+    "repository": "macro_system.Macros.repository",
+    "planner": "macro_system.Macros.planner",
+    "orchestrator": "macro_system.Macros.orchestrator",
+    "types": "macro_system.Macros.types",
+}
+
+_ALIASED_MODULES: AliasRegistry = _register_alias_modules(_ALIAS_MODULES)
+
+
+def __getattr__(name: str) -> ModuleType:
+    """Expose registered alias modules via attribute access."""
+
+    if name in _ALIASED_MODULES:
+        return _ALIASED_MODULES[name]
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+
+def __dir__() -> list[str]:
+    """Display dataclass exports alongside registered aliases."""
+
+    return sorted(set(__all__) | set(_ALIASED_MODULES))
+
+
+# === Error & Edge Handling ===
+# ``_register_alias_modules`` raises ``RuntimeError`` with context if imports fail.
+# ``__getattr__`` surfaces ``AttributeError`` for unknown names, aligning with Python expectations.
+
+
+# === Performance Considerations ===
+# Alias registration imports each Macros module once and caches them in ``sys.modules``.
+
+
+# === Exports / Public API ===
+__all__ = [
+    "AgentAssignment",
+    "DEFAULT_AGENT_MAP",
+    "Macro",
+    "MacroAudit",
+    "MacroCycleError",
+    "MacroDefinitionError",
+    "MacroEngine",
+    "MacroError",
+    "MacroNotFoundError",
+    "MacroOrchestrator",
+    "MacroPlanner",
+    "MacroRenderError",
+    "MacroRepository",
+    "MacroStats",
+    "MacroValidationError",
+    "PlanStep",
+]

--- a/macro_system/__main__.py
+++ b/macro_system/__main__.py
@@ -1,0 +1,36 @@
+"""Header & Purpose: executable entry point delegating to the Macros CLI."""
+
+from __future__ import annotations
+
+# === Imports / Dependencies ===
+from typing import Sequence
+
+from .Macros.cli import main as _cli_main
+
+# === Types / Interfaces / Schemas ===
+Args = Sequence[str]
+
+
+# === Core Logic / Implementation ===
+def main(argv: Args | None = None) -> int:
+    """Invoke the Macros CLI entry point with optional arguments."""
+
+    return _cli_main(argv)
+
+
+# === Error & Edge Handling ===
+# CLI exceptions propagate for upstream handling, mirroring direct CLI usage.
+
+
+# === Performance Considerations ===
+# Simple delegation adds no measurable overhead beyond the CLI invocation.
+
+
+# === Exports / Public API ===
+__all__ = ["main"]
+
+
+if __name__ == "__main__":  # pragma: no cover - command-line entry
+    import sys
+
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- add conversational prompt generation helpers to agent assignments and expose formatted dispatching from the macro orchestrator
- extend the CLI with --assign-prompts flags that stream prompt, outline, or text payloads for one or more macros
- document the new workflows and cover them with regression tests for orchestrator dispatch and CLI behaviour

## Testing
- python -m pytest macro_system/Macros/tests

------
https://chatgpt.com/codex/tasks/task_e_68d2014bc53483218169a010f9dca8b2