### PR TITLE
Enhance QA evaluations and macro integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 logs/
 .env
 dist/
+__pycache__/

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,15 @@
+"""
+SECTION: Header & Purpose
+    - Aggregates agent-facing utilities for consumers of the QA framework.
+
+SECTION: Imports / Dependencies
+    - Provides convenient imports for the base agent class and meta agent implementation.
+
+SECTION: Exports / Public API
+    - ``Agent`` and ``MetaAgent`` classes.
+"""
+
+from .agent_base import Agent, AgentTaskError
+from .meta_agent import MetaAgent
+
+__all__ = ["Agent", "AgentTaskError", "MetaAgent"]

--- a/agents/agent_base.py
+++ b/agents/agent_base.py
@@ -1,0 +1,108 @@
+"""
+SECTION: Header & Purpose
+    - Defines an abstract ``Agent`` base class that encapsulates QA enforcement behaviour for agent workflows.
+    - Provides integration hooks for the shared ``QAEngine`` and ``QAEventBus`` components.
+    - Normalises reported QA metrics, enforces execution of mandatory regression tests, captures task exceptions,
+      and forwards severity/untracked-metric insights to orchestrators.
+
+SECTION: Imports / Dependencies
+    - Imports typing helpers alongside the shared QA modules.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Sequence
+
+from qa.qa_engine import QAEvaluation, QAEngine
+from qa.qa_event_bus import QAEventBus
+
+
+class AgentTaskError(RuntimeError):
+    """Exception raised when ``perform_task`` fails; carries the QA evaluation context."""
+
+    def __init__(self, agent: str, original: BaseException, evaluation: QAEvaluation) -> None:
+        message = f"Agent '{agent}' task execution failed: {original}"
+        super().__init__(message)
+        self.agent = agent
+        self.original = original
+        self.evaluation = evaluation
+
+
+class Agent:
+    """Abstract base class representing an autonomous agent participating in QA governance."""
+
+    def __init__(self, name: str, qa_engine: QAEngine, event_bus: QAEventBus) -> None:
+        self.name = name
+        self.qa_engine = qa_engine
+        self.event_bus = event_bus
+
+    def perform_task(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+        """Execute the agent-specific task and return a dictionary of resulting metrics/data."""
+
+        raise NotImplementedError("Subclasses must implement perform_task")
+
+    def run_with_qa(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+        """Run ``perform_task`` and automatically evaluate the output against QA budgets."""
+
+        try:
+            result = self.perform_task(*args, **kwargs)
+        except Exception as exc:  # noqa: BLE001 - intentional broad catch for QA recording
+            evaluation = self.qa_engine.assess_exception(self.name, exc)
+            payload = evaluation.to_event_payload()
+            if not payload.get("error"):
+                payload["error"] = {"type": exc.__class__.__name__, "message": str(exc)}
+            self.event_bus.publish("qa_failure", payload)
+            raise AgentTaskError(self.name, exc, evaluation) from exc
+
+        if not isinstance(result, dict):
+            raise TypeError("Agent perform_task must return a dictionary of metrics and data")
+
+        tests_executed: Optional[Sequence[str]] = None
+        if "tests_executed" in result:
+            tests_value = result["tests_executed"]
+            if tests_value is None:
+                tests_executed = None
+            elif isinstance(tests_value, Sequence) and not isinstance(tests_value, (str, bytes)):
+                tests_executed = [str(test) for test in tests_value]
+            else:
+                raise TypeError(
+                    "tests_executed must be an iterable of test identifiers when provided"
+                )
+
+        evaluation = self.qa_engine.assess_task_result(
+            self.name, dict(result), tests_executed=tests_executed
+        )
+
+        event_type = "qa_success" if evaluation.passed else "qa_failure"
+        self.event_bus.publish(event_type, evaluation.to_event_payload())
+
+        if evaluation.violations:
+            result.setdefault("qa_failures", []).extend(evaluation.violations)
+        if evaluation.missing_tests:
+            result.setdefault("qa_missing_tests", []).extend(evaluation.missing_tests)
+        if evaluation.remediation_macros:
+            existing_macros = result.setdefault("qa_recommended_macros", [])
+            for macro in evaluation.remediation_macros:
+                if macro not in existing_macros:
+                    existing_macros.append(macro)
+        if evaluation.metric_violations:
+            result["qa_metric_violations"] = [
+                violation.to_dict() for violation in evaluation.metric_violations
+            ]
+        if evaluation.untracked_metrics:
+            untracked = result.setdefault("qa_untracked_metrics", [])
+            for metric in evaluation.untracked_metrics:
+                if metric not in untracked:
+                    untracked.append(metric)
+        if evaluation.tests_executed:
+            result["qa_tests_executed"] = list(evaluation.tests_executed)
+        result["qa_severity_score"] = evaluation.severity
+        result["qa_severity_level"] = evaluation.severity_level
+        result["qa_evaluation"] = evaluation
+        result["qa_evaluation_payload"] = evaluation.to_dict()
+
+        return result
+
+    def required_tests(self) -> Sequence[str]:
+        """Return the QA test identifiers that this agent is expected to execute."""
+
+        return self.qa_engine.get_agent_tests(self.name)

--- a/agents/meta_agent.py
+++ b/agents/meta_agent.py
@@ -1,0 +1,163 @@
+"""
+SECTION: Header & Purpose
+    - Implements the ``MetaAgent`` responsible for arbitrating QA signals and coordinating trust updates.
+    - Listens to QA event bus topics, enforces missing-test escalations, weighs severity scoring, tracks error payloads,
+      and publishes consolidated arbitration outcomes.
+
+SECTION: Imports / Dependencies
+    - Depends on the shared QA engine and event bus modules only.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from qa.qa_engine import QAEngine
+from qa.qa_event_bus import QAEventBus
+
+
+class MetaAgent:
+    """Observer that aggregates QA events, updates trust, and publishes arbitration decisions."""
+
+    def __init__(self, qa_engine: QAEngine, event_bus: QAEventBus) -> None:
+        self.qa_engine = qa_engine
+        self.event_bus = event_bus
+        self.arbitration_memory: Dict[Tuple[str, str], Dict[str, Any]] = {}
+        self.agent_last_event: Dict[str, Dict[str, Any]] = {}
+        self.event_bus.subscribe("qa_failure", self.handle_qa_failure)
+        self.event_bus.subscribe("qa_success", self.handle_qa_success)
+
+    def handle_qa_failure(self, event_type: str, data: Dict[str, Any]) -> None:
+        """Process QA failure events and publish an arbitration decision."""
+
+        evaluation = self._normalise_event_payload(data, passed=False)
+        resolution = self._arbitrate(evaluation, event_type)
+        self.event_bus.publish("qa_arbitration", resolution)
+
+    def handle_qa_success(self, event_type: str, data: Dict[str, Any]) -> None:
+        """Record a QA success event and publish the resulting arbitration decision."""
+
+        evaluation = self._normalise_event_payload(data, passed=True)
+        resolution = self._arbitrate(evaluation, event_type)
+        self.event_bus.publish("qa_arbitration", resolution)
+
+    def _normalise_event_payload(self, data: Dict[str, Any], passed: bool) -> Dict[str, Any]:
+        """Ensure event payloads contain the standard fields used for arbitration."""
+
+        agent = data.get("agent", "unknown")
+        metrics = dict(data.get("metrics", {}))
+        violations = list(data.get("violations", []))
+        remediation = list(data.get("remediation", []))
+        missing_tests = list(data.get("missing_tests", []))
+        tests_executed = list(data.get("tests_executed", []))
+        trust = data.get("trust", self.qa_engine.get_agent_trust(agent))
+        failure_history = list(data.get("failure_history", []))
+        error = data.get("error") if data.get("error") else None
+        recommended_macros = list(data.get("remediation_macros", []))
+        metric_violations = list(data.get("metric_violations", []))
+        severity = float(data.get("severity", 0.0))
+        severity_level = str(data.get("severity_level", "none"))
+        untracked_metrics = list(data.get("untracked_metrics", []))
+
+        payload = {
+            "agent": agent,
+            "status": "success" if passed else "failure",
+            "metrics": metrics,
+            "violations": violations,
+            "remediation": remediation,
+            "missing_tests": missing_tests,
+            "tests_executed": tests_executed,
+            "trust": trust,
+            "failure_history": failure_history,
+            "error": error,
+            "recommended_macros": recommended_macros,
+            "metric_violations": metric_violations,
+            "severity": severity,
+            "severity_level": severity_level,
+            "untracked_metrics": untracked_metrics,
+        }
+        return payload
+
+    def _arbitrate(self, evaluation: Dict[str, Any], event_type: str) -> Dict[str, Any]:
+        """Resolve the latest QA signal against historical context and emit a decision."""
+
+        agent = evaluation["agent"]
+        previous: Optional[Dict[str, Any]] = self.agent_last_event.get(agent)
+        conflict = bool(previous) and previous.get("status") != evaluation.get("status")
+        missing_tests = evaluation.get("missing_tests", [])
+        severity = float(evaluation.get("severity", 0.0))
+        severity_level = str(evaluation.get("severity_level", "none"))
+        untracked_metrics = list(evaluation.get("untracked_metrics", []))
+
+        if missing_tests:
+            decision = "tests_required"
+        elif severity_level == "high":
+            decision = "escalate_for_review"
+        elif severity_level == "medium" and evaluation["status"] == "failure":
+            decision = "remediation_required"
+        elif conflict and evaluation["status"] == "failure":
+            decision = "escalate_for_review"
+        elif conflict and evaluation["status"] == "success":
+            decision = "recovery_confirmed"
+        elif evaluation["status"] == "failure":
+            decision = "failure_recorded"
+        else:
+            decision = "success_recorded"
+
+        recommended_macros = evaluation.get("recommended_macros", [])
+        resolution = {
+            "agent": agent,
+            "decision": decision,
+            "status": evaluation["status"],
+            "trust": evaluation.get("trust", self.qa_engine.get_agent_trust(agent)),
+            "conflict": conflict,
+            "previous_event": previous,
+            "violations": evaluation.get("violations", []),
+            "remediation": evaluation.get("remediation", []),
+            "missing_tests": missing_tests,
+            "tests_executed": evaluation.get("tests_executed", []),
+            "event_type": event_type,
+            "error": evaluation.get("error"),
+            "recommended_macros": recommended_macros,
+            "metric_violations": evaluation.get("metric_violations", []),
+            "severity": severity,
+            "severity_level": severity_level,
+            "untracked_metrics": untracked_metrics,
+        }
+
+        memory_key = (agent, evaluation["status"])
+        self.arbitration_memory[memory_key] = {
+            "decision": decision,
+            "trust": resolution["trust"],
+            "conflict": conflict,
+            "metrics": evaluation.get("metrics", {}),
+            "missing_tests": missing_tests,
+            "tests_executed": evaluation.get("tests_executed", []),
+            "recommended_macros": recommended_macros,
+            "severity": severity,
+        }
+        self.agent_last_event[agent] = evaluation
+
+        next_steps: List[str] = []
+        if evaluation["status"] == "failure" and evaluation.get("remediation"):
+            next_steps.extend(evaluation.get("remediation", []))
+        if missing_tests:
+            next_steps.append(
+                "Execute required QA tests: " + ", ".join(sorted(set(missing_tests)))
+            )
+        if recommended_macros:
+            next_steps.append(
+                "Trigger remediation macros: " + ", ".join(sorted(set(recommended_macros)))
+            )
+        if untracked_metrics:
+            next_steps.append(
+                "Define QA coverage for untracked metrics: "
+                + ", ".join(sorted(set(untracked_metrics)))
+            )
+        if severity_level in {"medium", "high"} and evaluation["status"] == "failure":
+            next_steps.append(
+                f"Review severity level '{severity_level}' impact with Macro & QA coordinators"
+            )
+        if next_steps:
+            resolution["next_steps"] = next_steps
+
+        return resolution

--- a/docs/QA.md
+++ b/docs/QA.md
@@ -1,0 +1,80 @@
+# Codex QA Constitution
+
+## 1. Purpose & Scope
+- Establish a shared quality framework for all Codex agents and macro orchestrators.
+- Provide a human-readable companion to the machine-readable rules in `qa/qa_rules.json`.
+- Ensure transparency, explainability, and continuous improvement for every generated artifact.
+
+## 2. Governing Principles
+1. **Single Source of Truth** – QA rules are centrally managed and versioned.
+2. **Budget Accountability** – Each agent must respect explicit performance, reliability, and quality budgets.
+3. **Event-Driven Oversight** – QA results are communicated via the `QAEventBus` to promote loose coupling.
+4. **Explainability & Trust** – Failures are recorded with clear reasons; trust scores evolve based on behaviour.
+5. **Self-Healing Evolution** – Repeated failures trigger retrospectives, rule refinements, and macro updates.
+
+## 3. Agent Budgets & Test Expectations
+| Agent      | Key Budgets                        | Mandatory Tests                          |
+| ---------- | ---------------------------------- | ---------------------------------------- |
+| Frontend   | Lighthouse score ≥ 90, Accessibility pass required | `jest_unit`, `axe_core_a11y`, `lighthouse` |
+| Backend    | API latency p95 ≤ 300 ms           | `pytest_unit`, `api_fuzz`, `contract`    |
+| Architect  | Dependency graph integrity         | `schema_validation`, `macro_dependency`  |
+| QA         | Holistic QA sign-off               | `full_suite`                             |
+
+> **Test Execution Enforcement** – Agents must report the tests they executed. Missing any mandatory tests will trigger a `tests_required` arbitration decision and remediation guidance to run the outstanding checks. Task payloads surface `qa_tests_executed` and a JSON-safe `qa_evaluation_payload`, enabling Agent MD, macro orchestrators, and external dashboards to compare executed versus missing tests without Python-specific serialization.
+
+### 3a. Metric Policies & Remediation Macros
+- Each agent budget now includes optional `metrics` metadata describing comparison behaviour (`gte`, `lte`, `eq`), severity weightings, remediation steps, and remediation macros.
+- The QA engine surfaces these policies in every `QAEvaluation.metric_violations` entry, empowering orchestrators to map failing metrics directly to macro automation.
+- Recommended macros (e.g. `::frontendgen-access`, `::perfprofile`) are emitted via `QAEvaluation.remediation_macros`, bubbled to agent results (`qa_recommended_macros`) and propagated through the MetaAgent for coordinated self-healing. `QAEngine.list_all_remediation_macros()` exposes the union of referenced macros so macro orchestrators can confirm coverage.
+
+### 3b. Severity Scoring & Coverage Drift Detection
+- Every `QAEvaluation` now includes a numeric `severity` score with a corresponding `severity_level` (`none`, `low`, `medium`, `high`). Scores are derived from metric policy weights, missing-test penalties, and exception handling paths.
+- The MetaAgent escalates any `high` severity outcome even without conflicting prior signals and marks `medium` failures as `remediation_required` to prioritise macro intervention.
+- Task results also surface `qa_untracked_metrics` when agents emit metrics without explicit budgets. The QA engine attaches remediation guidance to register coverage for these signals, preventing drift between observed metrics and governed thresholds.
+
+## 4. Macro Quality Requirements
+Every macro must include the following fields:
+- `inputs`: Data prerequisites and assumptions.
+- `outputs`: Deterministic description of expected artefacts.
+- `failure_cases`: Known limitations and fallback plans.
+- `dependencies`: Referenced modules, APIs, or services.
+- `context`: Default environments (`dev`, `staging`, `prod`).
+
+Macros missing required fields are rejected by the `QAEngine`. Additional context such as `state_change` or `rollout_plan` is encouraged when available.
+
+> **Macro Validation API** – Call `QAEngine.assess_macro_definition()` to receive a structured `MacroValidationResult` covering missing or empty fields, out-of-policy contexts, recommended remediation steps, and the canonical environment list. This enables cross-language orchestrators to surface actionable validation errors without needing to understand the underlying JSON rules.
+
+### 4a. Macro Catalog Governance
+- Invoke `QAEngine.audit_macro_catalog(available_macros)` to reconcile remediation macros listed in QA rules with the live macro registry (e.g. Macro Engine JSON). The audit flags missing remediation macros per agent, surfaces the union of required macros, and lists available macros not currently referenced, preventing drift between QA policy and macro coverage.
+- Arbitration payloads include both `recommended_macros` and `tests_executed`, ensuring macro orchestrators can trigger the correct recovery sequences and verify that remediation automation executes the promised tests.
+
+## 5. Event Lifecycle
+1. **Agent Execution** – Agents run tasks through `Agent.run_with_qa`.
+2. **Budget Evaluation** – Metrics are compared against budgets via the `QAEngine`.
+3. **Structured Assessment** – `QAEngine.assess_task_result` emits a `QAEvaluation` object containing trust deltas, severity scoring, remediation guidance, executed and missing test inventories, untracked metric indicators, and failure history. `QAEvaluation.to_dict()` and the propagated `qa_evaluation_payload` guarantee a stable cross-language representation for API and event consumers.
+4. **Event Publication** – Success and failure evaluations are published to the `QAEventBus`.
+5. **Meta Arbitration** – The `MetaAgent` analyses successive events for conflicts, flags missing test execution with a `tests_required` decision, escalates repeated failures, and emits `qa_arbitration` decisions that include macro-trigger recommendations and weighted remediation playbooks.
+6. **Continuous Improvement** – Recorded failures drive remediation work items and rule updates.
+
+## 5a. Runtime Refresh & Health Reporting
+- `QAEngine.refresh_from_source()` reloads the JSON rules and schema at runtime, reconciling added or removed agents without requiring a process restart.
+- `QAEngine.generate_health_report()` surfaces consolidated trust scores, outstanding failures, budget/test expectations, metric policies (thresholds, comparisons, weights), and the macros most frequently recommended for recovery.
+- Exceptions raised by any agent are converted into structured `qa_failure` events and arbitration guidance, ensuring orchestrators receive actionable diagnostics even when tasks abort early.
+
+## 6. Trust & Governance
+- Trust scores start at `1.0` and are reduced by 10% (floor `0.1`) per recorded failure.
+- Successful runs add `0.05` trust (ceiling `1.5`), reinforcing consistent quality.
+- Overrides must be documented with justification and reviewed by the QA Agent.
+- No deployment proceeds without green budgets and explicit QA sign-off.
+
+## 7. Drift Detection & Self-Healing
+- Track failure trends in `QAEngine.agent_failures` for recurring issues.
+- Use `QAEngine.generate_remediation_plan()` for contextual recovery guidance after every failure.
+- Escalate to Architecture when failures involve schema or dependency drift.
+- MetaAgent arbitration decisions include escalation recommendations when recent success/failure signals conflict.
+- Rule refresh and health report APIs enable orchestrators to recalibrate budgets dynamically as remediation tasks complete.
+
+## 8. Future Enhancements
+- Persist trust and failure history to durable storage for cross-session analytics.
+- Introduce hypothesis-driven or property-based testing for macros.
+- Evaluate asynchronous event processing for large-scale agent orchestration.

--- a/qa/__init__.py
+++ b/qa/__init__.py
@@ -1,0 +1,34 @@
+"""
+SECTION: Header & Purpose
+    - Exposes QA-related modules and value objects as a cohesive package for importers.
+
+SECTION: Imports / Dependencies
+    - Imports the primary QA engine components for convenience re-exporting.
+
+SECTION: Exports / Public API
+    - ``qa_engine`` and ``qa_event_bus`` modules alongside ``QAEvaluation``, ``QAEngine``, ``QARules``, and ``QAEventBus``.
+"""
+
+from .qa_engine import (
+    MacroValidationResult,
+    MetricPolicy,
+    MetricViolation,
+    QAEvaluation,
+    QAEngine,
+    QARules,
+    RemediationPlan,
+)
+from .qa_event_bus import QAEventBus
+
+__all__ = [
+    "qa_engine",
+    "qa_event_bus",
+    "MacroValidationResult",
+    "MetricPolicy",
+    "MetricViolation",
+    "QAEvaluation",
+    "QAEngine",
+    "QARules",
+    "RemediationPlan",
+    "QAEventBus",
+]

--- a/qa/qa_engine.py
+++ b/qa/qa_engine.py
@@ -1,0 +1,1010 @@
+"""
+SECTION: Header & Purpose
+    - Implements QARules data container and QAEngine runtime facade for QA governance.
+    - Exposes utilities for loading machine-readable QA rules, querying agent budgets, validating macros,
+      enforcing mandatory test execution, tracking agent trust metrics, scoring severity, detecting untracked
+      metrics, auditing remediation macros, and refreshing QA rules at runtime.
+
+SECTION: Imports / Dependencies
+    - Relies only on the Python standard library for portability (json, pathlib, dataclasses, typing, logging).
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, MutableMapping, Optional, Sequence, Set, Tuple, Literal, cast
+
+
+class QARulesError(Exception):
+    """Exception raised when QA rules cannot be loaded or validated."""
+
+
+@dataclass
+class MetricPolicy:
+    """Optional metadata describing how to evaluate and remediate an agent metric."""
+
+    comparison: Literal["auto", "lte", "gte", "eq"] = "auto"
+    remediation_steps: List[str] = field(default_factory=list)
+    remediation_macros: List[str] = field(default_factory=list)
+    weight: float = 1.0
+
+    def resolved_comparison(self) -> Literal["auto", "lte", "gte", "eq"]:
+        """Return the configured comparison mode for the metric."""
+
+        return self.comparison
+
+    def normalised_weight(self) -> float:
+        """Return the non-negative weight multiplier associated with this metric."""
+
+        return max(self.weight, 0.0)
+
+
+@dataclass
+class MetricViolation:
+    """Structured description of a metric violation detected during assessment."""
+
+    metric: str
+    message: str
+    weight: float = 1.0
+    remediation_steps: List[str] = field(default_factory=list)
+    remediation_macros: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialise the violation for downstream event consumers."""
+
+        return {
+            "metric": self.metric,
+            "message": self.message,
+            "weight": self.weight,
+            "remediation_steps": list(self.remediation_steps),
+            "remediation_macros": list(self.remediation_macros),
+        }
+
+
+@dataclass
+class RemediationPlan:
+    """Collection of remediation steps and remediation macros for a failure."""
+
+    steps: List[str] = field(default_factory=list)
+    macros: List[str] = field(default_factory=list)
+
+
+@dataclass
+class AgentBudget:
+    """Container describing the QA budget thresholds and required tests for an agent."""
+
+    budgets: Dict[str, Any] = field(default_factory=dict)
+    tests: List[str] = field(default_factory=list)
+    metric_policies: Dict[str, MetricPolicy] = field(default_factory=dict)
+
+    def get_metric_names(self) -> Iterable[str]:
+        """Return the collection of metric keys defined for the agent."""
+
+        return self.budgets.keys()
+
+    def get_metric_policy(self, metric_name: str) -> Optional[MetricPolicy]:
+        """Return the configured metric policy for ``metric_name`` if present."""
+
+        return self.metric_policies.get(metric_name)
+
+
+@dataclass
+class QAEvaluation:
+    """Structured result describing the outcome of assessing an agent task."""
+
+    agent: str
+    passed: bool
+    metrics: Dict[str, Any] = field(default_factory=dict)
+    violations: List[str] = field(default_factory=list)
+    trust: float = 0.0
+    failure_history: List[str] = field(default_factory=list)
+    remediation: List[str] = field(default_factory=list)
+    required_tests: List[str] = field(default_factory=list)
+    missing_tests: List[str] = field(default_factory=list)
+    tests_executed: List[str] = field(default_factory=list)
+    remediation_macros: List[str] = field(default_factory=list)
+    metric_violations: List[MetricViolation] = field(default_factory=list)
+    severity: float = 0.0
+    severity_level: str = "none"
+    untracked_metrics: List[str] = field(default_factory=list)
+    error: Optional[Dict[str, str]] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize the evaluation as a JSON-friendly dictionary for cross-language consumers."""
+
+        payload = {
+            "agent": self.agent,
+            "status": "success" if self.passed else "failure",
+            "passed": self.passed,
+            "metrics": dict(self.metrics),
+            "violations": list(self.violations),
+            "trust": self.trust,
+            "failure_history": list(self.failure_history),
+            "remediation": list(self.remediation),
+            "required_tests": list(self.required_tests),
+            "missing_tests": list(self.missing_tests),
+            "tests_executed": list(self.tests_executed),
+            "remediation_macros": list(self.remediation_macros),
+            "metric_violations": [violation.to_dict() for violation in self.metric_violations],
+            "severity": self.severity,
+            "severity_level": self.severity_level,
+            "untracked_metrics": list(self.untracked_metrics),
+            "error": dict(self.error) if self.error else None,
+        }
+        return payload
+
+    def to_event_payload(self) -> Dict[str, Any]:
+        """Serialize the evaluation for emission on the QA event bus."""
+
+        return self.to_dict()
+
+
+@dataclass
+class MacroValidationResult:
+    """Detailed evaluation describing the validity of a macro definition."""
+
+    macro: Dict[str, Any]
+    is_valid: bool
+    missing_fields: List[str] = field(default_factory=list)
+    empty_fields: List[str] = field(default_factory=list)
+    invalid_context: List[str] = field(default_factory=list)
+    recommended_context: List[str] = field(default_factory=list)
+    remediation: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialise the validation result for cross-language consumption."""
+
+        return {
+            "is_valid": self.is_valid,
+            "missing_fields": list(self.missing_fields),
+            "empty_fields": list(self.empty_fields),
+            "invalid_context": list(self.invalid_context),
+            "recommended_context": list(self.recommended_context),
+            "remediation": list(self.remediation),
+        }
+
+
+@dataclass
+class QARules:
+    """Immutable snapshot of QA rules loaded from disk."""
+
+    version: str
+    agents: Dict[str, AgentBudget] = field(default_factory=dict)
+    macros: Dict[str, Any] = field(default_factory=dict)
+
+    @staticmethod
+    def load_from_file(rules_path: Path, schema_path: Optional[Path] = None) -> "QARules":
+        """Load QA rules from ``rules_path`` and validate the payload against ``schema_path`` if provided."""
+
+        try:
+            data = json.loads(rules_path.read_text(encoding="utf-8"))
+        except OSError as exc:  # file IO issues
+            raise QARulesError(f"Failed to read QA rules file: {exc}") from exc
+        except json.JSONDecodeError as exc:
+            raise QARulesError(f"QA rules file is not valid JSON: {exc}") from exc
+
+        if schema_path is not None:
+            try:
+                schema_data = json.loads(schema_path.read_text(encoding="utf-8"))
+            except OSError as exc:
+                raise QARulesError(f"Failed to read QA schema file: {exc}") from exc
+            except json.JSONDecodeError as exc:
+                raise QARulesError(f"QA schema file is not valid JSON: {exc}") from exc
+            _validate_against_embedded_schema(data, schema_data)
+
+        agents: Dict[str, AgentBudget] = {}
+        for agent_name, config in data.get("agents", {}).items():
+            agents[agent_name] = AgentBudget(
+                budgets=dict(config.get("budgets", {})),
+                tests=list(config.get("tests", [])),
+                metric_policies=_parse_metric_policies(agent_name, config.get("metrics")),
+            )
+
+        macros = dict(data.get("macros", {}))
+        return QARules(version=str(data.get("version", "0.0.0")), agents=agents, macros=macros)
+
+
+def _validate_against_embedded_schema(data: MutableMapping[str, Any], schema: MutableMapping[str, Any]) -> None:
+    """Perform a focused validation that mirrors the bundled schema requirements."""
+
+    def _expect(condition: bool, message: str) -> None:
+        if not condition:
+            raise QARulesError(f"QA rules validation failed: {message}")
+
+    _expect(isinstance(data, dict), "top-level structure must be an object")
+
+    properties = schema.get("properties", {})
+    required_keys = tuple(schema.get("required", ("version", "agents", "macros")))
+    for required_key in required_keys:
+        _expect(required_key in data, f"missing required property '{required_key}'")
+
+    allowed_top_level = set(properties.keys()) or set(required_keys)
+    extra_top_level = set(data) - allowed_top_level
+    _expect(not extra_top_level, f"unknown top-level keys: {sorted(extra_top_level)}")
+
+    _expect(isinstance(data["version"], str), "'version' must be a string")
+
+    agents = data["agents"]
+    _expect(isinstance(agents, dict), "'agents' must be an object")
+    agent_properties = (
+        schema.get("properties", {})
+        .get("agents", {})
+        .get("additionalProperties", {})
+        .get("properties", {})
+    )
+    allowed_agent_keys = set(agent_properties.keys()) or {"budgets", "tests"}
+
+    for agent_name, agent_cfg in agents.items():
+        _expect(isinstance(agent_cfg, dict), f"agent '{agent_name}' configuration must be an object")
+        extra_keys = set(agent_cfg) - allowed_agent_keys
+        _expect(not extra_keys, f"agent '{agent_name}' has unknown keys: {sorted(extra_keys)}")
+        _expect("budgets" in agent_cfg, f"agent '{agent_name}' missing 'budgets'")
+        _expect("tests" in agent_cfg, f"agent '{agent_name}' missing 'tests'")
+
+        budgets = agent_cfg["budgets"]
+        _expect(isinstance(budgets, dict), f"agent '{agent_name}' budgets must be an object")
+        _expect(not isinstance(budgets, bool), f"agent '{agent_name}' budgets must not be boolean")
+        for metric_name, metric_value in budgets.items():
+            _expect(
+                isinstance(metric_value, (int, float, bool, str)),
+                f"agent '{agent_name}' budget '{metric_name}' must be number, boolean, or string",
+            )
+
+        tests = agent_cfg["tests"]
+        _expect(isinstance(tests, list), f"agent '{agent_name}' tests must be an array")
+        _expect(all(isinstance(test_name, str) for test_name in tests), f"agent '{agent_name}' test entries must be strings")
+        for test_name in tests:
+            _expect(isinstance(test_name, str), f"agent '{agent_name}' test entries must be strings")
+
+        metrics_cfg = agent_cfg.get("metrics")
+        if metrics_cfg is not None:
+            _expect(isinstance(metrics_cfg, dict), f"agent '{agent_name}' metrics must be an object")
+            for metric_name, policy_cfg in metrics_cfg.items():
+                _expect(isinstance(metric_name, str), "metric keys must be strings")
+                _expect(isinstance(policy_cfg, dict), f"agent '{agent_name}' metric '{metric_name}' policy must be an object")
+                comparison = policy_cfg.get("comparison", "auto")
+                _expect(
+                    comparison in {"auto", "lte", "gte", "eq"},
+                    f"agent '{agent_name}' metric '{metric_name}' comparison must be one of 'auto', 'lte', 'gte', 'eq'",
+                )
+                remediation_steps = policy_cfg.get("remediation_steps")
+                if remediation_steps is not None:
+                    _expect(
+                        isinstance(remediation_steps, list)
+                        and all(isinstance(step, str) for step in remediation_steps),
+                        f"agent '{agent_name}' metric '{metric_name}' remediation_steps must be an array of strings",
+                    )
+                remediation_macros = policy_cfg.get("remediation_macros")
+                if remediation_macros is not None:
+                    _expect(
+                        isinstance(remediation_macros, list)
+                        and all(isinstance(entry, str) for entry in remediation_macros),
+                        f"agent '{agent_name}' metric '{metric_name}' remediation_macros must be an array of strings",
+                    )
+                if "weight" in policy_cfg:
+                    weight = policy_cfg["weight"]
+                    _expect(
+                        isinstance(weight, (int, float)) and weight >= 0,
+                        f"agent '{agent_name}' metric '{metric_name}' weight must be a non-negative number",
+                    )
+
+    macros = data["macros"]
+    _expect(isinstance(macros, dict), "'macros' must be an object")
+    macro_properties = schema.get("properties", {}).get("macros", {}).get("properties", {})
+    allowed_macro_keys = set(macro_properties.keys()) or {"required_fields", "default_context"}
+    extra_macro_keys = set(macros) - allowed_macro_keys
+    _expect(not extra_macro_keys, f"macros object has unknown keys: {sorted(extra_macro_keys)}")
+    _expect("required_fields" in macros, "macros missing 'required_fields'")
+    _expect("default_context" in macros, "macros missing 'default_context'")
+
+    required_fields = macros["required_fields"]
+    _expect(isinstance(required_fields, list), "'required_fields' must be an array")
+    for field_name in required_fields:
+        _expect(isinstance(field_name, str), "each required field must be a string")
+
+    default_context = macros["default_context"]
+    _expect(isinstance(default_context, list), "'default_context' must be an array")
+    for ctx in default_context:
+        _expect(isinstance(ctx, str), "each default context entry must be a string")
+    _expect(len(set(default_context)) == len(default_context), "'default_context' entries must be unique")
+
+
+def _coerce_string_list(value: Any, error_context: str) -> List[str]:
+    """Return a list of unique strings, raising when ``value`` is not a list of strings."""
+
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise QARulesError(f"{error_context} must be defined as an array of strings")
+
+    result: List[str] = []
+    seen: Set[str] = set()
+    for entry in value:
+        if not isinstance(entry, str):
+            raise QARulesError(f"{error_context} entries must be strings")
+        if entry not in seen:
+            seen.add(entry)
+            result.append(entry)
+    return result
+
+
+def _parse_metric_policies(agent_name: str, raw: Any) -> Dict[str, MetricPolicy]:
+    """Parse the optional metric policy configuration for ``agent_name``."""
+
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise QARulesError(
+            f"Metrics configuration for agent '{agent_name}' must be an object when provided"
+        )
+
+    policies: Dict[str, MetricPolicy] = {}
+    for metric_name, payload in raw.items():
+        if not isinstance(metric_name, str):
+            raise QARulesError("Metric names must be strings")
+        if not isinstance(payload, dict):
+            raise QARulesError(
+                f"Metric policy for agent '{agent_name}' metric '{metric_name}' must be an object"
+            )
+
+        comparison = str(payload.get("comparison", "auto")).lower()
+        if comparison not in {"auto", "lte", "gte", "eq"}:
+            raise QARulesError(
+                f"Metric policy comparison for agent '{agent_name}' metric '{metric_name}' must be one of 'auto', 'lte', 'gte', 'eq'"
+            )
+
+        remediation_steps = _coerce_string_list(
+            payload.get("remediation_steps"),
+            f"agent '{agent_name}' metric '{metric_name}' remediation_steps",
+        )
+        remediation_macros = _coerce_string_list(
+            payload.get("remediation_macros"),
+            f"agent '{agent_name}' metric '{metric_name}' remediation_macros",
+        )
+
+        raw_weight = payload.get("weight", 1.0)
+        try:
+            weight = float(raw_weight)
+        except (TypeError, ValueError) as exc:
+            raise QARulesError(
+                f"Metric policy weight for agent '{agent_name}' metric '{metric_name}' must be numeric"
+            ) from exc
+        if weight < 0:
+            raise QARulesError(
+                f"Metric policy weight for agent '{agent_name}' metric '{metric_name}' must be non-negative"
+            )
+
+        policies[metric_name] = MetricPolicy(
+            comparison=cast(Literal["auto", "lte", "gte", "eq"], comparison),
+            remediation_steps=remediation_steps,
+            remediation_macros=remediation_macros,
+            weight=weight,
+        )
+
+    return policies
+
+
+class QAEngine:
+    """Runtime QA coordinator that provides budget queries, macro validation, and trust tracking."""
+
+    FAILURE_DECAY: float = 0.9
+    FAILURE_FLOOR: float = 0.1
+    SUCCESS_BOOST: float = 0.05
+    SUCCESS_CEILING: float = 1.5
+    NUMERIC_UPPER_BOUND_HINTS: tuple[str, ...] = ("latency", "duration", "time", "error", "p95", "p99")
+
+    def __init__(
+        self,
+        rules: QARules,
+        *,
+        rules_source: Optional[Tuple[Path, Optional[Path]]] = None,
+    ) -> None:
+        self.rules = rules
+        self.trust_scores: Dict[str, float] = {agent: 1.0 for agent in rules.agents}
+        self.agent_failures: Dict[str, List[str]] = {agent: [] for agent in rules.agents}
+        self._rules_source: Optional[Tuple[Path, Optional[Path]]] = rules_source
+        logging.debug("QAEngine initialised with agents: %s", list(self.rules.agents.keys()))
+
+    @classmethod
+    def from_files(cls, rules_path: Path, schema_path: Optional[Path] = None) -> "QAEngine":
+        """Factory helper that loads rules from disk and returns a ready-to-use engine instance."""
+
+        rules = QARules.load_from_file(rules_path, schema_path)
+        return cls(rules, rules_source=(rules_path, schema_path))
+
+    @property
+    def rules_source(self) -> Optional[Tuple[Path, Optional[Path]]]:
+        """Return the configured rules source paths, if the engine was built from files."""
+
+        return self._rules_source
+
+    def attach_rules_source(
+        self, rules_path: Path, schema_path: Optional[Path] = None
+    ) -> None:
+        """Associate on-disk rule locations for future refresh operations."""
+
+        self._rules_source = (rules_path, schema_path)
+
+    def get_agent_budget(self, agent_name: str) -> Optional[AgentBudget]:
+        """Return the ``AgentBudget`` for ``agent_name`` if one exists."""
+
+        return self.rules.agents.get(agent_name)
+
+    def get_agent_tests(self, agent_name: str) -> List[str]:
+        """Return the list of tests that the agent is expected to run."""
+
+        budget = self.get_agent_budget(agent_name)
+        return [] if budget is None else list(budget.tests)
+
+    def get_macro_required_fields(self) -> List[str]:
+        """Expose the required fields that macro definitions must contain."""
+
+        fields = self.rules.macros.get("required_fields", [])
+        return list(fields) if isinstance(fields, list) else []
+
+    def get_macro_default_context(self) -> List[str]:
+        """Return the default macro context list used by orchestrators."""
+
+        context = self.rules.macros.get("default_context", [])
+        return list(context) if isinstance(context, list) else []
+
+    @staticmethod
+    def _categorise_severity(score: float) -> str:
+        """Return a human-readable severity label for the provided ``score``."""
+
+        if score <= 0:
+            return "none"
+        if score < 1.0:
+            return "low"
+        if score < 2.0:
+            return "medium"
+        return "high"
+
+    def validate_macro_definition(self, macro_def: Dict[str, Any]) -> List[str]:
+        """Validate ``macro_def`` and return a list of missing required fields."""
+
+        return self.assess_macro_definition(macro_def).missing_fields
+
+    def assess_macro_definition(self, macro_def: Dict[str, Any]) -> MacroValidationResult:
+        """Return a comprehensive validation result for the provided macro definition."""
+
+        missing: List[str] = []
+        empty: List[str] = []
+        invalid_context: List[str] = []
+        required_fields = self.get_macro_required_fields()
+        default_context = self.get_macro_default_context()
+
+        for field_name in required_fields:
+            if field_name not in macro_def:
+                missing.append(field_name)
+                continue
+
+            value = macro_def[field_name]
+            if value in (None, "", [], {}):
+                empty.append(field_name)
+
+        if "context" in macro_def and "context" not in missing:
+            raw_context = macro_def.get("context")
+            if isinstance(raw_context, str):
+                context_values = [raw_context]
+            elif isinstance(raw_context, (list, tuple, set)):
+                context_values = [str(entry) for entry in raw_context]
+            else:
+                invalid_context = ["context"]
+                context_values = []
+
+            if not invalid_context:
+                allowed = set(default_context)
+                invalid_context = [value for value in context_values if value not in allowed]
+
+        remediation: List[str] = []
+        if missing:
+            remediation.append(
+                "Populate required macro fields: " + ", ".join(sorted(missing))
+            )
+        if empty:
+            remediation.append(
+                "Ensure required fields are not empty: " + ", ".join(sorted(empty))
+            )
+        if invalid_context:
+            remediation.append(
+                "Align macro context with allowed values: " + ", ".join(sorted(default_context))
+            )
+
+        is_valid = not (missing or empty or invalid_context)
+        return MacroValidationResult(
+            macro=dict(macro_def),
+            is_valid=is_valid,
+            missing_fields=missing,
+            empty_fields=empty,
+            invalid_context=invalid_context,
+            recommended_context=default_context,
+            remediation=remediation,
+        )
+
+    def reload_rules(self, rules: QARules) -> Dict[str, List[str]]:
+        """Replace the in-memory rules snapshot and reconcile trust tracking state."""
+
+        previous_agents = set(self.rules.agents)
+        next_agents = set(rules.agents)
+
+        added = sorted(next_agents - previous_agents)
+        removed = sorted(previous_agents - next_agents)
+
+        self.rules = rules
+
+        for agent in added:
+            self.trust_scores[agent] = 1.0
+            self.agent_failures[agent] = []
+
+        for agent in removed:
+            self.trust_scores.pop(agent, None)
+            self.agent_failures.pop(agent, None)
+
+        logging.info(
+            "QAEngine rules reloaded: added agents=%s removed agents=%s",
+            added,
+            removed,
+        )
+
+        return {"added_agents": added, "removed_agents": removed}
+
+    def refresh_from_source(self) -> Dict[str, List[str]]:
+        """Reload QA rules from the configured on-disk source, if available."""
+
+        if self._rules_source is None:
+            raise QARulesError("No rules source configured for refresh")
+
+        rules_path, schema_path = self._rules_source
+        refreshed = QARules.load_from_file(rules_path, schema_path)
+        return self.reload_rules(refreshed)
+
+    def assess_task_result(
+        self,
+        agent_name: str,
+        metrics: Dict[str, Any],
+        tests_executed: Optional[Sequence[str]] = None,
+    ) -> QAEvaluation:
+        """Evaluate ``metrics`` and executed tests, then return a structured assessment."""
+
+        executed_tests = [str(test) for test in tests_executed] if tests_executed else []
+        metric_violations = self.evaluate_metrics_detailed(agent_name, metrics)
+        missing_tests = self.evaluate_required_tests(agent_name, executed_tests)
+
+        violation_messages = [violation.message for violation in metric_violations]
+        violation_weights = [violation.weight for violation in metric_violations]
+        violated_metrics = [violation.metric for violation in metric_violations]
+
+        if missing_tests:
+            violation_messages.append(
+                "Required QA tests not executed: " + ", ".join(sorted(missing_tests))
+            )
+            violation_weights.append(1.0)
+
+        severity_score = float(sum(violation_weights)) if violation_weights else 0.0
+        severity_level = self._categorise_severity(severity_score)
+        untracked_metrics = self.identify_untracked_metrics(agent_name, metrics)
+
+        if violation_messages:
+            self.record_agent_failures(
+                agent_name,
+                violation_messages,
+                weights=violation_weights,
+            )
+            remediation_plan = self.generate_remediation_plan(
+                agent_name,
+                violated_metrics=violated_metrics,
+                missing_tests=missing_tests,
+            )
+        else:
+            self.record_agent_success(agent_name, "QA metrics within budget")
+            remediation_plan = RemediationPlan()
+
+        remediation_steps = list(remediation_plan.steps)
+        if untracked_metrics:
+            remediation_steps.append(
+                "Register QA budgets for untracked metrics: "
+                + ", ".join(untracked_metrics)
+            )
+
+        evaluation = QAEvaluation(
+            agent=agent_name,
+            passed=not violation_messages,
+            metrics=dict(metrics),
+            violations=list(violation_messages),
+            trust=self.get_agent_trust(agent_name),
+            failure_history=self.get_failure_history(agent_name),
+            remediation=_deduplicate_preserve_order(remediation_steps),
+            required_tests=self.get_agent_tests(agent_name),
+            missing_tests=list(missing_tests),
+            tests_executed=executed_tests,
+            remediation_macros=list(remediation_plan.macros),
+            metric_violations=list(metric_violations),
+            severity=severity_score,
+            severity_level=severity_level,
+            untracked_metrics=untracked_metrics,
+            error=None,
+        )
+        return evaluation
+
+    def record_agent_failures(
+        self, agent_name: str, reasons: Sequence[str], *, weights: Optional[Sequence[float]] = None
+    ) -> None:
+        """Record one or more QA failures while applying weighted trust decay per reason."""
+
+        if not reasons:
+            return
+
+        failures = self.agent_failures.setdefault(agent_name, [])
+        weight_list = list(weights) if weights is not None else []
+
+        for index, reason in enumerate(reasons):
+            failures.append(reason)
+            raw_weight = weight_list[index] if index < len(weight_list) else 1.0
+            try:
+                weight = float(raw_weight)
+            except (TypeError, ValueError):
+                weight = 1.0
+            weight = max(weight, 0.0)
+            decay_factor = self.FAILURE_DECAY ** weight if weight > 0 else 1.0
+
+            current_score = self.trust_scores.get(agent_name, 1.0)
+            updated_score = max(current_score * decay_factor, self.FAILURE_FLOOR)
+            self.trust_scores[agent_name] = updated_score
+            logging.warning("QA failure recorded for agent '%s': %s", agent_name, reason)
+
+    def record_agent_failure(self, agent_name: str, reason: str) -> None:
+        """Compatibility wrapper that records a single QA failure reason."""
+
+        self.record_agent_failures(agent_name, [reason], weights=[1.0])
+
+    def record_agent_success(self, agent_name: str, note: str | None = None) -> None:
+        """Increase trust following a successful QA outcome to encourage recovery over time."""
+
+        current_score = self.trust_scores.get(agent_name, 1.0)
+        updated_score = min(current_score + self.SUCCESS_BOOST, self.SUCCESS_CEILING)
+        self.trust_scores[agent_name] = updated_score
+        if note:
+            logging.info("QA success recorded for agent '%s': %s", agent_name, note)
+
+    def get_agent_trust(self, agent_name: str) -> float:
+        """Return the trust score for ``agent_name`` (defaults to ``0.0`` for unknown agents)."""
+
+        return self.trust_scores.get(agent_name, 0.0)
+
+    def get_failure_history(self, agent_name: str) -> List[str]:
+        """Return the list of QA failure reasons that have been recorded for the agent."""
+
+        return list(self.agent_failures.get(agent_name, []))
+
+    def evaluate_metrics_detailed(
+        self, agent_name: str, metrics: Dict[str, Any]
+    ) -> List[MetricViolation]:
+        """Compare ``metrics`` against budgets and return structured violation details."""
+
+        budget = self.get_agent_budget(agent_name)
+        if budget is None:
+            return []
+
+        violations: List[MetricViolation] = []
+        for metric_name, threshold in budget.budgets.items():
+            policy = budget.get_metric_policy(metric_name)
+            weight = policy.normalised_weight() if policy else 1.0
+            remediation_steps = list(policy.remediation_steps) if policy else []
+            remediation_macros = list(policy.remediation_macros) if policy else []
+
+            if metric_name not in metrics:
+                violations.append(
+                    MetricViolation(
+                        metric=metric_name,
+                        message=f"Metric '{metric_name}' is required by budget but missing from task result",
+                        weight=weight,
+                        remediation_steps=remediation_steps,
+                        remediation_macros=remediation_macros,
+                    )
+                )
+                continue
+
+            value = metrics[metric_name]
+            comparison_mode = policy.resolved_comparison() if policy else "auto"
+
+            if isinstance(threshold, (int, float)):
+                if value is None or not isinstance(value, (int, float)):
+                    violations.append(
+                        MetricViolation(
+                            metric=metric_name,
+                            message=f"Metric '{metric_name}' missing numeric value for comparison",
+                            weight=weight,
+                            remediation_steps=remediation_steps,
+                            remediation_macros=remediation_macros,
+                        )
+                    )
+                    continue
+
+                mode = comparison_mode
+                if mode == "auto":
+                    mode = "lte" if self._treat_as_upper_bound(metric_name) else "gte"
+
+                if mode == "lte" and value > threshold:
+                    violations.append(
+                        MetricViolation(
+                            metric=metric_name,
+                            message=f"Metric '{metric_name}' value {value} exceeds threshold {threshold}",
+                            weight=weight,
+                            remediation_steps=remediation_steps,
+                            remediation_macros=remediation_macros,
+                        )
+                    )
+                elif mode == "gte" and value < threshold:
+                    violations.append(
+                        MetricViolation(
+                            metric=metric_name,
+                            message=f"Metric '{metric_name}' value {value} is below minimum {threshold}",
+                            weight=weight,
+                            remediation_steps=remediation_steps,
+                            remediation_macros=remediation_macros,
+                        )
+                    )
+                elif mode == "eq" and value != threshold:
+                    violations.append(
+                        MetricViolation(
+                            metric=metric_name,
+                            message=f"Metric '{metric_name}' expected value {threshold} but received {value}",
+                            weight=weight,
+                            remediation_steps=remediation_steps,
+                            remediation_macros=remediation_macros,
+                        )
+                    )
+            elif isinstance(threshold, bool):
+                expected = bool(threshold)
+                if bool(value) != expected:
+                    violations.append(
+                        MetricViolation(
+                            metric=metric_name,
+                            message=f"Metric '{metric_name}' expected boolean {expected} but received {value}",
+                            weight=weight,
+                            remediation_steps=remediation_steps,
+                            remediation_macros=remediation_macros,
+                        )
+                    )
+            else:
+                if str(value) != str(threshold):
+                    violations.append(
+                        MetricViolation(
+                            metric=metric_name,
+                            message=f"Metric '{metric_name}' expected '{threshold}' but received '{value}'",
+                            weight=weight,
+                            remediation_steps=remediation_steps,
+                            remediation_macros=remediation_macros,
+                        )
+                    )
+
+        return violations
+
+    def evaluate_metrics(self, agent_name: str, metrics: Dict[str, Any]) -> List[str]:
+        """Return violation messages for compatibility with legacy integrations."""
+
+        return [violation.message for violation in self.evaluate_metrics_detailed(agent_name, metrics)]
+
+    @classmethod
+    def _treat_as_upper_bound(cls, metric_name: str) -> bool:
+        """Infer whether the metric should be evaluated as an upper bound based on its name."""
+
+        name = metric_name.lower()
+        return any(hint in name for hint in cls.NUMERIC_UPPER_BOUND_HINTS)
+
+    def generate_remediation_plan(
+        self,
+        agent_name: str,
+        violated_metrics: Optional[Sequence[str]] = None,
+        missing_tests: Optional[Sequence[str]] = None,
+    ) -> RemediationPlan:
+        """Return heuristic remediation actions and recommended macros for an agent."""
+
+        history = self.agent_failures.get(agent_name, [])
+        steps: List[str] = []
+        macros: List[str] = []
+
+        if missing_tests:
+            steps.append(
+                "Execute missing QA tests: " + ", ".join(sorted(set(missing_tests)))
+            )
+        else:
+            required_tests = self.get_agent_tests(agent_name)
+            if required_tests:
+                steps.append(
+                    "Re-run mandatory QA tests: " + ", ".join(sorted(required_tests))
+                )
+
+        budget = self.get_agent_budget(agent_name)
+        if budget is not None and violated_metrics:
+            for metric_name in violated_metrics:
+                policy = budget.get_metric_policy(metric_name)
+                if policy is None:
+                    continue
+                steps.extend(policy.remediation_steps)
+                macros.extend(policy.remediation_macros)
+
+        if len(history) >= 3:
+            steps.append(
+                "Escalate to Architecture for systemic review due to repeated failures."
+            )
+
+        if any("latency" in reason.lower() for reason in history):
+            steps.append("Profile performance hotspots and review caching strategies.")
+
+        if not steps:
+            steps.append("Review recent changes and update QA rules if necessary.")
+
+        deduped_steps = _deduplicate_preserve_order(steps)
+        deduped_macros = _deduplicate_preserve_order(macros)
+        return RemediationPlan(steps=deduped_steps, macros=deduped_macros)
+
+    def list_agent_remediation_macros(self, agent_name: str) -> List[str]:
+        """Return the set of macros referenced by metric policies for an agent."""
+
+        budget = self.get_agent_budget(agent_name)
+        if budget is None:
+            return []
+
+        macros: List[str] = []
+        for policy in budget.metric_policies.values():
+            macros.extend(policy.remediation_macros)
+        return _deduplicate_preserve_order(macros)
+
+    def evaluate_required_tests(
+        self, agent_name: str, tests_executed: Optional[Sequence[str]]
+    ) -> List[str]:
+        """Determine which mandatory QA tests were not executed for ``agent_name``."""
+
+        required = self.get_agent_tests(agent_name)
+        if not required:
+            return []
+
+        if tests_executed is None:
+            return list(required)
+
+        executed = {test for test in tests_executed if isinstance(test, str)}
+        return [test for test in required if test not in executed]
+
+    def identify_untracked_metrics(self, agent_name: str, metrics: Dict[str, Any]) -> List[str]:
+        """Return metrics reported by the agent that are not governed by the QA budget."""
+
+        budget = self.get_agent_budget(agent_name)
+        if budget is None:
+            return []
+
+        governed = set(budget.budgets.keys())
+        unexpected: List[str] = []
+        for key, value in metrics.items():
+            if key in governed:
+                continue
+            if key == "tests_executed" or key.startswith("qa_"):
+                continue
+            if isinstance(value, (dict, list, tuple, set)):
+                continue
+            unexpected.append(key)
+        return _deduplicate_preserve_order(unexpected)
+
+    def assess_exception(self, agent_name: str, error: BaseException) -> QAEvaluation:
+        """Generate a failure evaluation for exceptions raised during task execution."""
+
+        message = f"Task execution raised {error.__class__.__name__}: {error}"
+        self.record_agent_failure(agent_name, message)
+        required_tests = self.get_agent_tests(agent_name)
+        plan = self.generate_remediation_plan(agent_name, missing_tests=required_tests)
+        remediation = [
+            "Inspect stack trace and logs for the raised exception.",
+            "Address the root cause and re-run missing QA tests.",
+            *plan.steps,
+        ]
+        remediation_steps = _deduplicate_preserve_order(remediation)
+        remediation_macros = plan.macros or self.list_agent_remediation_macros(agent_name)
+
+        severity_score = 1.0
+        if required_tests:
+            severity_score = max(severity_score, float(len(required_tests)))
+
+        evaluation = QAEvaluation(
+            agent=agent_name,
+            passed=False,
+            metrics={},
+            violations=[message],
+            trust=self.get_agent_trust(agent_name),
+            failure_history=self.get_failure_history(agent_name),
+            remediation=remediation_steps,
+            required_tests=required_tests,
+            missing_tests=list(required_tests),
+            tests_executed=[],
+            remediation_macros=remediation_macros,
+            metric_violations=[],
+            severity=severity_score,
+            severity_level=self._categorise_severity(severity_score),
+            untracked_metrics=[],
+            error={
+                "type": error.__class__.__name__,
+                "message": str(error),
+            },
+        )
+        return evaluation
+
+    def list_all_remediation_macros(self) -> List[str]:
+        """Return the union of remediation macros referenced across all agents."""
+
+        macros: List[str] = []
+        for agent_name in self.rules.agents:
+            macros.extend(self.list_agent_remediation_macros(agent_name))
+        return _deduplicate_preserve_order(macros)
+
+    def audit_macro_catalog(self, available_macros: Iterable[str]) -> Dict[str, Any]:
+        """Compare remediation macro requirements with ``available_macros`` from the macro system."""
+
+        available_set = {str(name) for name in available_macros}
+        missing_by_agent: Dict[str, List[str]] = {}
+
+        for agent_name in self.rules.agents:
+            required = self.list_agent_remediation_macros(agent_name)
+            missing = [macro for macro in required if macro not in available_set]
+            if missing:
+                missing_by_agent[agent_name] = missing
+
+        required_macros = self.list_all_remediation_macros()
+        missing_macros = _deduplicate_preserve_order(
+            macro for macros in missing_by_agent.values() for macro in macros
+        )
+        unused_available = _deduplicate_preserve_order(
+            macro for macro in sorted(available_set) if macro not in required_macros
+        )
+
+        return {
+            "missing": missing_by_agent,
+            "missing_macros": missing_macros,
+            "required_macros": required_macros,
+            "unused_available": unused_available,
+        }
+
+    def generate_health_report(self) -> Dict[str, Any]:
+        """Return a summary of agent trust, failures, and QA rule expectations."""
+
+        agents_report: Dict[str, Any] = {}
+        for agent_name, budget in self.rules.agents.items():
+            metric_details: Dict[str, Any] = {}
+            for metric_name, threshold in budget.budgets.items():
+                policy = budget.get_metric_policy(metric_name)
+                metric_details[metric_name] = {
+                    "threshold": threshold,
+                    "comparison": policy.resolved_comparison() if policy else "auto",
+                    "weight": policy.normalised_weight() if policy else 1.0,
+                    "remediation_steps": list(policy.remediation_steps) if policy else [],
+                    "remediation_macros": list(policy.remediation_macros) if policy else [],
+                }
+
+            agents_report[agent_name] = {
+                "trust": self.get_agent_trust(agent_name),
+                "failures": list(self.agent_failures.get(agent_name, [])),
+                "budgets": dict(budget.budgets),
+                "tests": list(budget.tests),
+                "metrics": metric_details,
+                "recommended_macros": self.list_agent_remediation_macros(agent_name),
+            }
+
+        return {
+            "rules_version": self.rules.version,
+            "agents": agents_report,
+        }
+
+
+def _deduplicate_preserve_order(values: Iterable[str]) -> List[str]:
+    """Return ``values`` without duplicates while preserving the original order."""
+
+    seen: Set[str] = set()
+    ordered: List[str] = []
+    for value in values:
+        if not value:
+            continue
+        if value not in seen:
+            seen.add(value)
+            ordered.append(value)
+    return ordered

--- a/qa/qa_event_bus.py
+++ b/qa/qa_event_bus.py
@@ -1,0 +1,63 @@
+"""
+SECTION: Header & Purpose
+    - Provides a lightweight thread-safe publish/subscribe event bus dedicated to QA signals.
+    - Enables decoupled communication between agents, orchestrators, and arbitration components.
+
+SECTION: Imports / Dependencies
+    - Uses Python's standard ``threading`` primitives and typing utilities only.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from collections import defaultdict
+from typing import Any, Callable, DefaultDict, List
+
+
+EventCallback = Callable[[str, Any], None]
+
+
+class QAEventBus:
+    """Thread-safe event bus dedicated to QA telemetry and arbitration events."""
+
+    def __init__(self) -> None:
+        self._subscribers: DefaultDict[str, List[EventCallback]] = defaultdict(list)
+        self._lock = threading.RLock()
+        logging.debug("QAEventBus initialised")
+
+    def subscribe(self, event_type: str, callback: EventCallback) -> None:
+        """Register ``callback`` to receive events of type ``event_type``."""
+
+        with self._lock:
+            self._subscribers[event_type].append(callback)
+            logging.debug("QAEventBus subscriber added for '%s': %s", event_type, callback)
+
+    def unsubscribe(self, event_type: str, callback: EventCallback) -> None:
+        """Remove ``callback`` from the subscription list for ``event_type`` if present."""
+
+        with self._lock:
+            callbacks = self._subscribers.get(event_type, [])
+            if callback in callbacks:
+                callbacks.remove(callback)
+                logging.debug("QAEventBus subscriber removed for '%s': %s", event_type, callback)
+            if not callbacks and event_type in self._subscribers:
+                del self._subscribers[event_type]
+
+    def publish(self, event_type: str, data: Any) -> None:
+        """Publish ``data`` to all subscribers registered under ``event_type``."""
+
+        with self._lock:
+            subscribers_snapshot = list(self._subscribers.get(event_type, []))
+        logging.debug("QAEventBus publishing '%s' to %d subscriber(s)", event_type, len(subscribers_snapshot))
+        for callback in subscribers_snapshot:
+            try:
+                callback(event_type, data)
+            except Exception as exc:  # defensive: prevent one subscriber from blocking others
+                logging.exception("QAEventBus subscriber failure for '%s': %s", event_type, exc)
+
+    def clear(self) -> None:
+        """Remove all registered subscribers, useful for tear-down in tests."""
+
+        with self._lock:
+            self._subscribers.clear()
+            logging.debug("QAEventBus cleared")

--- a/qa/qa_rules.json
+++ b/qa/qa_rules.json
@@ -1,0 +1,92 @@
+{
+  "version": "1.0.0",
+  "agents": {
+    "Frontend": {
+      "budgets": {
+        "lighthouse_score": 90,
+        "accessibility_pass": true
+      },
+      "tests": [
+        "jest_unit",
+        "axe_core_a11y",
+        "lighthouse"
+      ],
+      "metrics": {
+        "lighthouse_score": {
+          "comparison": "gte",
+          "remediation_steps": [
+            "Optimise bundle size, fonts, and media delivery to raise Lighthouse results.",
+            "Review Core Web Vitals and prioritise layout stability fixes."
+          ],
+          "remediation_macros": [
+            "::frontendgen-tests",
+            "::frontendgen-motion",
+            "::frontendgen-access"
+          ],
+          "weight": 1.3
+        },
+        "accessibility_pass": {
+          "comparison": "eq",
+          "remediation_steps": [
+            "Resolve accessibility audit failures and re-run axe-core checks."
+          ],
+          "remediation_macros": [
+            "::frontendgen-access"
+          ],
+          "weight": 1.0
+        }
+      }
+    },
+    "Backend": {
+      "budgets": {
+        "api_latency_ms_p95": 300
+      },
+      "tests": [
+        "pytest_unit",
+        "api_fuzz",
+        "contract"
+      ],
+      "metrics": {
+        "api_latency_ms_p95": {
+          "comparison": "lte",
+          "remediation_steps": [
+            "Profile slow endpoints and optimise database access patterns.",
+            "Introduce caching or queueing where appropriate to reduce response times."
+          ],
+          "remediation_macros": [
+            "::perfprofile",
+            "::backendgen-logging"
+          ],
+          "weight": 1.5
+        }
+      }
+    },
+    "Architect": {
+      "budgets": {},
+      "tests": [
+        "schema_validation",
+        "macro_dependency"
+      ]
+    },
+    "QA": {
+      "budgets": {},
+      "tests": [
+        "full_suite"
+      ]
+    }
+  },
+  "macros": {
+    "required_fields": [
+      "inputs",
+      "outputs",
+      "failure_cases",
+      "dependencies",
+      "context"
+    ],
+    "default_context": [
+      "dev",
+      "staging",
+      "prod"
+    ]
+  }
+}

--- a/qa/qa_rules.schema.json
+++ b/qa/qa_rules.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "QA Rules Schema",
+  "description": "Schema for validating QA rules used by agents and macros.",
+  "type": "object",
+  "required": ["version", "agents", "macros"],
+  "properties": {
+    "version": { "type": "string" },
+    "agents": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "budgets": {
+            "type": "object",
+            "additionalProperties": {
+              "anyOf": [
+                { "type": "number" },
+                { "type": "boolean" },
+                { "type": "string" }
+              ]
+            }
+          },
+          "tests": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "metrics": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "comparison": {
+                  "type": "string",
+                  "enum": ["auto", "lte", "gte", "eq"]
+                },
+                "remediation_steps": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                },
+                "remediation_macros": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                },
+                "weight": {
+                  "type": "number",
+                  "minimum": 0
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": ["budgets", "tests"],
+        "additionalProperties": false
+      }
+    },
+    "macros": {
+      "type": "object",
+      "required": ["required_fields", "default_context"],
+      "properties": {
+        "required_fields": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "default_context": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+"""
+SECTION: Header & Purpose
+    - Pytest configuration ensuring the project root is importable during test execution.
+
+SECTION: Imports / Dependencies
+    - Relies on ``pathlib`` and ``sys`` from the standard library.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests/test_agent_meta_integration.py
+++ b/tests/test_agent_meta_integration.py
@@ -1,0 +1,219 @@
+"""Integration tests covering Agent, QAEngine, QAEventBus, and MetaAgent interactions."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+import pytest
+
+from agents.agent_base import Agent, AgentTaskError
+from agents.meta_agent import MetaAgent
+from qa.qa_engine import QAEngine, QARules
+from qa.qa_event_bus import QAEventBus
+
+
+class DummyAgent(Agent):
+    """Lightweight agent used to simulate deterministic task outcomes for tests."""
+
+    def __init__(
+        self,
+        name: str,
+        qa_engine: QAEngine,
+        event_bus: QAEventBus,
+        metrics: Dict[str, Any],
+        tests_executed: Optional[Sequence[str]] = None,
+    ) -> None:
+        super().__init__(name, qa_engine, event_bus)
+        self._metrics = metrics
+        self._tests_executed = list(tests_executed) if tests_executed is not None else None
+
+    def perform_task(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+        payload = dict(self._metrics)
+        if self._tests_executed is not None:
+            payload["tests_executed"] = list(self._tests_executed)
+        return payload
+
+
+@pytest.fixture()
+def qa_engine_obj() -> QAEngine:
+    """Provide a QAEngine loaded from the repository's bundled rules and schema."""
+
+    base = Path(__file__).resolve().parent.parent
+    rules = QARules.load_from_file(base / "qa" / "qa_rules.json", base / "qa" / "qa_rules.schema.json")
+    return QAEngine(rules)
+
+
+def test_agent_success_flow_emits_events(qa_engine_obj: QAEngine) -> None:
+    """A successful agent run should emit success events and a positive arbitration decision."""
+
+    bus = QAEventBus()
+    MetaAgent(qa_engine_obj, bus)
+    success_events: List[Dict[str, Any]] = []
+    arbitration_events: List[Dict[str, Any]] = []
+
+    bus.subscribe("qa_success", lambda event, data: success_events.append(data))
+    bus.subscribe("qa_arbitration", lambda event, data: arbitration_events.append(data))
+
+    agent = DummyAgent(
+        "Frontend",
+        qa_engine_obj,
+        bus,
+        {"lighthouse_score": 95, "accessibility_pass": True},
+        tests_executed=qa_engine_obj.get_agent_tests("Frontend"),
+    )
+    result = agent.run_with_qa()
+
+    assert result["qa_evaluation"].passed is True
+    assert result["qa_evaluation_payload"]["tests_executed"] == qa_engine_obj.get_agent_tests("Frontend")
+    assert result["qa_tests_executed"] == qa_engine_obj.get_agent_tests("Frontend")
+    assert success_events and success_events[0]["status"] == "success"
+    assert arbitration_events and arbitration_events[0]["decision"] == "success_recorded"
+    assert arbitration_events[0]["conflict"] is False
+    assert "qa_recommended_macros" not in result
+    assert result["qa_evaluation"].metric_violations == []
+    assert result["qa_severity_level"] == "none"
+    assert result["qa_severity_score"] == 0.0
+    assert "qa_untracked_metrics" not in result
+    assert success_events[0]["severity_level"] == "none"
+    assert arbitration_events[0]["severity_level"] == "none"
+    assert success_events[0]["tests_executed"] == qa_engine_obj.get_agent_tests("Frontend")
+    assert arbitration_events[0]["tests_executed"] == qa_engine_obj.get_agent_tests("Frontend")
+
+
+def test_agent_failure_triggers_remediation(qa_engine_obj: QAEngine) -> None:
+    """Failing metrics should produce remediation guidance and arbitration next steps."""
+
+    bus = QAEventBus()
+    MetaAgent(qa_engine_obj, bus)
+    arbitration_events: List[Dict[str, Any]] = []
+    bus.subscribe("qa_arbitration", lambda event, data: arbitration_events.append(data))
+
+    agent = DummyAgent(
+        "Frontend",
+        qa_engine_obj,
+        bus,
+        {"lighthouse_score": 10, "accessibility_pass": False},
+        tests_executed=["jest_unit"],
+    )
+    result = agent.run_with_qa()
+
+    assert result["qa_evaluation"].passed is False
+    assert arbitration_events
+    decision = arbitration_events[-1]
+    assert decision["decision"] == "tests_required"
+    assert decision["missing_tests"]
+    assert decision["next_steps"]
+    assert "::frontendgen-access" in result["qa_recommended_macros"]
+    assert "::frontendgen-access" in decision["recommended_macros"]
+    assert result["qa_severity_level"] in {"medium", "high"}
+    assert result["qa_severity_score"] > 0
+    assert decision["severity_level"] in {"medium", "high"}
+    assert decision["severity"] >= result["qa_severity_score"]
+    assert decision.get("untracked_metrics", []) == []
+    assert result["qa_tests_executed"] == ["jest_unit"]
+    assert decision["tests_executed"] == ["jest_unit"]
+
+
+def test_meta_agent_medium_severity_prompts_remediation(qa_engine_obj: QAEngine) -> None:
+    """Medium-severity failures without missing tests should trigger remediation decisions."""
+
+    bus = QAEventBus()
+    MetaAgent(qa_engine_obj, bus)
+    arbitration_events: List[Dict[str, Any]] = []
+    bus.subscribe("qa_arbitration", lambda event, data: arbitration_events.append(data))
+
+    agent = DummyAgent(
+        "Frontend",
+        qa_engine_obj,
+        bus,
+        {"lighthouse_score": 75, "accessibility_pass": True},
+        tests_executed=qa_engine_obj.get_agent_tests("Frontend"),
+    )
+    result = agent.run_with_qa()
+
+    assert arbitration_events, "Expected arbitration decision"
+    decision = arbitration_events[-1]
+    assert decision["decision"] == "remediation_required"
+    assert decision["severity_level"] == "medium"
+    assert decision["severity"] == pytest.approx(result["qa_severity_score"], rel=1e-6)
+    assert "Execute required QA tests" not in " ".join(decision.get("next_steps", []))
+    assert decision["tests_executed"] == qa_engine_obj.get_agent_tests("Frontend")
+
+
+def test_meta_agent_detects_conflicting_signals(qa_engine_obj: QAEngine) -> None:
+    """When success is followed by failure, the MetaAgent should flag a conflict and escalate."""
+
+    bus = QAEventBus()
+    MetaAgent(qa_engine_obj, bus)
+    arbitration_events: List[Dict[str, Any]] = []
+    bus.subscribe("qa_arbitration", lambda event, data: arbitration_events.append(data))
+
+    success_agent = DummyAgent(
+        "Frontend",
+        qa_engine_obj,
+        bus,
+        {"lighthouse_score": 95, "accessibility_pass": True},
+        tests_executed=qa_engine_obj.get_agent_tests("Frontend"),
+    )
+    success_agent.run_with_qa()
+
+    failing_agent = DummyAgent(
+        "Frontend",
+        qa_engine_obj,
+        bus,
+        {"lighthouse_score": 70, "accessibility_pass": False},
+        tests_executed=qa_engine_obj.get_agent_tests("Frontend"),
+    )
+    failing_agent.run_with_qa()
+
+    assert len(arbitration_events) >= 2
+    last_decision = arbitration_events[-1]
+    assert last_decision["conflict"] is True
+    assert last_decision["decision"] == "escalate_for_review"
+    assert "next_steps" in last_decision
+    assert "::frontendgen-access" in last_decision["recommended_macros"]
+    assert last_decision["severity_level"] in {"medium", "high"}
+    assert last_decision["severity"] > 0
+    assert last_decision["tests_executed"] == qa_engine_obj.get_agent_tests("Frontend")
+
+
+def test_agent_exception_publishes_failure(qa_engine_obj: QAEngine) -> None:
+    """Exceptions raised during task execution should emit QA failure events and evaluations."""
+
+    bus = QAEventBus()
+    MetaAgent(qa_engine_obj, bus)
+    failure_events: List[Dict[str, Any]] = []
+    arbitration_events: List[Dict[str, Any]] = []
+
+    bus.subscribe("qa_failure", lambda event, data: failure_events.append(data))
+    bus.subscribe("qa_arbitration", lambda event, data: arbitration_events.append(data))
+
+    class ErrorAgent(Agent):
+        def perform_task(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+            raise RuntimeError("calculation failed")
+
+    agent = ErrorAgent("Frontend", qa_engine_obj, bus)
+
+    with pytest.raises(AgentTaskError) as excinfo:
+        agent.run_with_qa()
+
+    evaluation = excinfo.value.evaluation
+    assert evaluation.passed is False
+    assert evaluation.error == {"type": "RuntimeError", "message": "calculation failed"}
+
+    assert failure_events, "Expected failure event to be published"
+    failure_payload = failure_events[-1]
+    assert failure_payload["error"]["type"] == "RuntimeError"
+    assert not evaluation.passed
+    assert "::frontendgen-access" in failure_payload.get("remediation_macros", [])
+    assert failure_payload["severity_level"] in {"medium", "high"}
+    assert failure_payload["severity"] >= 1.0
+    assert failure_payload["tests_executed"] == []
+
+    assert arbitration_events, "Expected arbitration decision to be produced"
+    arbitration_payload = arbitration_events[-1]
+    assert arbitration_payload["decision"] in {"failure_recorded", "tests_required"}
+    assert "::frontendgen-access" in arbitration_payload.get("recommended_macros", [])
+    assert arbitration_payload["severity_level"] in {"medium", "high"}
+    assert arbitration_payload["severity"] >= 1.0
+    assert arbitration_payload["tests_executed"] == []

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -1,0 +1,59 @@
+"""Unit tests validating the behaviour of the QAEventBus."""
+from __future__ import annotations
+
+from typing import Any, List, Tuple
+
+from qa.qa_event_bus import QAEventBus
+
+
+def test_publish_and_subscribe() -> None:
+    """Subscribers should receive payloads published under their event type."""
+
+    bus = QAEventBus()
+    received: List[Tuple[str, Any]] = []
+
+    def listener(event_type: str, data: Any) -> None:
+        received.append((event_type, data))
+
+    bus.subscribe("example", listener)
+    bus.publish("example", {"value": 42})
+    assert received == [("example", {"value": 42})]
+
+
+def test_listener_exception_does_not_block_other_subscribers(capfd) -> None:
+    """Errors raised by one subscriber must not prevent other listeners from receiving events."""
+
+    bus = QAEventBus()
+    calls: List[str] = []
+
+    def bad_listener(event_type: str, data: Any) -> None:
+        raise RuntimeError("listener failure")
+
+    def good_listener(event_type: str, data: Any) -> None:
+        calls.append("good")
+
+    bus.subscribe("failing", bad_listener)
+    bus.subscribe("failing", good_listener)
+    bus.publish("failing", None)
+
+    # Ensure the good listener still executed
+    assert calls == ["good"]
+
+    # Ensure the test harness captured the exception without breaking other listeners
+    capfd.readouterr()
+
+
+def test_unsubscribe_removes_listener() -> None:
+    """Subscribers removed via ``unsubscribe`` should no longer receive events."""
+
+    bus = QAEventBus()
+    calls: List[str] = []
+
+    def listener(event_type: str, data: Any) -> None:
+        calls.append("called")
+
+    bus.subscribe("remove_me", listener)
+    bus.unsubscribe("remove_me", listener)
+    bus.publish("remove_me", None)
+
+    assert calls == []

--- a/tests/test_qa_engine.py
+++ b/tests/test_qa_engine.py
@@ -1,0 +1,371 @@
+"""Unit tests for the QAEngine covering rule loading, budget evaluation, and trust management."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+from macro_system.engine import MacroEngine
+from qa.qa_engine import (
+    MacroValidationResult,
+    MetricViolation,
+    QAEngine,
+    QARules,
+)
+
+
+@pytest.fixture()
+def qa_files() -> Dict[str, Path]:
+    """Provide paths to the QA rules and schema files bundled with the repository."""
+
+    base = Path(__file__).resolve().parent.parent
+    return {
+        "rules": base / "qa" / "qa_rules.json",
+        "schema": base / "qa" / "qa_rules.schema.json",
+    }
+
+
+@pytest.fixture()
+def qa_engine(qa_files: Dict[str, Path]) -> QAEngine:
+    """Load QA rules through the schema validator and return a ready engine."""
+
+    rules = QARules.load_from_file(qa_files["rules"], qa_files["schema"])
+    return QAEngine(rules)
+
+
+@pytest.fixture()
+def qa_engine_with_source(tmp_path: Path, qa_files: Dict[str, Path]) -> QAEngine:
+    """Provide a QAEngine wired to on-disk rule files for refresh testing."""
+
+    rules_copy = tmp_path / "qa_rules.json"
+    schema_copy = tmp_path / "qa_rules.schema.json"
+    rules_copy.write_text(qa_files["rules"].read_text(encoding="utf-8"), encoding="utf-8")
+    schema_copy.write_text(qa_files["schema"].read_text(encoding="utf-8"), encoding="utf-8")
+
+    engine = QAEngine.from_files(rules_copy, schema_copy)
+    return engine
+
+
+def test_get_agent_budget_and_tests(qa_engine: QAEngine) -> None:
+    """Ensure agent budgets and test lists are loaded as defined in the rules file."""
+
+    frontend_budget = qa_engine.get_agent_budget("Frontend")
+    assert frontend_budget is not None
+    assert frontend_budget.budgets["lighthouse_score"] == 90
+    assert "lighthouse" in qa_engine.get_agent_tests("Frontend")
+    assert qa_engine.get_agent_budget("Unknown") is None
+
+
+def test_metric_policies_loaded(qa_engine: QAEngine) -> None:
+    """Metric policies should expose comparison modes, weights, and macros."""
+
+    frontend_budget = qa_engine.get_agent_budget("Frontend")
+    assert frontend_budget is not None
+    policy = frontend_budget.get_metric_policy("lighthouse_score")
+    assert policy is not None
+    assert policy.resolved_comparison() == "gte"
+    assert policy.normalised_weight() == pytest.approx(1.3, rel=1e-3)
+    assert "::frontendgen-tests" in policy.remediation_macros
+
+
+def test_validate_macro_definition_detects_missing_fields(qa_engine: QAEngine) -> None:
+    """Macro validation should flag missing required fields according to the rules."""
+
+    missing = qa_engine.validate_macro_definition({"inputs": [], "outputs": []})
+    assert "failure_cases" in missing
+    assert "dependencies" in missing
+    assert "context" in missing
+
+
+def test_assess_macro_definition_success_path(qa_engine: QAEngine) -> None:
+    """Macro assessment should recognise valid definitions with allowed contexts."""
+
+    macro = {
+        "inputs": ["payload"],
+        "outputs": ["artifact"],
+        "failure_cases": ["timeout"],
+        "dependencies": ["service"],
+        "context": ["dev", "staging"],
+    }
+    result = qa_engine.assess_macro_definition(macro)
+    assert isinstance(result, MacroValidationResult)
+    assert result.is_valid is True
+    assert result.missing_fields == []
+    assert result.empty_fields == []
+    assert result.invalid_context == []
+    assert set(result.recommended_context) == set(qa_engine.get_macro_default_context())
+
+
+def test_assess_macro_definition_flags_invalid_context(qa_engine: QAEngine) -> None:
+    """Macro assessment should detect contexts outside of the allowed defaults."""
+
+    macro = {
+        "inputs": ["payload"],
+        "outputs": ["artifact"],
+        "failure_cases": ["timeout"],
+        "dependencies": ["service"],
+        "context": ["qa", "prod"],
+    }
+    result = qa_engine.assess_macro_definition(macro)
+    assert result.is_valid is False
+    assert result.invalid_context == ["qa"]
+    assert any("context" in step for step in result.remediation)
+
+
+def test_record_agent_failure_updates_trust(qa_engine: QAEngine) -> None:
+    """Recording a failure should decay the agent's trust score and retain history."""
+
+    initial_trust = qa_engine.get_agent_trust("Frontend")
+    qa_engine.record_agent_failure("Frontend", "Exceeded latency budget")
+    assert qa_engine.get_agent_trust("Frontend") < initial_trust
+    assert qa_engine.get_failure_history("Frontend") == ["Exceeded latency budget"]
+
+
+def test_weighted_failures_decay_trust_faster(qa_engine: QAEngine) -> None:
+    """Failure weights should amplify trust decay according to severity."""
+
+    initial_trust = qa_engine.get_agent_trust("Frontend")
+    qa_engine.record_agent_failures(
+        "Frontend", ["major regression"], weights=[2.0]
+    )
+    expected = max(
+        initial_trust * (qa_engine.FAILURE_DECAY ** 2.0),
+        qa_engine.FAILURE_FLOOR,
+    )
+    assert qa_engine.get_agent_trust("Frontend") == pytest.approx(expected)
+
+
+def test_record_agent_success_caps_growth(qa_engine: QAEngine) -> None:
+    """Successful events should increment trust but stay within the configured ceiling."""
+
+    qa_engine.record_agent_success("Frontend")
+    assert qa_engine.get_agent_trust("Frontend") > 1.0
+    for _ in range(50):
+        qa_engine.record_agent_success("Frontend")
+    assert qa_engine.get_agent_trust("Frontend") <= QAEngine.SUCCESS_CEILING
+
+
+def test_evaluate_metrics_detects_numeric_and_boolean_violations(qa_engine: QAEngine) -> None:
+    """Budget evaluation should detect threshold breaches for numeric and boolean metrics."""
+
+    metrics = {"lighthouse_score": 80, "accessibility_pass": False}
+    violations = qa_engine.evaluate_metrics("Frontend", metrics)
+    assert any("lighthouse_score" in violation for violation in violations)
+    assert any("accessibility_pass" in violation for violation in violations)
+
+
+def test_evaluate_metrics_detailed_returns_structured_data(qa_engine: QAEngine) -> None:
+    """Detailed metric evaluation should surface policy metadata and remediation macros."""
+
+    metrics = {"lighthouse_score": 70, "accessibility_pass": True}
+    violations = qa_engine.evaluate_metrics_detailed("Frontend", metrics)
+    assert any(isinstance(item, MetricViolation) for item in violations)
+    lighthouse_violation = next(
+        item for item in violations if item.metric == "lighthouse_score"
+    )
+    assert lighthouse_violation.weight > 1.0
+    assert "::frontendgen-tests" in lighthouse_violation.remediation_macros
+
+
+def test_assess_task_result_success_returns_evaluation(qa_engine: QAEngine) -> None:
+    """Successful assessments should boost trust and return a populated evaluation object."""
+
+    metrics = {"lighthouse_score": 95, "accessibility_pass": True}
+    required_tests = qa_engine.get_agent_tests("Frontend")
+    evaluation = qa_engine.assess_task_result(
+        "Frontend", metrics, tests_executed=required_tests
+    )
+    assert evaluation.passed is True
+    assert evaluation.violations == []
+    assert evaluation.metrics["lighthouse_score"] == 95
+    assert evaluation.trust > 1.0
+    assert "jest_unit" in evaluation.required_tests
+    assert evaluation.missing_tests == []
+    assert evaluation.tests_executed == required_tests
+    assert evaluation.remediation == []
+    assert evaluation.remediation_macros == []
+    assert evaluation.metric_violations == []
+    assert evaluation.severity == 0.0
+    assert evaluation.severity_level == "none"
+    assert evaluation.untracked_metrics == []
+
+
+def test_assess_task_result_failure_includes_remediation(qa_engine: QAEngine) -> None:
+    """Failed assessments should return remediation guidance and log history."""
+
+    metrics = {"lighthouse_score": 50, "accessibility_pass": False}
+    evaluation = qa_engine.assess_task_result(
+        "Frontend", metrics, tests_executed=["jest_unit"]
+    )
+    assert evaluation.passed is False
+    assert len(evaluation.violations) >= 3
+    assert evaluation.remediation, "Expected remediation actions when violations occur"
+    assert qa_engine.get_failure_history("Frontend")
+    assert sorted(evaluation.missing_tests) == sorted(
+        set(qa_engine.get_agent_tests("Frontend")) - {"jest_unit"}
+    )
+    assert evaluation.tests_executed == ["jest_unit"]
+    assert any(
+        "Required QA tests not executed" in violation
+        for violation in evaluation.violations
+    )
+    assert any(isinstance(item, MetricViolation) for item in evaluation.metric_violations)
+    assert "::frontendgen-access" in evaluation.remediation_macros
+    assert evaluation.severity > 0
+    assert evaluation.severity_level in {"medium", "high"}
+    assert evaluation.untracked_metrics == []
+
+
+def test_generate_remediation_plan_scales_with_history(qa_engine: QAEngine) -> None:
+    """Repeated failures should trigger escalation guidance in the remediation plan."""
+
+    qa_engine.record_agent_failure("Frontend", "latency regression")
+    qa_engine.record_agent_failure("Frontend", "latency regression")
+    qa_engine.record_agent_failure("Frontend", "latency regression")
+    plan = qa_engine.generate_remediation_plan("Frontend")
+    assert any("Escalate" in step for step in plan.steps)
+    assert any("Profile performance" in step for step in plan.steps)
+
+
+def test_generate_remediation_plan_includes_macros(qa_engine: QAEngine) -> None:
+    """Metric-specific remediation should include macro recommendations."""
+
+    plan = qa_engine.generate_remediation_plan(
+        "Frontend", violated_metrics=["lighthouse_score"]
+    )
+    assert any("Optimise" in step for step in plan.steps)
+    assert "::frontendgen-motion" in plan.macros
+
+
+def test_assess_task_result_reports_untracked_metrics(qa_engine: QAEngine) -> None:
+    """Assessments should surface metrics that are not yet governed by QA budgets."""
+
+    metrics = {
+        "lighthouse_score": 95,
+        "accessibility_pass": True,
+        "runtime_ms": 120,
+    }
+    evaluation = qa_engine.assess_task_result(
+        "Frontend", metrics, tests_executed=qa_engine.get_agent_tests("Frontend")
+    )
+    assert evaluation.passed is True
+    assert evaluation.untracked_metrics == ["runtime_ms"]
+    assert any("untracked" in step.lower() for step in evaluation.remediation)
+    assert evaluation.severity == 0.0
+    assert evaluation.severity_level == "none"
+
+
+def test_evaluate_metrics_missing_metric_is_flagged(qa_engine: QAEngine) -> None:
+    """Budget evaluation must flag when required metrics are absent from the task result."""
+
+    metrics = {"accessibility_pass": True}
+    violations = qa_engine.evaluate_metrics("Frontend", metrics)
+    assert any("missing" in violation for violation in violations)
+
+
+def test_assess_task_result_requires_all_tests(qa_engine: QAEngine) -> None:
+    """Agents must report all mandatory tests; omissions should produce violations."""
+
+    metrics = {"lighthouse_score": 95, "accessibility_pass": True}
+    evaluation = qa_engine.assess_task_result(
+        "Frontend", metrics, tests_executed=["lighthouse"]
+    )
+    assert evaluation.passed is False
+    assert any(
+        "Required QA tests not executed" in violation
+        for violation in evaluation.violations
+    )
+    assert sorted(evaluation.missing_tests) == sorted(
+        set(qa_engine.get_agent_tests("Frontend")) - {"lighthouse"}
+    )
+
+
+def test_assess_exception_records_failure(qa_engine: QAEngine) -> None:
+    """Exceptions during task execution should record failures and remediation guidance."""
+
+    initial_trust = qa_engine.get_agent_trust("Frontend")
+    evaluation = qa_engine.assess_exception("Frontend", RuntimeError("boom"))
+
+    assert evaluation.passed is False
+    assert evaluation.error == {"type": "RuntimeError", "message": "boom"}
+    assert qa_engine.get_agent_trust("Frontend") < initial_trust
+    assert set(evaluation.missing_tests) == set(qa_engine.get_agent_tests("Frontend"))
+    assert any("QA tests" in step for step in evaluation.remediation)
+    assert "::frontendgen-access" in evaluation.remediation_macros
+    assert evaluation.severity >= 1.0
+    assert evaluation.severity_level in {"medium", "high"}
+    assert evaluation.tests_executed == []
+
+
+def test_generate_health_report_includes_agents(qa_engine: QAEngine) -> None:
+    """Health report should expose trust metrics and budgets for each agent."""
+
+    report = qa_engine.generate_health_report()
+    assert report["rules_version"] == "1.0.0"
+    assert "Frontend" in report["agents"]
+    frontend = report["agents"]["Frontend"]
+    assert "trust" in frontend
+    assert "budgets" in frontend
+    assert "metrics" in frontend
+    assert frontend["metrics"]["lighthouse_score"]["comparison"] == "gte"
+    assert "::frontendgen-tests" in frontend["recommended_macros"]
+
+
+def test_reload_rules_reconciles_agents(qa_engine: QAEngine, tmp_path: Path, qa_files: Dict[str, Path]) -> None:
+    """Reloading rules should adjust tracked agents and reset trust for new ones."""
+
+    rules_data = json.loads(qa_files["rules"].read_text(encoding="utf-8"))
+    rules_data["agents"]["Data"] = {"budgets": {"throughput": 1000}, "tests": ["load_test"]}
+    new_rules_path = tmp_path / "qa_rules.json"
+    new_rules_path.write_text(json.dumps(rules_data), encoding="utf-8")
+
+    new_rules = QARules.load_from_file(new_rules_path, qa_files["schema"])
+    result = qa_engine.reload_rules(new_rules)
+
+    assert "Data" in qa_engine.rules.agents
+    assert qa_engine.get_agent_trust("Data") == 1.0
+    assert result["added_agents"] == ["Data"]
+
+
+def test_refresh_from_source_updates_version(qa_engine_with_source: QAEngine) -> None:
+    """Refreshing from source should reload modified rule files and surface changes."""
+
+    assert qa_engine_with_source.rules_source is not None
+    rules_path, _ = qa_engine_with_source.rules_source
+    rules_data = json.loads(rules_path.read_text(encoding="utf-8"))
+    rules_data["version"] = "1.1.0"
+    rules_path.write_text(json.dumps(rules_data), encoding="utf-8")
+
+    changes = qa_engine_with_source.refresh_from_source()
+    assert qa_engine_with_source.rules.version == "1.1.0"
+    assert changes == {"added_agents": [], "removed_agents": []}
+
+
+def test_list_all_remediation_macros_exposes_union(qa_engine: QAEngine) -> None:
+    """The engine should return the union of remediation macros across all agents."""
+
+    macros = qa_engine.list_all_remediation_macros()
+    assert "::frontendgen-access" in macros
+    assert "::perfprofile" in macros
+
+
+def test_audit_macro_catalog_detects_missing_macros(qa_engine: QAEngine) -> None:
+    """Macro catalog audits should flag missing remediation macros per agent."""
+
+    base = Path(__file__).resolve().parent.parent
+    macros_path = base / "macro_system" / "macros.json"
+    engine = MacroEngine.from_json(macros_path)
+    available = engine.available_macros()
+
+    full_audit = qa_engine.audit_macro_catalog(available)
+    assert full_audit["missing"] == {}
+    assert full_audit["missing_macros"] == []
+    assert "::frontendgen" in full_audit["unused_available"]
+
+    limited_audit = qa_engine.audit_macro_catalog(
+        [macro for macro in available if macro != "::frontendgen-access"]
+    )
+    assert limited_audit["missing"]["Frontend"] == ["::frontendgen-access"]
+    assert "::frontendgen-access" in limited_audit["missing_macros"]


### PR DESCRIPTION
## Summary
- add JSON-friendly QA evaluation payloads that include executed tests and propagate through agents and the meta-agent for downstream orchestration
- audit remediation macro coverage via new QA engine helpers and document the macro catalog governance workflow
- extend QA engine and integration tests to verify executed test reporting, macro audits, and event payload enrichments

## Testing
- pytest tests -q
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68d282f5c6ac83218d497523f396640a