### PR TITLE
Add macro schema export and integration suites

### DIFF
--- a/macro_system/__init__.py
+++ b/macro_system/__init__.py
@@ -3,7 +3,16 @@
 # === Imports ===
 from .engine import MacroEngine
 from .planner import MacroPlanner
+from .reports import MacroReview, generate_macro_review
+from .schema import macro_schema
 from .types import PlanStep
 
 # === Exports ===
-__all__ = ["MacroEngine", "MacroPlanner", "PlanStep"]
+__all__ = [
+    "MacroEngine",
+    "MacroPlanner",
+    "MacroReview",
+    "PlanStep",
+    "generate_macro_review",
+    "macro_schema",
+]

--- a/macro_system/macros.json
+++ b/macro_system/macros.json
@@ -9,35 +9,150 @@
       "::frontendgen-motion",
       "::frontendgen-tests",
       "::frontendgen-docs"
-    ]
+    ],
+    "ownerAgent": "Frontend Agent",
+    "outcomes": [
+      "Frontend Agent delivers the ::frontendgen macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ],
+    "phase": "build",
+    "priority": "P1",
+    "status": "planned",
+    "estimatedDuration": "8h",
+    "tags": [
+      "frontend",
+      "scaffold"
+    ],
+    "version": "1.1.0"
   },
   "::frontendgen-layout": {
     "expansion": "Designs grid layouts using patterns such as cinematic Z, modular cockpit, F-pattern or gallery spotlight to organise the UI.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Frontend Agent",
+    "outcomes": [
+      "Frontend Agent delivers the ::frontendgen-layout macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::frontendgen-state": {
     "expansion": "Sets up state management (Context API or Redux) and data flow for components, ensuring unidirectional data and predictable updates.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Backend Agent",
+    "outcomes": [
+      "Backend Agent delivers the ::frontendgen-state macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::frontendgen-forms": {
     "expansion": "Creates form components with validation, error handling and user friendly UX guidelines.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Frontend Agent",
+    "outcomes": [
+      "Frontend Agent delivers the ::frontendgen-forms macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::frontendgen-access": {
     "expansion": "Performs accessibility audits including contrast ratio checks, ARIA attributes and keyboard navigation.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::frontendgen-access macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::frontendgen-motion": {
     "expansion": "Integrates Framer Motion to add subtle animations following motion grammar for natural interactions.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Frontend Agent",
+    "outcomes": [
+      "Frontend Agent delivers the ::frontendgen-motion macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::frontendgen-tests": {
     "expansion": "Generates front-end unit tests using React Testing Library with high coverage.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::frontendgen-tests macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::frontendgen-docs": {
     "expansion": "Produces UI documentation with Storybook or equivalent to showcase components and usage.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Knowledge Agent",
+    "outcomes": [
+      "Knowledge Agent delivers the ::frontendgen-docs macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::backendgen": {
     "expansion": "Creates a robust RESTful API scaffold using FastAPI (or chosen framework), including database connection, models and security primitives.",
@@ -50,39 +165,158 @@
       "::backendgen-logging",
       "::backendgen-tests",
       "::backendgen-docs"
+    ],
+    "ownerAgent": "Backend Agent",
+    "outcomes": [
+      "Backend Agent delivers the ::backendgen macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
     ]
   },
   "::backendgen-api": {
     "expansion": "Scaffolds CRUD endpoints with pagination and filtering on the chosen framework.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Backend Agent",
+    "outcomes": [
+      "Backend Agent delivers the ::backendgen-api macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::backendgen-auth": {
     "expansion": "Implements authentication and authorization mechanisms (JWT or OAuth2).",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Backend Agent",
+    "outcomes": [
+      "Backend Agent delivers the ::backendgen-auth macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::backendgen-models": {
     "expansion": "Defines ORM models and Pydantic schemas based on the database schema.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Backend Agent",
+    "outcomes": [
+      "Backend Agent delivers the ::backendgen-models macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::backendgen-security": {
     "expansion": "Adds security measures such as input sanitization, CSRF protection and rate limiting.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::backendgen-security macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::backendgen-migrations": {
     "expansion": "Creates database migration scripts to manage schema evolution (Alembic or equivalent).",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Backend Agent",
+    "outcomes": [
+      "Backend Agent delivers the ::backendgen-migrations macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::backendgen-logging": {
     "expansion": "Sets up structured logging and monitoring hooks to trace API behaviour and performance.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Backend Agent",
+    "outcomes": [
+      "Backend Agent delivers the ::backendgen-logging macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::backendgen-tests": {
     "expansion": "Generates API unit and integration tests to ensure endpoint correctness and error handling.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::backendgen-tests macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::backendgen-docs": {
     "expansion": "Auto-generates API documentation (OpenAPI/Swagger) and example usages.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Knowledge Agent",
+    "outcomes": [
+      "Knowledge Agent delivers the ::backendgen-docs macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::dbdesign": {
     "expansion": "Designs a database schema (relational or NoSQL) from business requirements.",
@@ -92,27 +326,106 @@
       "::dbdesign-index",
       "::dbdesign-seed",
       "::dbdesign-migrate"
+    ],
+    "ownerAgent": "Backend Agent",
+    "outcomes": [
+      "Backend Agent delivers the ::dbdesign macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
     ]
   },
   "::dbdesign-schema": {
     "expansion": "Produces entity–relationship diagrams and table/collection definitions with keys and constraints.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Backend Agent",
+    "outcomes": [
+      "Backend Agent delivers the ::dbdesign-schema macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::dbdesign-normalize": {
     "expansion": "Normalises the schema to third normal form while balancing denormalization for performance.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Backend Agent",
+    "outcomes": [
+      "Backend Agent delivers the ::dbdesign-normalize macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::dbdesign-index": {
     "expansion": "Suggests indexes and partitioning strategies to optimise query performance.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Frontend Agent",
+    "outcomes": [
+      "Frontend Agent delivers the ::dbdesign-index macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::dbdesign-seed": {
     "expansion": "Generates seed data aligned with schema definitions for development and testing.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::dbdesign-seed macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::dbdesign-migrate": {
     "expansion": "Writes migration scripts to evolve the database schema safely across versions.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Backend Agent",
+    "outcomes": [
+      "Backend Agent delivers the ::dbdesign-migrate macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::apidocgen": {
     "expansion": "Generates comprehensive API documentation including endpoints, request/response examples and error codes.",
@@ -121,23 +434,89 @@
       "::apidocgen-code",
       "::apidocgen-errors",
       "::apidocgen-tests"
+    ],
+    "ownerAgent": "Knowledge Agent",
+    "outcomes": [
+      "Knowledge Agent delivers the ::apidocgen macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
     ]
   },
   "::apidocgen-swagger": {
     "expansion": "Creates an OpenAPI/Swagger specification for the API.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Backend Agent",
+    "outcomes": [
+      "Backend Agent delivers the ::apidocgen-swagger macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::apidocgen-code": {
     "expansion": "Provides example code snippets (curl, Python, JS) demonstrating API usage.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Backend Agent",
+    "outcomes": [
+      "Backend Agent delivers the ::apidocgen-code macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::apidocgen-errors": {
     "expansion": "Documents standardised error codes and messages with causes and solutions.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::apidocgen-errors macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::apidocgen-tests": {
     "expansion": "Creates tests to validate that the API documentation matches the actual implementation.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::apidocgen-tests macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::testgen": {
     "expansion": "Constructs a suite of tests across units, integrations, end-to-end scenarios, coverage analysis and performance.",
@@ -148,31 +527,129 @@
       "::testgen-coverage",
       "::testgen-performance",
       "::testgen-security"
+    ],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::testgen macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
     ]
   },
   "::testgen-unit": {
     "expansion": "Generates unit tests for individual functions or modules, covering nominal and edge cases.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::testgen-unit macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::testgen-integration": {
     "expansion": "Produces integration tests to verify interactions between components and external services.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::testgen-integration macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::testgen-e2e": {
     "expansion": "Creates end-to-end tests with headless browsers or API calls to simulate real user flows.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::testgen-e2e macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::testgen-coverage": {
     "expansion": "Measures code coverage and identifies untested paths.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::testgen-coverage macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::testgen-performance": {
     "expansion": "Implements performance stress tests and benchmarks to assess throughput and latency.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::testgen-performance macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::testgen-security": {
     "expansion": "Creates security tests to check for vulnerabilities such as injection, authentication bypass and misconfigurations.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::testgen-security macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::cicdsetup": {
     "expansion": "Sets up continuous integration and deployment pipelines with linting, testing, building, deployment and monitoring stages.",
@@ -184,39 +661,160 @@
       "::cicd-monitor",
       "::cicd-notify",
       "::cicd-rollback"
+    ],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::cicdsetup macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
     ]
   },
   "::cicd-lint": {
     "expansion": "Runs linting tools (ESLint, PEP8, Prettier) and applies automatic fixes to formatting issues.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::cicd-lint macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::cicd-test": {
     "expansion": "Executes unit, integration and end-to-end tests during the pipeline.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::cicd-test macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::cicd-build": {
     "expansion": "Builds and bundles the application (e.g., Webpack/Vite bundling or Docker image creation).",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::cicd-build macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::cicd-deploy": {
     "expansion": "Deploys the application to the target environment (Docker, Render, Kubernetes) and performs environment configuration.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::cicd-deploy macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::cicd-monitor": {
     "expansion": "Monitors deployed applications with health checks and alerts to detect failures or performance degradations.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::cicd-monitor macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::cicd-notify": {
     "expansion": "Sends notifications (Slack, email) about pipeline status and deployment outcomes.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::cicd-notify macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::cicd-rollback": {
     "expansion": "Provides automated rollback procedures when deployments fail or regress.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::cicd-rollback macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::lintfix": {
     "expansion": "Applies linting and formatting rules to all project files and reports violations.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::lintfix macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::securityaudit": {
     "expansion": "Runs a comprehensive security audit, scanning source code, dependencies and configurations for vulnerabilities and ethics issues.",
@@ -228,35 +826,147 @@
       "::security-report",
       "::security-fairness",
       "::security-ethics"
+    ],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::securityaudit macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
     ]
   },
   "::security-static": {
     "expansion": "Performs static analysis (SAST) to detect vulnerabilities such as SQL injection or XSS.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::security-static macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::security-deps": {
     "expansion": "Scans dependencies for known CVEs and insecure versions.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::security-deps macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::security-injection": {
     "expansion": "Identifies injection vulnerabilities in code paths accepting external input.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::security-injection macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::security-authz": {
     "expansion": "Audits roles, permissions and secrets management for proper authorization enforcement.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::security-authz macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::security-report": {
     "expansion": "Generates a risk report with severity scores and remediation advice.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::security-report macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::security-fairness": {
     "expansion": "Assesses algorithmic bias and fairness metrics across demographic groups.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::security-fairness macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::security-ethics": {
     "expansion": "Evaluates ethical compliance including privacy, diversity and inclusion considerations.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::security-ethics macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::perfprofile": {
     "expansion": "Profiles code performance (CPU, memory, I/O, network) and recommends optimisations.",
@@ -266,27 +976,105 @@
       "::perf-io",
       "::perf-network",
       "::perf-benchmark"
+    ],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::perfprofile macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
     ]
   },
   "::perf-cpu": {
     "expansion": "Measures CPU usage and identifies hot spots in the code.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::perf-cpu macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::perf-memory": {
     "expansion": "Analyzes memory allocations and detects leaks.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::perf-memory macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::perf-io": {
     "expansion": "Profiles disk and network I/O patterns to detect bottlenecks.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::perf-io macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::perf-network": {
     "expansion": "Measures network latency, throughput and concurrency for API endpoints.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Backend Agent",
+    "outcomes": [
+      "Backend Agent delivers the ::perf-network macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::perf-benchmark": {
     "expansion": "Provides comparative benchmarks across different implementations or configurations.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::perf-benchmark macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::coderefactor": {
     "expansion": "Refactors code to improve maintainability and architecture using design patterns and modularisation.",
@@ -296,27 +1084,105 @@
       "::refactor-modular",
       "::refactor-complexity",
       "::refactor-docs"
+    ],
+    "ownerAgent": "Frontend Agent",
+    "outcomes": [
+      "Frontend Agent delivers the ::coderefactor macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
     ]
   },
   "::refactor-smells": {
     "expansion": "Detects and resolves code smells such as duplication, large methods and long parameter lists.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::refactor-smells macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::refactor-patterns": {
     "expansion": "Suggests design patterns and architecture improvements to enhance flexibility and extensibility.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Frontend Agent",
+    "outcomes": [
+      "Frontend Agent delivers the ::refactor-patterns macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::refactor-modular": {
     "expansion": "Splits monoliths into modular components and services.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::refactor-modular macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::refactor-complexity": {
     "expansion": "Reduces cyclomatic complexity by simplifying logic and improving cohesion.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::refactor-complexity macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::refactor-docs": {
     "expansion": "Updates docstrings and comments to reflect refactored code structure.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Knowledge Agent",
+    "outcomes": [
+      "Knowledge Agent delivers the ::refactor-docs macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::codequality": {
     "expansion": "Evaluates code readability, maintainability, architecture and adherence to standards.",
@@ -325,23 +1191,93 @@
       "::codequality-maintain",
       "::codequality-architecture",
       "::codequality-standards"
+    ],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::codequality macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
     ]
   },
   "::codequality-read": {
     "expansion": "Assesses variable naming, code clarity and documentation quality.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::codequality-read macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::codequality-maintain": {
     "expansion": "Identifies maintainability issues such as tight coupling and poor separation of concerns.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::codequality-maintain macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::codequality-architecture": {
     "expansion": "Evaluates overall architecture coherence and alignment with best practices.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::codequality-architecture macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::codequality-standards": {
     "expansion": "Ensures adherence to organisational coding standards and style guides.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::codequality-standards macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::typegen": {
     "expansion": "Generates type definitions and schemas (Pydantic, TypeScript, JSON Schema, Protobuf, ORM models) from data samples or schemas.",
@@ -351,27 +1287,105 @@
       "::typegen-jsonschema",
       "::typegen-proto",
       "::typegen-orm"
+    ],
+    "ownerAgent": "Backend Agent",
+    "outcomes": [
+      "Backend Agent delivers the ::typegen macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
     ]
   },
   "::typegen-pydantic": {
     "expansion": "Creates Pydantic models from JSON or Python dictionaries.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::typegen-pydantic macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::typegen-ts": {
     "expansion": "Generates TypeScript interfaces from API responses or schemas.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Backend Agent",
+    "outcomes": [
+      "Backend Agent delivers the ::typegen-ts macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::typegen-jsonschema": {
     "expansion": "Produces JSON Schema definitions for data validation and documentation.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Knowledge Agent",
+    "outcomes": [
+      "Knowledge Agent delivers the ::typegen-jsonschema macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::typegen-proto": {
     "expansion": "Creates Protocol Buffer definitions for gRPC services.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::typegen-proto macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::typegen-orm": {
     "expansion": "Generates ORM models (SQLAlchemy, TypeORM) based on schema definitions.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Backend Agent",
+    "outcomes": [
+      "Backend Agent delivers the ::typegen-orm macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::mockdata": {
     "expansion": "Generates realistic test data for development, testing and demonstration purposes.",
@@ -380,23 +1394,91 @@
       "::mockdata-distrib",
       "::mockdata-edge",
       "::mockdata-sensitive"
+    ],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::mockdata macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
     ]
   },
   "::mockdata-sample": {
     "expansion": "Creates standard dummy data consistent with given types and constraints.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::mockdata-sample macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::mockdata-distrib": {
     "expansion": "Samples data from statistical distributions to mimic real-world values.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::mockdata-distrib macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::mockdata-edge": {
     "expansion": "Produces edge-case data to test boundary conditions.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::mockdata-edge macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::mockdata-sensitive": {
     "expansion": "Generates anonymised versions of sensitive data to preserve privacy while testing.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::mockdata-sensitive macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::deployscript": {
     "expansion": "Creates deployment scripts and configuration for various environments (Docker, Kubernetes, Render).",
@@ -405,23 +1487,88 @@
       "::deploy-env",
       "::deploy-scaling",
       "::deploy-monitor"
+    ],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::deployscript macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
     ]
   },
   "::deploy-docker": {
     "expansion": "Generates Dockerfile and docker-compose configurations with best practices.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::deploy-docker macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::deploy-env": {
     "expansion": "Creates environment variable templates and secrets management guidelines.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::deploy-env macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::deploy-scaling": {
     "expansion": "Produces configuration for autoscaling clusters (Kubernetes, Render) with resource limits and health probes.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::deploy-scaling macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::deploy-monitor": {
     "expansion": "Integrates logging and monitoring agents for observability after deployment.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::deploy-monitor macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::uiuxaudit": {
     "expansion": "Conducts UI/UX audits covering colour harmony, typography, layout, motion and emotional resonance.",
@@ -431,27 +1578,106 @@
       "::uiux-layout",
       "::uiux-motion",
       "::uiux-emotion"
+    ],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::uiuxaudit macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
     ]
   },
   "::uiux-color": {
     "expansion": "Checks colour palettes for harmony and sufficient contrast ratios.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::uiux-color macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::uiux-typography": {
     "expansion": "Evaluates typography flow, font choices and legibility across devices.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::uiux-typography macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::uiux-layout": {
     "expansion": "Analyzes spatial rhythm, grid balance and alignment.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::uiux-layout macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::uiux-motion": {
     "expansion": "Assesses animation usage for naturalness, timing and context.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Frontend Agent",
+    "outcomes": [
+      "Frontend Agent delivers the ::uiux-motion macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::uiux-emotion": {
     "expansion": "Reviews emotional tone and resonance of the user interface.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Frontend Agent",
+    "outcomes": [
+      "Frontend Agent delivers the ::uiux-emotion macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::analyticsinject": {
     "expansion": "Inserts analytics instrumentation with probabilistic sampling for event tracking and performance metrics.",
@@ -460,23 +1686,89 @@
       "::analytics-performance",
       "::analytics-userflow",
       "::analytics-abtest"
+    ],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::analyticsinject macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
     ]
   },
   "::analytics-events": {
     "expansion": "Tracks page views, clicks and custom events across the application.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::analytics-events macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::analytics-performance": {
     "expansion": "Measures load times, rendering performance and resource usage for analytics.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::analytics-performance macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::analytics-userflow": {
     "expansion": "Collects funnel and conversion metrics to understand user behaviour.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::analytics-userflow macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::analytics-abtest": {
     "expansion": "Creates instrumentation for A/B testing of variants and features.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::analytics-abtest macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::erroranalysis": {
     "expansion": "Parses logs and diagnostics to identify root causes of errors and suggest fixes.",
@@ -486,27 +1778,106 @@
       "::error-fixsuggest",
       "::error-reproduce",
       "::error-report"
+    ],
+    "ownerAgent": "Knowledge Agent",
+    "outcomes": [
+      "Knowledge Agent delivers the ::erroranalysis macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
     ]
   },
   "::error-logparser": {
     "expansion": "Parses application logs and extracts error events, stack traces and context.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::error-logparser macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::error-rootcause": {
     "expansion": "Identifies the root cause of errors by analysing call stacks and dependencies.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::error-rootcause macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::error-fixsuggest": {
     "expansion": "Suggests code changes or configuration adjustments to fix identified issues.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::error-fixsuggest macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::error-reproduce": {
     "expansion": "Generates reproducible test cases to trigger the observed error.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::error-reproduce macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::error-report": {
     "expansion": "Summarizes the error analysis in a clear report for developers and stakeholders.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Knowledge Agent",
+    "outcomes": [
+      "Knowledge Agent delivers the ::error-report macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::integrationtest": {
     "expansion": "Builds automated integration test scripts for third-party APIs and services.",
@@ -515,23 +1886,93 @@
       "::integration-call",
       "::integration-validate",
       "::integration-teardown"
+    ],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::integrationtest macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
     ]
   },
   "::integration-setup": {
     "expansion": "Sets up the testing environment and any required test data for integration tests.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::integration-setup macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::integration-call": {
     "expansion": "Sends requests to APIs and services with various payloads during integration tests.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::integration-call macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::integration-validate": {
     "expansion": "Validates responses and side effects from integration tests against expected outcomes.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::integration-validate macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::integration-teardown": {
     "expansion": "Cleans up the environment after integration tests are executed.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::integration-teardown macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::fulldeveloper": {
     "expansion": "Orchestrates the rapid creation of an end-to-end prototype by combining front-end, back-end, database, testing and deployment tasks.",
@@ -540,36 +1981,204 @@
       "::prototype-tests",
       "::prototype-deploy",
       "::prototype-docs"
+    ],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::fulldeveloper macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
     ]
   },
   "::prototype-scaffold": {
     "expansion": "Quickly builds a working UI, API and database skeleton for prototyping.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Backend Agent",
+    "outcomes": [
+      "Backend Agent delivers the ::prototype-scaffold macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::prototype-tests": {
     "expansion": "Sets up a minimal testing harness for the prototype to ensure basic functionality.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::prototype-tests macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::prototype-deploy": {
     "expansion": "Packages the prototype for deployment, creating necessary scripts and configuration.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::prototype-deploy macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::prototype-docs": {
     "expansion": "Generates basic documentation describing the prototype’s architecture and usage.",
-    "calls": []
+    "calls": [],
+    "ownerAgent": "Knowledge Agent",
+    "outcomes": [
+      "Knowledge Agent delivers the ::prototype-docs macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
+    ]
   },
   "::frontendsuite": {
-    "expansion": "Executes all front-end related macros including layout, state, forms, access, motion, tests and docs.",
+    "expansion": "Executes the front-end scaffold and coordinates QA alignment for the resulting assets.",
     "calls": [
       "::frontendgen",
-      "::frontendgen-layout",
-      "::frontendgen-state",
-      "::frontendgen-forms",
-      "::frontendgen-access",
-      "::frontendgen-motion",
-      "::frontendgen-tests",
-      "::frontendgen-docs"
-    ]
+      "::qa-agent-md-integration"
+    ],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::frontendsuite macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
+    ],
+    "phase": "qa",
+    "priority": "P0",
+    "status": "ready",
+    "estimatedDuration": "3h",
+    "tags": [
+      "frontend",
+      "qa",
+      "integration"
+    ],
+    "version": "1.0.1"
+  },
+  "::qa-agent-md-integration": {
+    "expansion": "Maps macro outcomes to QA Agent MD assertions, establishing measurable checkpoints and reporting cadence.",
+    "calls": [],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent MD receives structured checkpoints with measurable signals.",
+      "Macro outcomes align with automated QA scorecards."
+    ],
+    "acceptanceCriteria": [
+      "Every referenced outcome includes at least one measurable assertion.",
+      "QA hooks enumerate trigger identifiers for automation."
+    ],
+    "qaHooks": [
+      "qa::calibrate",
+      "qa::score",
+      "qa::report"
+    ],
+    "phase": "qa",
+    "priority": "P0",
+    "status": "in-progress",
+    "estimatedDuration": "2h",
+    "tags": [
+      "qa",
+      "integration"
+    ],
+    "version": "1.0.0"
+  },
+  "::meta-agent-orchestration": {
+    "expansion": "Defines scheduling phases, dependencies, and communication cadences for the Meta Agent to coordinate.",
+    "calls": [],
+    "ownerAgent": "Meta Agent",
+    "outcomes": [
+      "Meta Agent can generate a sequenced orchestration timeline with explicit phase markers.",
+      "Dependencies between macro deliverables are encoded for conflict avoidance."
+    ],
+    "acceptanceCriteria": [
+      "Each macro dependency includes a status gate and expected duration.",
+      "A communication cadence is documented for cross-agent sync."
+    ],
+    "qaHooks": [
+      "meta::sync",
+      "meta::timeline"
+    ],
+    "phase": "orchestration",
+    "priority": "P1",
+    "status": "planned",
+    "estimatedDuration": "90m",
+    "tags": [
+      "meta",
+      "scheduling"
+    ],
+    "version": "1.0.0"
+  },
+  "::agent-integration-suite": {
+    "expansion": "Synchronises QA Agent MD calibration with Meta Agent orchestration to provide integration-ready outputs.",
+    "calls": [
+      "::qa-agent-md-integration",
+      "::meta-agent-orchestration"
+    ],
+    "ownerAgent": "Meta Agent",
+    "outcomes": [
+      "QA and Meta agents collaborate on a single, deduplicated execution record.",
+      "Integration tasks expose metrics, owners, and dependency chains for automation."
+    ],
+    "acceptanceCriteria": [
+      "QA deliverables reference the same identifiers surfaced in the Meta manifest.",
+      "Meta Agent receives priority and status metadata from each contributing macro."
+    ],
+    "qaHooks": [
+      "meta::sync",
+      "qa::handoff"
+    ],
+    "phase": "integration",
+    "priority": "P0",
+    "status": "ready",
+    "estimatedDuration": "2h",
+    "tags": [
+      "integration",
+      "meta",
+      "qa"
+    ],
+    "version": "1.0.0"
   },
   "::backendsuite": {
     "expansion": "Runs back-end scaffolding, DB design and API documentation macros.",
@@ -577,6 +2186,19 @@
       "::backendgen",
       "::dbdesign",
       "::apidocgen"
+    ],
+    "ownerAgent": "Backend Agent",
+    "outcomes": [
+      "Backend Agent delivers the ::backendsuite macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
     ]
   },
   "::testsuite": {
@@ -585,6 +2207,20 @@
       "::testgen",
       "::integrationtest",
       "::erroranalysis"
+    ],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::testsuite macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
     ]
   },
   "::cicdsuite": {
@@ -593,12 +2229,40 @@
       "::cicdsetup",
       "::securityaudit",
       "::perfprofile"
+    ],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::cicdsuite macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
     ]
   },
   "::securesuite": {
     "expansion": "Combines security analysis, fairness and ethical review macros.",
     "calls": [
       "::securityaudit"
+    ],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::securesuite macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
     ]
   },
   "::optimizsuite": {
@@ -607,12 +2271,39 @@
       "::perfprofile",
       "::coderefactor",
       "::codequality"
+    ],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::optimizsuite macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
     ]
   },
   "::deploysuite": {
     "expansion": "Generates deployment scripts and configures scaling and monitoring.",
     "calls": [
       "::deployscript"
+    ],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::deploysuite macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
     ]
   },
   "::datasuite": {
@@ -620,6 +2311,19 @@
     "calls": [
       "::typegen",
       "::mockdata"
+    ],
+    "ownerAgent": "Backend Agent",
+    "outcomes": [
+      "Backend Agent delivers the ::datasuite macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
     ]
   },
   "::uxsuite": {
@@ -627,6 +2331,19 @@
     "calls": [
       "::uiuxaudit",
       "::analyticsinject"
+    ],
+    "ownerAgent": "Frontend Agent",
+    "outcomes": [
+      "Frontend Agent delivers the ::uxsuite macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
     ]
   },
   "::fullstacksuite": {
@@ -636,7 +2353,22 @@
       "::backendsuite",
       "::testsuite",
       "::cicdsuite",
-      "::deploysuite"
+      "::deploysuite",
+      "::agent-integration-suite"
+    ],
+    "ownerAgent": "QA Agent",
+    "outcomes": [
+      "QA Agent delivers the ::fullstacksuite macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::execute",
+      "qa::review",
+      "qa::report"
     ]
   },
   "::masterdev": {
@@ -647,6 +2379,19 @@
       "::securesuite",
       "::optimizsuite",
       "::uxsuite"
+    ],
+    "ownerAgent": "Architect Agent",
+    "outcomes": [
+      "Architect Agent delivers the ::masterdev macro with actionable guidance.",
+      "Outputs are structured for downstream agent consumption."
+    ],
+    "acceptanceCriteria": [
+      "All dependencies expand without errors and metadata fields are populated.",
+      "QA Agent MD can identify the accountable owner for this macro step."
+    ],
+    "qaHooks": [
+      "qa::review",
+      "qa::report"
     ]
   }
 }

--- a/macro_system/migrations/__init__.py
+++ b/macro_system/migrations/__init__.py
@@ -1,0 +1,3 @@
+"""Migration utilities for evolving macro definitions."""
+
+__all__ = []

--- a/macro_system/migrations/add_agent_metadata.py
+++ b/macro_system/migrations/add_agent_metadata.py
@@ -1,0 +1,265 @@
+"""Add agent metadata fields to legacy macro definitions.
+
+Header & Purpose:
+    Provides a command-line migration that enriches ``macros.json`` entries with
+    agent-aware metadata required for QA/Meta coordination.
+
+Imports/Dependencies:
+    * json for parsing and serialising macro definitions.
+    * pathlib.Path for filesystem access.
+    * typing for type annotations.
+
+Types/Interfaces/Schemas:
+    No custom types are introduced; the migration operates on ``dict`` objects
+    containing macro payloads.
+
+Core Logic/Implementation:
+    ``migrate_file`` reads the macros file, adds metadata when absent, and writes
+    back an ordered representation that maintains deterministic formatting.
+
+Error & Edge Handling:
+    The migration validates file existence and tolerates previously migrated
+    macros by leaving explicit metadata untouched.
+
+Performance Considerations:
+    The dataset is small (O(number of macros)), so a straightforward iteration is
+    sufficient.
+
+Exports/Public API:
+    ``migrate_file`` and ``main`` for programmatic and CLI usage respectively.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Dict, Iterable, Mapping, MutableMapping
+
+# === Constants ===
+
+_AGENT_KEYWORDS: Mapping[str, Iterable[str]] = {
+    "QA Agent": (
+        "qa",
+        "test",
+        "lint",
+        "quality",
+        "security",
+        "access",
+        "audit",
+    ),
+    "Meta Agent": (
+        "meta",
+        "orchestr",
+        "plan",
+        "coord",
+        "governance",
+    ),
+    "Knowledge Agent": (
+        "knowledge",
+        "research",
+        "docs",
+        "documentation",
+        "brief",
+        "analysis",
+    ),
+    "Backend Agent": (
+        "backend",
+        "api",
+        "database",
+        "schema",
+        "fastapi",
+        "server",
+    ),
+    "Frontend Agent": (
+        "frontend",
+        "ui",
+        "ux",
+        "react",
+        "design",
+        "motion",
+        "tailwind",
+    ),
+    "Architect Agent": (
+        "arch",
+        "strategy",
+        "master",
+        "system",
+    ),
+}
+
+_AGENT_PRIORITY: Mapping[str, int] = {
+    "QA Agent": 0,
+    "Meta Agent": 1,
+    "Knowledge Agent": 2,
+    "Backend Agent": 3,
+    "Frontend Agent": 4,
+    "Architect Agent": 5,
+}
+
+_DEFAULT_ACCEPTANCE: Iterable[str] = (
+    "All dependencies expand without errors and metadata fields are populated.",
+    "QA Agent MD can identify the accountable owner for this macro step.",
+)
+
+_DEFAULT_QA_HOOKS: Iterable[str] = (
+    "qa::review",
+    "qa::report",
+)
+
+# === Helpers ===
+
+
+def infer_owner(name: str, expansion: str) -> str:
+    """Infer an owner agent using heuristic keyword matching."""
+
+    normalised_name = name.lower()
+    if any(token in normalised_name for token in ("::qa", "qa", "test", "access", "audit", "security")):
+        return "QA Agent"
+
+    haystack = f"{name} {expansion}".lower()
+    tokens = set(re.findall(r"[a-z]+", haystack))
+    best_agent = "Architect Agent"
+    best_score = 0
+
+    for agent, keywords in _AGENT_KEYWORDS.items():
+        score = 0
+        for keyword in keywords:
+            keyword = keyword.lower()
+            if len(keyword) <= 3:
+                if keyword in tokens:
+                    score += 1
+            elif keyword in haystack:
+                score += 1
+        if score and (score > best_score or (
+            score == best_score
+            and _AGENT_PRIORITY.get(agent, 99) < _AGENT_PRIORITY.get(best_agent, 99)
+        )):
+            best_agent = agent
+            best_score = score
+
+    return best_agent
+
+
+def _default_outcomes(owner: str, name: str) -> list[str]:
+    """Return the default outcomes payload."""
+
+    return [
+        f"{owner} delivers the {name} macro with actionable guidance.",
+        "Outputs are structured for downstream agent consumption.",
+    ]
+
+
+def _looks_like_default_outcomes(values: object) -> bool:
+    """Return True when the supplied outcomes match the default template."""
+
+    if not isinstance(values, list) or len(values) != 2:
+        return False
+    first, second = values
+    return (
+        isinstance(first, str)
+        and "macro with actionable guidance" in first
+        and isinstance(second, str)
+        and second.strip() == "Outputs are structured for downstream agent consumption."
+    )
+
+
+def ensure_metadata(payload: MutableMapping[str, object]) -> None:
+    """Populate ownerAgent/outcomes/acceptanceCriteria/qaHooks fields."""
+
+    expansion = str(payload.get("expansion", ""))
+    name = str(payload.get("name", "")) or "::unknown"
+
+    payload["ownerAgent"] = infer_owner(name, expansion)
+    owner = payload["ownerAgent"]
+    outcomes = payload.get("outcomes")
+    if not isinstance(outcomes, list) or not outcomes or _looks_like_default_outcomes(outcomes):
+        payload["outcomes"] = _default_outcomes(owner, name)
+    else:
+        payload["outcomes"] = list(outcomes)
+
+    acceptance = payload.get("acceptanceCriteria")
+    if not isinstance(acceptance, list) or not acceptance:
+        payload["acceptanceCriteria"] = list(_DEFAULT_ACCEPTANCE)
+    else:
+        payload["acceptanceCriteria"] = list(acceptance)
+
+    qa_hooks = payload.get("qaHooks")
+    if not isinstance(qa_hooks, list) or not qa_hooks:
+        hooks = list(_DEFAULT_QA_HOOKS)
+    else:
+        hooks = list(dict.fromkeys(qa_hooks))
+
+    if payload["ownerAgent"] == "QA Agent" and "qa::execute" not in hooks:
+        hooks.insert(0, "qa::execute")
+
+    payload["qaHooks"] = hooks
+
+
+
+def reorder_payload(payload: MutableMapping[str, object]) -> Dict[str, object]:
+    """Return a new payload dict with deterministic key ordering."""
+
+    ordered: Dict[str, object] = {
+        "expansion": payload["expansion"],
+        "calls": payload.get("calls", []),
+        "ownerAgent": payload.get("ownerAgent"),
+        "outcomes": payload.get("outcomes", []),
+        "acceptanceCriteria": payload.get("acceptanceCriteria", []),
+        "qaHooks": payload.get("qaHooks", []),
+    }
+    return ordered
+
+
+# === Core Migration Logic ===
+
+
+def migrate_file(path: Path) -> None:
+    """Apply metadata enrichment to ``path`` in-place."""
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    updated: Dict[str, Dict[str, object]] = {}
+
+    for name, payload in data.items():
+        if not isinstance(payload, dict):
+            raise ValueError(f"Macro '{name}' must be defined as an object.")
+        payload = dict(payload)
+        payload.setdefault("name", name)
+        ensure_metadata(payload)
+        ordered = reorder_payload(payload)
+        updated[name] = ordered
+
+    path.write_text(json.dumps(updated, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+# === CLI Support ===
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Construct an argument parser for the migration script."""
+
+    parser = argparse.ArgumentParser(
+        description="Add agent metadata to macro definitions.",
+    )
+    parser.add_argument(
+        "path",
+        type=Path,
+        nargs="?",
+        default=Path("macro_system/macros.json"),
+        help="Path to the macros.json file to migrate.",
+    )
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    """Entry point for command-line usage."""
+
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    migrate_file(args.path)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - script execution guard
+    raise SystemExit(main())

--- a/macro_system/planner.py
+++ b/macro_system/planner.py
@@ -44,7 +44,21 @@ class MacroPlanner:
         children = [self._build_recursive(child, stack) for child in macro.calls]
         stack.pop()
 
-        return PlanStep(macro=name, description=macro.expansion, children=children)
+        return PlanStep(
+            macro=name,
+            description=macro.expansion,
+            owner_agent=macro.owner_agent,
+            outcomes=macro.outcomes,
+            acceptance_criteria=macro.acceptance_criteria,
+            qa_hooks=macro.qa_hooks,
+            phase=macro.phase,
+            priority=macro.priority,
+            status=macro.status,
+            estimated_duration=macro.estimated_duration,
+            tags=macro.tags,
+            version=macro.version,
+            children=children,
+        )
 
 
 # === Exports ===

--- a/macro_system/reports.py
+++ b/macro_system/reports.py
@@ -1,0 +1,169 @@
+"""Analytical helpers for auditing macro metadata coverage and readiness.
+
+Header & Purpose:
+    Provide utilities that inspect loaded macros to surface gaps ahead of QA/Meta
+    Agent integrations.
+
+Imports/Dependencies:
+    * collections for counting ownership coverage.
+    * dataclasses for structured reporting objects.
+    * typing for type hints across the public API.
+
+Types/Interfaces/Schemas:
+    ``AgentCoverage`` summarises how many macros each agent owns.
+    ``MetadataGaps`` lists macros lacking the metadata required by downstream
+    agents.
+    ``MacroReview`` composes the overall diagnostic payload returned to callers.
+
+Core Logic/Implementation:
+    ``generate_macro_review`` walks every macro, compiles coverage statistics,
+    and returns actionable suggestions.
+
+Error & Edge Handling:
+    The helpers tolerate missing metadata by classifying those macros under
+    "Unassigned" ownership and flagging them in the resulting report.
+
+Performance Considerations:
+    The operations are O(number of macros) and operate entirely in memory,
+    which remains efficient for the current catalogue size.
+
+Exports/Public API:
+    ``generate_macro_review`` for consumers that need an actionable summary of
+    the macro catalogue before orchestration.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import Iterable, List, Mapping
+
+from .types import Macro
+
+# === Types ===
+
+
+@dataclass(frozen=True)
+class AgentCoverage:
+    """Number of macros owned by each agent."""
+
+    total_macros: int
+    per_agent: Mapping[str, int]
+
+
+@dataclass(frozen=True)
+class MetadataGaps:
+    """Lists of macros missing critical metadata."""
+
+    unassigned: List[str]
+    missing_outcomes: List[str]
+    missing_acceptance: List[str]
+    missing_qa_hooks: List[str]
+    default_outcomes: List[str]
+
+
+@dataclass(frozen=True)
+class MacroReview:
+    """Structured review payload consumed by CLI and tests."""
+
+    coverage: AgentCoverage
+    gaps: MetadataGaps
+    recommendations: List[str]
+
+
+# === Implementation ===
+
+
+def generate_macro_review(macros: Mapping[str, Macro]) -> MacroReview:
+    """Inspect ``macros`` and return coverage statistics plus recommendations."""
+
+    total = len(macros)
+    ownership_counter: Counter[str] = Counter()
+    unassigned: List[str] = []
+    missing_outcomes: List[str] = []
+    missing_acceptance: List[str] = []
+    missing_qa_hooks: List[str] = []
+    default_outcomes: List[str] = []
+
+    for name, macro in macros.items():
+        owner = macro.owner_agent or "Unassigned"
+        ownership_counter[owner] += 1
+        if macro.owner_agent is None:
+            unassigned.append(name)
+        if not macro.outcomes:
+            missing_outcomes.append(name)
+        elif _looks_like_default_outcome(macro.outcomes):
+            default_outcomes.append(name)
+        if not macro.acceptance_criteria:
+            missing_acceptance.append(name)
+        if not macro.qa_hooks:
+            missing_qa_hooks.append(name)
+
+    coverage = AgentCoverage(total_macros=total, per_agent=dict(sorted(ownership_counter.items())))
+    gaps = MetadataGaps(
+        unassigned=sorted(unassigned),
+        missing_outcomes=sorted(missing_outcomes),
+        missing_acceptance=sorted(missing_acceptance),
+        missing_qa_hooks=sorted(missing_qa_hooks),
+        default_outcomes=sorted(default_outcomes),
+    )
+    recommendations = _build_recommendations(coverage, gaps)
+
+    return MacroReview(coverage=coverage, gaps=gaps, recommendations=recommendations)
+
+
+# === Helper Functions ===
+
+
+_DEFAULT_OUTCOME_MARKER = "Outputs are structured for downstream agent consumption."
+
+
+def _looks_like_default_outcome(values: Iterable[str]) -> bool:
+    """Return True if ``values`` are identical to the default migration payload."""
+
+    values = list(values)
+    if len(values) != 2:
+        return False
+    first, second = values
+    return (
+        isinstance(first, str)
+        and "macro with actionable guidance" in first
+        and isinstance(second, str)
+        and second.strip() == _DEFAULT_OUTCOME_MARKER
+    )
+
+
+def _build_recommendations(coverage: AgentCoverage, gaps: MetadataGaps) -> List[str]:
+    """Generate actionable follow-ups based on coverage and metadata gaps."""
+
+    actions: List[str] = []
+
+    if gaps.unassigned:
+        actions.append(
+            "Assign owner agents to all macros so Meta Agent can orchestrate hand-offs."
+        )
+    if gaps.missing_outcomes:
+        actions.append(
+            "Author macro-specific outcomes describing measurable deliverables."
+        )
+    if gaps.missing_acceptance:
+        actions.append(
+            "Provide acceptance criteria so QA Agent MD can score each macro."
+        )
+    if gaps.missing_qa_hooks:
+        actions.append(
+            "Attach qaHooks for every macro to wire automation entry points."
+        )
+    if gaps.default_outcomes:
+        actions.append(
+            "Replace default migration outcomes with detailed, agent-owned results."
+        )
+    if not actions:
+        actions.append("Metadata coverage complete — proceed with QA/Meta integration.")
+
+    return actions
+
+
+# === Exports ===
+
+__all__ = ["AgentCoverage", "MetadataGaps", "MacroReview", "generate_macro_review"]

--- a/macro_system/schema.py
+++ b/macro_system/schema.py
@@ -1,0 +1,97 @@
+"""JSON Schema utilities for validating macro catalogues."""
+
+# === Imports ===
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Dict, Mapping
+
+from .types import MacroDefinitionError
+
+# === Types ===
+
+MacroSchema = Dict[str, object]
+
+
+# === Core Logic ===
+
+_SCHEMA: MacroSchema = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://codexhub.dev/schemas/macro-system.json",
+    "title": "Macro System Catalogue",
+    "type": "object",
+    "additionalProperties": False,
+    "patternProperties": {
+        "^::[a-zA-Z0-9-]+$": {
+            "type": "object",
+            "required": ["expansion"],
+            "additionalProperties": False,
+            "properties": {
+                "expansion": {"type": "string", "minLength": 1},
+                "calls": {
+                    "type": "array",
+                    "items": {"type": "string", "pattern": "^::[a-zA-Z0-9-]+$"},
+                    "default": [],
+                },
+                "ownerAgent": {"type": "string"},
+                "outcomes": {"type": "array", "items": {"type": "string"}},
+                "acceptanceCriteria": {"type": "array", "items": {"type": "string"}},
+                "qaHooks": {"type": "array", "items": {"type": "string"}},
+                "phase": {"type": "string"},
+                "priority": {"type": "string"},
+                "status": {"type": "string"},
+                "estimatedDuration": {"type": "string"},
+                "tags": {"type": "array", "items": {"type": "string"}},
+                "version": {"type": "string"},
+            },
+        }
+    },
+}
+
+_ALLOWED_FIELDS = {
+    "expansion",
+    "calls",
+    "ownerAgent",
+    "outcomes",
+    "acceptanceCriteria",
+    "qaHooks",
+    "phase",
+    "priority",
+    "status",
+    "estimatedDuration",
+    "tags",
+    "version",
+}
+
+
+def macro_schema() -> MacroSchema:
+    """Return a copy of the macro JSON schema."""
+
+    return deepcopy(_SCHEMA)
+
+
+def validate_macro_catalog(payload: Mapping[str, object]) -> None:
+    """Perform lightweight schema validation for a macro catalogue."""
+
+    if not isinstance(payload, Mapping):
+        raise MacroDefinitionError("Macro catalogue must be an object.")
+
+    for name, body in payload.items():
+        if not isinstance(name, str) or not name.startswith("::"):
+            raise MacroDefinitionError("Macro names must be strings prefixed with '::'.")
+
+        if not isinstance(body, Mapping):
+            raise MacroDefinitionError(f"Macro '{name}' must be defined as an object.")
+
+        if "expansion" not in body:
+            raise MacroDefinitionError(f"Macro '{name}' must include an expansion field.")
+
+        unexpected = set(body) - _ALLOWED_FIELDS
+        if unexpected:
+            raise MacroDefinitionError(
+                f"Macro '{name}' includes unsupported fields: {sorted(unexpected)}"
+            )
+
+
+# === Exports ===
+__all__ = ["macro_schema", "validate_macro_catalog"]

--- a/macro_system/tests/test_macros.py
+++ b/macro_system/tests/test_macros.py
@@ -3,6 +3,7 @@
 # === Imports ===
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -10,6 +11,7 @@ import pytest
 from macro_system.cli import main as cli_main
 from macro_system.engine import MacroEngine
 from macro_system.macros import load_macros
+from macro_system.reports import generate_macro_review
 from macro_system.types import Macro, MacroCycleError, MacroNotFoundError
 
 # === Tests ===
@@ -27,6 +29,21 @@ def test_frontend_macro_expansion_includes_dependencies():
     assert "Generates a full front-end scaffold" in expansion
     assert "Designs grid layouts" in expansion
     assert "Generates front-end unit tests" in expansion
+
+
+def test_macro_metadata_is_loaded():
+    macros = load_macros(Path("macro_system/macros.json"))
+    frontend = macros["::frontendgen"]
+    assert frontend.owner_agent == "Frontend Agent"
+    assert "Outputs are structured" in frontend.outcomes[1]
+    assert "QA Agent MD" in frontend.acceptance_criteria[1]
+    assert "qa::review" in frontend.qa_hooks
+    assert frontend.phase == "build"
+    assert frontend.priority == "P1"
+    assert frontend.status == "planned"
+    assert frontend.estimated_duration == "8h"
+    assert "scaffold" in frontend.tags
+    assert frontend.version == "1.1.0"
 
 
 def test_missing_macro_reference_raises():
@@ -77,5 +94,117 @@ def test_cli_plan_command_outputs_outline(capsys):
     exit_code = cli_main(["--plan", "::frontendgen"])
     assert exit_code == 0
     captured = capsys.readouterr()
-    assert "::frontendgen" in captured.out
+    assert "::frontendgen [Frontend Agent] <P1> (planned)" in captured.out
     assert "::frontendgen-tests" in captured.out
+
+
+def test_cli_exports_qa_checklist(capsys):
+    exit_code = cli_main(["--qa-checklist", "::frontendgen"])
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert any(item["macro"] == "::frontendgen-tests" for item in payload)
+    root_entry = next(item for item in payload if item["macro"] == "::frontendgen")
+    assert root_entry["priority"] == "P1"
+    assert root_entry["status"] == "planned"
+
+
+def test_cli_exports_meta_manifest(capsys):
+    exit_code = cli_main(["--meta-manifest", "::frontendgen"])
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["root"] == "::frontendgen"
+    tests_entry = next(
+        item for item in payload["tasks"] if item["macro"] == "::frontendgen-tests"
+    )
+    assert tests_entry["dependsOn"] == ["::frontendgen"]
+    root_task = next(
+        item for item in payload["tasks"] if item["macro"] == "::frontendgen"
+    )
+    assert root_task["priority"] == "P1"
+    assert root_task["status"] == "planned"
+
+
+def test_cli_report_outputs_review(capsys):
+    exit_code = cli_main(["--report"])
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["totalMacros"] >= 80
+    assert "agentCoverage" in payload
+    assert "recommendations" in payload
+
+
+def test_generate_macro_review_detects_gaps():
+    macros = {
+        "::a": Macro(name="::a", expansion="A", calls=[], owner_agent=None),
+        "::b": Macro(
+            name="::b",
+            expansion="B",
+            calls=[],
+            owner_agent="Frontend Agent",
+            outcomes=[
+                "Frontend Agent delivers the ::b macro with actionable guidance.",
+                "Outputs are structured for downstream agent consumption.",
+            ],
+            acceptance_criteria=[],
+            qa_hooks=[],
+        ),
+    }
+
+    review = generate_macro_review(macros)
+
+    assert review.coverage.total_macros == 2
+    assert review.gaps.unassigned == ["::a"]
+    assert review.gaps.missing_acceptance == ["::a", "::b"]
+    assert review.gaps.missing_qa_hooks == ["::a", "::b"]
+    assert review.gaps.default_outcomes == ["::b"]
+    assert review.recommendations  # ensure at least one action exists
+
+
+def test_cli_exports_schema(capsys):
+    exit_code = cli_main(["--export-schema"])
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    schema = json.loads(captured.out)
+    assert schema["$schema"].startswith("https://json-schema.org")
+    assert "patternProperties" in schema
+
+
+def test_engine_cache_and_listeners():
+    engine = MacroEngine.from_json(Path("macro_system/macros.json"))
+    engine.invalidate_cache()
+    assert engine.cache_size() == 0
+
+    events: list[str] = []
+
+    def _listener(name: str, expansion: str) -> None:
+        events.append(name)
+
+    engine.register_listener(_listener)
+    engine.expand("::frontendsuite")
+
+    assert "::frontendsuite" in events
+    cached_size = engine.cache_size()
+    assert cached_size >= 1
+
+    events.clear()
+    engine.expand("::frontendsuite")
+    assert events == []  # expansion served from cache
+    assert engine.cache_size() == cached_size
+
+    engine.invalidate_cache()
+    assert engine.cache_size() == 0
+
+
+def test_frontendsuite_calls_are_deduplicated():
+    macros = load_macros(Path("macro_system/macros.json"))
+    frontendsuite = macros["::frontendsuite"]
+    assert frontendsuite.calls == ["::frontendgen", "::qa-agent-md-integration"]
+
+
+def test_fullstacksuite_includes_integration_suite():
+    macros = load_macros(Path("macro_system/macros.json"))
+    fullstack = macros["::fullstacksuite"]
+    assert "::agent-integration-suite" in fullstack.calls


### PR DESCRIPTION
## Summary
- add a JSON schema module and expose it through the CLI so downstream agents can validate macro catalogues
- extend macro metadata (phase, priority, status, duration, tags, version) through the engine, planner, and CLI outputs
- enrich macros with QA/Meta integration suites, deduplicate frontend suites, and document caching and schema workflows
- expand automated coverage for caching behaviour, schema export, and new metadata surfaces

## Testing
- pytest macro_system

------
https://chatgpt.com/codex/tasks/task_e_68d293f6e900832193817f86751ffad5