### PR TITLE
Refactor meta agent package structure

### DIFF
--- a/meta_agent/__init__.py
+++ b/meta_agent/__init__.py
@@ -1,0 +1,24 @@
+"""Meta Agent v2 package exposing orchestration components."""
+
+from .meta_agent_v2 import MetaAgent
+from .arbitration_engine import ArbitrationDecision, ArbitrationEngine
+from .drift_detector import DriftDetector
+from .fallback_manager import FallbackManager
+from .macro_dependency_manager import MacroDependencyManager, MacroState
+from .qa_event_bus import QAEventBus
+from .qa_rules_loader import GovernanceRules, load_governance_rules
+from .trust_engine import TrustEngine
+
+__all__ = [
+    "MetaAgent",
+    "ArbitrationDecision",
+    "ArbitrationEngine",
+    "DriftDetector",
+    "FallbackManager",
+    "MacroDependencyManager",
+    "MacroState",
+    "QAEventBus",
+    "GovernanceRules",
+    "TrustEngine",
+    "load_governance_rules",
+]

--- a/meta_agent/arbitration_engine.py
+++ b/meta_agent/arbitration_engine.py
@@ -1,0 +1,129 @@
+"""Arbitration logic for reconciling conflicting agent judgments."""
+
+# === Imports / Dependencies ===
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from .qa_rules_loader import load_governance_rules
+
+
+# === Types, Interfaces, Contracts, Schema ===
+@dataclass
+class _PendingEvent:
+    event: Dict[str, Any]
+    received_at: float
+    event_id: str
+
+
+@dataclass
+class ArbitrationDecision:
+    metric: str
+    winner: str
+    participants: List[Dict[str, Any]]
+    rationale: Dict[str, Any]
+
+
+class ArbitrationEngine:
+    """Coordinate arbitration decisions using trust scores and governance priorities."""
+
+    def __init__(self, stale_after: float = 30.0, max_queue: int = 50) -> None:
+        self.pending_events: Dict[str, List[_PendingEvent]] = {}
+        self.governance = load_governance_rules()
+        self._stale_after = stale_after
+        self._max_queue = max_queue
+
+    def add_event(self, event: Dict[str, Any]) -> None:
+        """Queue ``event`` for later conflict resolution grouped by metric."""
+
+        metric = event.get("metric")
+        if not metric:
+            return
+        queue = self.pending_events.setdefault(metric, [])
+        agent = event.get("agent")
+        if agent:
+            queue[:] = [pending for pending in queue if pending.event.get("agent") != agent]
+        queue.append(_PendingEvent(event=dict(event), received_at=time.monotonic(), event_id=str(uuid.uuid4())))
+        if len(queue) > self._max_queue:
+            queue.pop(0)
+
+    def collect_ready_conflicts(self, metric: str, now: Optional[float] = None) -> List[Dict[str, Any]]:
+        """Retrieve queued events when conflicts are ready for resolution."""
+
+        queue = self.pending_events.get(metric)
+        if not queue:
+            return []
+        current_time = time.monotonic() if now is None else now
+        if len(queue) >= 2 or current_time - queue[0].received_at >= self._stale_after:
+            self.pending_events.pop(metric, None)
+            ready: List[Dict[str, Any]] = []
+            for pending in queue:
+                event_copy = dict(pending.event)
+                event_copy.setdefault("event_id", pending.event_id)
+                ready.append(event_copy)
+            return ready
+        return []
+
+    def resolve_conflict(
+        self,
+        conflicts: List[Dict[str, Any]],
+        trust_scores: Dict[str, float],
+    ) -> ArbitrationDecision:
+        """Return a structured arbitration decision for the conflicting events."""
+
+        if not conflicts:
+            return ArbitrationDecision(
+                metric="unknown",
+                winner="unknown",
+                participants=[],
+                rationale={"reason": "no_conflicts"},
+            )
+        metric = next((event.get("metric") for event in conflicts if event.get("metric")), "unknown")
+        scores: List[Dict[str, Any]] = []
+        for event in conflicts:
+            agent = event.get("agent") or "unknown"
+            trust = float(trust_scores.get(agent, 1.0))
+            priority = float(self.governance.get_priority(metric, agent))
+            weight = trust * priority
+            scores.append({
+                "agent": agent,
+                "trust": trust,
+                "priority": priority,
+                "weight": weight,
+            })
+        sorted_scores = sorted(scores, key=lambda item: item["weight"], reverse=True)
+        winner = sorted_scores[0]["agent"] if sorted_scores else conflicts[0].get("agent", "unknown")
+        runner_up_weight = sorted_scores[1]["weight"] if len(sorted_scores) > 1 else 0.0
+        top_weight = sorted_scores[0]["weight"] if sorted_scores else 0.0
+        confidence = 0.0
+        if top_weight + runner_up_weight > 0:
+            confidence = (top_weight - runner_up_weight) / (top_weight + runner_up_weight)
+        rationale = {
+            "method": "trust_priority_weighting",
+            "scores": sorted_scores,
+            "confidence": max(confidence, 0.0),
+            "participant_count": len(conflicts),
+        }
+        return ArbitrationDecision(
+            metric=metric,
+            winner=winner,
+            participants=[dict(event) for event in conflicts],
+            rationale=rationale,
+        )
+
+
+# === Error & Edge Case Handling ===
+# Missing metrics or agent identifiers are ignored, and stale events resolve after ``stale_after`` seconds.
+# Duplicate agent entries replace older events to avoid runaway queues.
+
+
+# === Performance / Resource Considerations ===
+# Conflicts are resolved using a simple linear scan, sufficient for tens of agents per metric. Queue size is
+# capped to avoid unbounded memory growth, and stale events ensure eventual decisions.
+
+
+# === Exports / Public API ===
+__all__ = ["ArbitrationEngine", "ArbitrationDecision"]

--- a/meta_agent/docs/META_AGENT.md
+++ b/meta_agent/docs/META_AGENT.md
@@ -1,0 +1,82 @@
+# Meta Agent v2
+
+## Purpose and Scope
+Meta Agent v2 is the executive control plane for the Codex ecosystem. It aggregates QA
+signals, arbitrates conflicting judgments, curates trust scores, observes macro health, and
+proposes governance amendments when systemic drift is detected. The component harmonizes
+Frontend, Backend, Architect, QA, and Macro Orchestrator agents by ensuring a single
+source-of-truth for QA outcomes.
+
+## Architecture Overview
+- **MetaAgent** — Coordinates subsystem engines, subscribes to the QA event bus, records
+  causal traces, and publishes arbitration decisions.
+- **TrustEngine** — Maintains Bayesian-style trust scores with an append-only journal and
+  periodic snapshot compaction so trust survives restarts even during crashes.
+- **ArbitrationEngine** — Normalizes conflicting events and resolves winners using trust
+  weights and governance priorities loaded from `config/governance_rules.json` when
+  available.
+- **DriftDetector** — Observes sliding windows of QA events, flags repeated failures or
+  disables, and emits amendment proposals for QA.md/AGENTS.md.
+- **FallbackManager** — Invokes predefined macros when primary macros fail chaos or
+  resilience thresholds.
+- **MacroDependencyManager** — Tracks macro dependency schemas, blocks macros on
+  incompatibilities, persists state to disk, and emits structured diff metadata when
+  dependencies change.
+- **QAEventBus** — Asynchronous publish/subscribe broker with correlation IDs and
+  delivery metrics so arbitration, drift, and macro notifications never block one another.
+
+## Data Flow
+1. Agents publish standardized QA events (`qa_success` / `qa_failure`) via the event bus.
+2. MetaAgent consumes each event, sanitizes payloads (validating numeric ranges and
+   required identifiers), normalizes status synonyms (e.g., success/pass/fail), updates
+   trust scores, and forwards the event—complete with a
+   correlation ID—to the ArbitrationEngine queue.
+3. When multiple judgments exist for the same metric, the ArbitrationEngine resolves a
+   winner based on trust × governance priority, captures the confidence gap, and emits an
+   audit log entry plus a `qa_arbitration` event.
+4. DriftDetector records every outcome; if repeated failures or disables cross the
+   configured threshold, it emits a drift proposal broadcast through `qa_drift` events for
+   human governance review.
+5. MacroDependencyManager listens to macro definition and dependency update events,
+   blocking or unblocking macros when schema compatibility changes. It publishes
+   `macro_blocked`/`macro_unblocked` events enriched with dependency diffs for
+   orchestrators and persists compatibility state for replay.
+6. FallbackManager executes resilience macros whenever metrics exceed thresholds to ensure
+   continuous operation during chaos experiments or outages.
+
+## Governance Integration
+- Governance rules are externalized in JSON, enabling compliance reviewers to adjust agent
+  priorities without touching code.
+- Arbitration decisions are persisted as JSON Lines (defaulting to `logs/arbitrations.jsonl`)
+  for auditability, and publish a `qa_arbitration_log_error` diagnostic if disk writes fail.
+- Macro compatibility changes emit explicit `macro_blocked`/`macro_unblocked` events,
+  enabling orchestrators to pause or resume workflows as dependencies evolve.
+- Drift proposals surface suggested amendments to QA.md and AGENTS.md with severity,
+  failure counts, and recommended document sections, but require human ratification before
+  enforcement.
+
+## Security & Privacy
+- Event payloads are sanitized to avoid leaking secrets into logs and always carry
+  correlation IDs for traceability.
+- Trust and arbitration logs are stored on disk with directories created explicitly to
+  avoid accidental path traversal.
+- The system assumes authenticated agents publish events; additional verification should be
+  layered at the bus boundary for production deployments.
+
+## Resilience & Chaos Engineering
+- Chaos experiments can publish simulated failures to validate fallback macros while the
+  asynchronous bus ensures other arbitration streams continue unhindered.
+- Drift detection catches repeated test disables or sudden coverage loss.
+- Trust recalibration ensures unreliable agents lose authority until their performance
+  recovers.
+
+## Extensibility
+- Engines are composed via dependency injection, enabling alternative trust models,
+  arbitration policies, or drift algorithms without modifying MetaAgent core logic.
+- Additional event types (e.g., `qa_warning`, `qa_exemption`) can be integrated by
+  extending the event bus subscriptions.
+
+## Operational Guidance
+- Persist trust scores and arbitration logs on durable storage to survive restarts.
+- Review drift proposals regularly and amend governance documents when warranted.
+- Monitor the size of arbitration logs and rotate as part of operational hygiene.

--- a/meta_agent/drift_detector.py
+++ b/meta_agent/drift_detector.py
@@ -1,0 +1,113 @@
+"""Sliding window drift detection for QA metrics and governance rules."""
+
+# === Imports / Dependencies ===
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from typing import Any, Deque, Dict, List, Optional, Tuple
+
+
+# === Types, Interfaces, Contracts, Schema ===
+class DriftDetector:
+    """Track metric outcomes and flag repeated failures that suggest drift."""
+
+    def __init__(self, window_size: int = 5, threshold: int = 3) -> None:
+        if window_size <= 0:
+            raise ValueError("window_size must be positive")
+        if threshold <= 0:
+            raise ValueError("threshold must be positive")
+        self.window_size = window_size
+        self.threshold = threshold
+        self.history: Dict[Tuple[str, str], Deque[str]] = defaultdict(
+            lambda: deque(maxlen=self.window_size)
+        )
+        self._last_drift: Optional[Dict[str, Any]] = None
+        self._proposals: List[Dict[str, Any]] = []
+
+    def record_event(self, agent: Optional[str], metric: Optional[str], status: str) -> None:
+        """Record ``status`` for ``agent`` and ``metric`` in the sliding window."""
+
+        if not agent or not metric:
+            return
+        window = self.history[(agent, metric)]
+        window.append(status)
+        metadata = self._evaluate_window(agent, metric, window)
+        if metadata:
+            self._last_drift = metadata
+
+    def is_drift(self) -> bool:
+        """Return ``True`` when any tracked metric crosses the failure threshold."""
+
+        if self._last_drift is not None:
+            return True
+        for (agent, metric), window in self.history.items():
+            metadata = self._evaluate_window(agent, metric, window)
+            if metadata:
+                self._last_drift = metadata
+                return True
+        return False
+
+    def propose_amendment(self) -> Dict[str, Any]:
+        """Return a governance amendment proposal describing the observed drift."""
+
+        if self._last_drift is None and not self.is_drift():
+            raise RuntimeError("no drift detected to propose amendment")
+        metadata = self._last_drift or {}
+        proposal = {
+            "action": "review",
+            "reason": "repeated test failures",
+            "agent": metadata.get("agent"),
+            "metric": metadata.get("metric"),
+            "severity": metadata.get("severity"),
+            "fail_count": metadata.get("fail_count", 0),
+            "disabled_count": metadata.get("disabled_count", 0),
+            "window_size": self.window_size,
+            "threshold": self.threshold,
+            "recommended_documents": metadata.get("documents", ["QA.md"]),
+            "correlation_hint": metadata.get("correlation_hint"),
+        }
+        self._proposals.append(proposal)
+        self._last_drift = None
+        return proposal
+
+    def get_proposals(self) -> List[Dict[str, Any]]:
+        """Expose accumulated amendment proposals for auditing."""
+
+        return list(self._proposals)
+
+    def _evaluate_window(
+        self,
+        agent: str,
+        metric: str,
+        window: Deque[str],
+    ) -> Optional[Dict[str, Any]]:
+        fail_count = window.count("fail")
+        disabled_count = window.count("disabled")
+        if fail_count >= self.threshold or disabled_count >= self.threshold:
+            severity = "high" if fail_count >= self.threshold * 2 else "moderate"
+            documents = ["QA.md"]
+            if disabled_count >= self.threshold:
+                documents.append("AGENTS.md")
+            return {
+                "agent": agent,
+                "metric": metric,
+                "fail_count": fail_count,
+                "disabled_count": disabled_count,
+                "severity": severity,
+                "documents": documents,
+                "correlation_hint": f"{agent}:{metric}",
+            }
+        return None
+
+
+# === Error & Edge Case Handling ===
+# Missing agent or metric identifiers are ignored. Invalid initialization parameters raise ``ValueError``.
+# Proposals are only generated when drift metadata exists to avoid empty recommendations.
+
+
+# === Performance / Resource Considerations ===
+# Memory usage grows with ``window_size`` × number of (agent, metric) pairs. Operations are O(window_size).
+
+
+# === Exports / Public API ===
+__all__ = ["DriftDetector"]

--- a/meta_agent/fallback_manager.py
+++ b/meta_agent/fallback_manager.py
@@ -1,0 +1,36 @@
+"""Fallback macro coordination for resilience testing."""
+
+# === Imports / Dependencies ===
+from __future__ import annotations
+
+from typing import Callable, Dict
+
+
+# === Types, Interfaces, Contracts, Schema ===
+FallbackCallable = Callable[[float, float], None]
+
+
+class FallbackManager:
+    """Manage fallback macro invocations when primary macros fail thresholds."""
+
+    def __init__(self, fallbacks: Dict[str, FallbackCallable]) -> None:
+        self.fallbacks = dict(fallbacks)
+
+    def evaluate_and_trigger(self, metric: str, value: float, threshold: float) -> None:
+        """Invoke fallback for ``metric`` if ``value`` breaches ``threshold``."""
+
+        if metric in self.fallbacks and value is not None and threshold is not None:
+            if value > threshold:
+                self.fallbacks[metric](value, threshold)
+
+
+# === Error & Edge Case Handling ===
+# Metrics without configured fallbacks are ignored. None values skip evaluation.
+
+
+# === Performance / Resource Considerations ===
+# Operations are O(1) dictionary lookups; fallbacks defer to user-supplied callables.
+
+
+# === Exports / Public API ===
+__all__ = ["FallbackManager", "FallbackCallable"]

--- a/meta_agent/macro_dependency_manager.py
+++ b/meta_agent/macro_dependency_manager.py
@@ -1,0 +1,283 @@
+"""Macro dependency compatibility management and blocking orchestration."""
+
+# === Imports / Dependencies ===
+from __future__ import annotations
+
+import json
+import os
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, Optional, Set
+import contextlib
+
+
+# === Types, Interfaces, Contracts, Schema ===
+@dataclass
+class MacroState:
+    """Snapshot of a macro's schema, dependencies, and block status."""
+
+    macro: str
+    schema_version: Optional[str]
+    dependencies: Dict[str, str] = field(default_factory=dict)
+    blocked: bool = False
+    reason: Optional[str] = None
+    diff: Dict[str, object] = field(default_factory=dict)
+
+
+class MacroDependencyManager:
+    """Track macro dependency compatibility and emit block/unblock states."""
+
+    def __init__(self, storage_path: Optional[Path] = None) -> None:
+        self._macros: Dict[str, MacroState] = {}
+        self._dependency_versions: Dict[str, str] = {}
+        self._reverse_index: Dict[str, Set[str]] = {}
+        self._lock = threading.RLock()
+        self._storage_path = storage_path
+        if self._storage_path is not None:
+            self._storage_path.parent.mkdir(parents=True, exist_ok=True)
+            self._load()
+
+    # === Core Logic / Implementation ===
+    def register_macro(
+        self,
+        macro: str,
+        schema_version: Optional[str],
+        dependencies: Mapping[str, str],
+    ) -> MacroState:
+        """Register or update ``macro`` requirements and return its state."""
+
+        if not macro:
+            raise ValueError("macro name must be provided")
+        normalized_dependencies = {str(dep): str(version) for dep, version in dependencies.items()}
+        normalized_schema = str(schema_version) if schema_version is not None else None
+        with self._lock:
+            previous = self._macros.get(macro)
+            if previous:
+                self._remove_reverse_links(macro, previous.dependencies.keys())
+            state = MacroState(macro=macro, schema_version=normalized_schema, dependencies=normalized_dependencies)
+            self._macros[macro] = state
+            self._add_reverse_links(macro, normalized_dependencies.keys())
+            self._evaluate_macro(macro)
+            decorated = self._decorate_state(macro, previous)
+            self._persist()
+            return decorated
+
+    def update_dependency_schema(self, dependency: str, schema_version: str) -> List[MacroState]:
+        """Update actual ``dependency`` schema version and return impacted macro states."""
+
+        if not dependency:
+            raise ValueError("dependency must be provided")
+        normalized = str(schema_version)
+        impacted: List[MacroState] = []
+        with self._lock:
+            self._dependency_versions[dependency] = normalized
+            for macro in self._reverse_index.get(dependency, set()):
+                previous = self._macros.get(macro)
+                if previous is None:
+                    continue
+                previous_copy = MacroState(
+                    macro=previous.macro,
+                    schema_version=previous.schema_version,
+                    dependencies=dict(previous.dependencies),
+                    blocked=previous.blocked,
+                    reason=previous.reason,
+                )
+                if self._evaluate_macro(macro):
+                    impacted.append(self._decorate_state(macro, previous_copy))
+            if impacted:
+                self._persist()
+        return impacted
+
+    def get_state(self, macro: str) -> MacroState:
+        """Return a defensive copy of the stored state for ``macro``."""
+
+        with self._lock:
+            state = self._macros.get(macro)
+            if not state:
+                raise KeyError(f"macro '{macro}' is not registered")
+            return MacroState(
+                macro=state.macro,
+                schema_version=state.schema_version,
+                dependencies=dict(state.dependencies),
+                blocked=state.blocked,
+                reason=state.reason,
+                diff=dict(state.diff),
+            )
+
+    def is_blocked(self, macro: str) -> bool:
+        """Return True if ``macro`` is currently blocked."""
+
+        return self.get_state(macro).blocked
+
+    def get_block_reason(self, macro: str) -> Optional[str]:
+        """Return the block reason for ``macro`` if blocked."""
+
+        return self.get_state(macro).reason
+
+    def get_blocked_macros(self) -> Dict[str, str]:
+        """Return mapping of blocked macros to their reasons."""
+
+        with self._lock:
+            blocked: Dict[str, str] = {}
+            for macro, state in self._macros.items():
+                if state.blocked:
+                    blocked[macro] = state.reason or ""
+            return blocked
+
+    # === Error & Edge Case Handling ===
+    def _evaluate_macro(self, macro: str) -> bool:
+        state = self._macros[macro]
+        previous_blocked = state.blocked
+        previous_reason = state.reason
+        reason: Optional[str] = None
+        for dependency, expected in state.dependencies.items():
+            actual = self._dependency_versions.get(dependency)
+            if actual is None:
+                reason = f"dependency {dependency} schema unknown"
+                break
+            if actual != expected:
+                reason = f"dependency {dependency} schema mismatch: expected {expected}, got {actual}"
+                break
+        state.blocked = reason is not None
+        state.reason = reason
+        return state.blocked != previous_blocked or state.reason != previous_reason
+
+    def _remove_reverse_links(self, macro: str, dependencies: Iterable[str]) -> None:
+        for dependency in dependencies:
+            watchers = self._reverse_index.get(dependency)
+            if not watchers:
+                continue
+            watchers.discard(macro)
+            if not watchers:
+                self._reverse_index.pop(dependency, None)
+
+    def _add_reverse_links(self, macro: str, dependencies: Iterable[str]) -> None:
+        for dependency in dependencies:
+            self._reverse_index.setdefault(dependency, set()).add(macro)
+
+    def _decorate_state(self, macro: str, previous: Optional[MacroState]) -> MacroState:
+        current = self._macros[macro]
+        diff: Dict[str, object] = {}
+        if previous is not None:
+            dependency_diff = self._diff_dependencies(previous.dependencies, current.dependencies)
+            if any(dependency_diff.values()):
+                diff["dependencies"] = dependency_diff
+            if previous.schema_version != current.schema_version:
+                diff["schema_version"] = {
+                    "before": previous.schema_version,
+                    "after": current.schema_version,
+                }
+            if previous.blocked != current.blocked:
+                diff["blocked"] = {
+                    "before": previous.blocked,
+                    "after": current.blocked,
+                }
+            if previous.reason != current.reason:
+                diff["reason"] = {
+                    "before": previous.reason,
+                    "after": current.reason,
+                }
+        else:
+            diff["initialized_at"] = datetime.now(timezone.utc).isoformat()
+        decorated = MacroState(
+            macro=current.macro,
+            schema_version=current.schema_version,
+            dependencies=dict(current.dependencies),
+            blocked=current.blocked,
+            reason=current.reason,
+            diff=diff,
+        )
+        self._macros[macro] = MacroState(
+            macro=current.macro,
+            schema_version=current.schema_version,
+            dependencies=dict(current.dependencies),
+            blocked=current.blocked,
+            reason=current.reason,
+            diff=diff,
+        )
+        return decorated
+
+    def _diff_dependencies(self, previous: Mapping[str, str], current: Mapping[str, str]) -> Dict[str, Dict[str, object]]:
+        prev_keys = set(previous)
+        curr_keys = set(current)
+        added = {key: current[key] for key in curr_keys - prev_keys}
+        removed = {key: previous[key] for key in prev_keys - curr_keys}
+        changed = {
+            key: {"before": previous[key], "after": current[key]}
+            for key in prev_keys & curr_keys
+            if previous[key] != current[key]
+        }
+        return {"added": added, "removed": removed, "changed": changed}
+
+    def _persist(self) -> None:
+        if self._storage_path is None:
+            return
+        payload = {
+            "macros": {
+                macro: {
+                    "schema_version": state.schema_version,
+                    "dependencies": state.dependencies,
+                    "blocked": state.blocked,
+                    "reason": state.reason,
+                }
+                for macro, state in self._macros.items()
+            },
+            "dependencies": dict(self._dependency_versions),
+        }
+        serialized = json.dumps(payload, sort_keys=True)
+        temp_path = self._storage_path.with_suffix(f"{self._storage_path.suffix}.tmp")
+        try:
+            temp_path.write_text(serialized, encoding="utf-8")
+            os.replace(temp_path, self._storage_path)
+        except OSError:
+            with contextlib.suppress(FileNotFoundError, OSError):
+                temp_path.unlink()
+
+    def _load(self) -> None:
+        try:
+            raw = self._storage_path.read_text(encoding="utf-8") if self._storage_path else ""
+        except (FileNotFoundError, OSError):
+            return
+        try:
+            payload = json.loads(raw)
+        except (ValueError, TypeError):
+            return
+        if not isinstance(payload, dict):
+            return
+        macros = payload.get("macros", {})
+        dependencies = payload.get("dependencies", {})
+        if isinstance(macros, dict):
+            for macro, state in macros.items():
+                if not isinstance(state, dict):
+                    continue
+                deps = state.get("dependencies", {})
+                if isinstance(deps, dict):
+                    dependencies_map = {str(dep): str(version) for dep, version in deps.items()}
+                else:
+                    dependencies_map = {}
+                schema_version = state.get("schema_version")
+                blocked = bool(state.get("blocked", False))
+                reason = state.get("reason")
+                macro_state = MacroState(
+                    macro=str(macro),
+                    schema_version=str(schema_version) if schema_version is not None else None,
+                    dependencies=dependencies_map,
+                    blocked=blocked,
+                    reason=str(reason) if isinstance(reason, str) else None,
+                )
+                self._macros[str(macro)] = macro_state
+                self._add_reverse_links(str(macro), dependencies_map.keys())
+        if isinstance(dependencies, dict):
+            for dependency, version in dependencies.items():
+                self._dependency_versions[str(dependency)] = str(version)
+
+
+# === Performance / Resource Considerations ===
+# Compatibility checks are O(number of dependencies per macro). Reverse indexes ensure only impacted macros
+# are evaluated on dependency changes. State copies safeguard callers from accidental mutation.
+
+
+# === Exports / Public API ===
+__all__ = ["MacroDependencyManager", "MacroState"]

--- a/meta_agent/meta_agent_v2.py
+++ b/meta_agent/meta_agent_v2.py
@@ -1,0 +1,321 @@
+"""Meta Agent v2 orchestrates arbitration, trust, drift detection, fallbacks, and macros."""
+
+# === Imports / Dependencies ===
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, Optional
+
+from .arbitration_engine import ArbitrationDecision, ArbitrationEngine
+from .drift_detector import DriftDetector
+from .fallback_manager import FallbackManager
+from .macro_dependency_manager import MacroDependencyManager, MacroState
+from .qa_event_bus import QAEventBus
+from .trust_engine import TrustEngine
+
+
+logger = logging.getLogger(__name__)
+
+
+# === Types, Interfaces, Contracts, Schema ===
+class MetaAgent:
+    """Executive layer that coordinates subsystem engines for QA governance."""
+
+    def __init__(
+        self,
+        trust_engine: TrustEngine,
+        arbitration_engine: ArbitrationEngine,
+        drift_detector: DriftDetector,
+        fallback_manager: FallbackManager,
+        macro_manager: MacroDependencyManager,
+        event_bus: QAEventBus,
+        arbitration_log_path: Optional[Path] = None,
+    ) -> None:
+        self.trust_engine = trust_engine
+        self.arbitration_engine = arbitration_engine
+        self.drift_detector = drift_detector
+        self.fallback_manager = fallback_manager
+        self.macro_manager = macro_manager
+        self.event_bus = event_bus
+        self._lock = threading.RLock()
+        self._arbitration_log_path = (
+            arbitration_log_path if arbitration_log_path is not None else Path("logs/arbitrations.jsonl")
+        )
+        self._arbitration_log_path.parent.mkdir(parents=True, exist_ok=True)
+        self.event_bus.subscribe("qa_failure", self.handle_event)
+        self.event_bus.subscribe("qa_success", self.handle_event)
+        self.event_bus.subscribe("macro_definition", self.handle_event)
+        self.event_bus.subscribe("macro_dependency_update", self.handle_event)
+
+    def handle_event(self, event_type: str, data: Dict[str, Any]) -> None:
+        """Route events to QA processing, macro tracking, or ignore unknown types."""
+
+        if event_type in {"qa_failure", "qa_success"}:
+            self._process_qa_event(event_type, data)
+        elif event_type == "macro_definition":
+            self._process_macro_definition(data)
+        elif event_type == "macro_dependency_update":
+            self._process_dependency_update(data)
+
+    def propose_rule_update(self) -> Dict[str, Any]:
+        """Expose accumulated drift proposals for human/architect review."""
+
+        proposals = self.drift_detector.get_proposals()
+        return {"proposals": proposals}
+
+    # === Core Logic / Implementation ===
+    def _process_qa_event(self, event_type: str, data: Dict[str, Any]) -> None:
+        """Process QA events: update trust, arbitrate conflicts, and manage drift."""
+
+        sanitized = self._sanitize_event_payload(data)
+        if not sanitized:
+            return
+        correlation_id = sanitized["correlation_id"]
+        agent = sanitized.get("agent")
+        metric = sanitized.get("metric")
+        status = sanitized.get("status") or self._infer_status(event_type)
+        value = sanitized.get("value")
+        threshold = sanitized.get("threshold")
+        event_record = {
+            "agent": agent,
+            "metric": metric,
+            "status": status,
+            "value": value,
+            "threshold": threshold,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "event_type": event_type,
+            "correlation_id": correlation_id,
+        }
+        conflicts: Optional[Iterable[Dict[str, Any]]] = None
+        trust_snapshot: Dict[str, float] = {}
+        drift_triggered = False
+        trigger_fallback = metric is not None and value is not None and threshold is not None
+        with self._lock:
+            self._update_trust(agent, status)
+            trust_snapshot = self.trust_engine.get_trust_scores()
+            self.drift_detector.record_event(agent, metric, status or "unknown")
+            if metric:
+                self.arbitration_engine.add_event(event_record)
+                conflicts = self.arbitration_engine.collect_ready_conflicts(metric)
+            drift_triggered = self.drift_detector.is_drift()
+        if conflicts:
+            decision = self.arbitration_engine.resolve_conflict(list(conflicts), trust_snapshot)
+            decision_payload = self._build_arbitration_payload(decision, trust_snapshot, correlation_id)
+            self._record_arbitration(decision_payload)
+            self._publish("qa_arbitration", decision_payload, correlation_id)
+        if drift_triggered:
+            try:
+                amendment = self.drift_detector.propose_amendment()
+            except RuntimeError:
+                amendment = None
+            if amendment:
+                amendment["correlation_id"] = correlation_id
+                self._publish("qa_drift", amendment, correlation_id)
+        if trigger_fallback and value is not None and threshold is not None and metric is not None:
+            self.fallback_manager.evaluate_and_trigger(metric, value, threshold)
+
+    def _process_macro_definition(self, data: Dict[str, Any]) -> None:
+        """Register macro schemas and broadcast their compatibility state."""
+
+        sanitized = self._sanitize_macro_definition(data)
+        macro = sanitized.get("macro")
+        dependencies = sanitized.get("dependencies", {})
+        schema_version = sanitized.get("schema_version")
+        if not macro:
+            return
+        correlation_id = sanitized.get("correlation_id", str(uuid.uuid4()))
+        with self._lock:
+            state = self.macro_manager.register_macro(macro, schema_version, dependencies)
+        self._broadcast_macro_states([state], correlation_id)
+
+    def _process_dependency_update(self, data: Dict[str, Any]) -> None:
+        """Update dependency schema versions and notify impacted macros."""
+
+        sanitized = self._sanitize_dependency_update(data)
+        dependency = sanitized.get("dependency")
+        schema_version = sanitized.get("schema_version")
+        if not dependency or schema_version is None:
+            return
+        correlation_id = sanitized.get("correlation_id", str(uuid.uuid4()))
+        with self._lock:
+            impacted = self.macro_manager.update_dependency_schema(dependency, schema_version)
+        if impacted:
+            self._broadcast_macro_states(impacted, correlation_id)
+
+    def _update_trust(self, agent: Optional[str], status: Optional[str]) -> None:
+        if not agent:
+            return
+        if status == "fail":
+            self.trust_engine.record_failure(agent)
+        elif status == "pass":
+            self.trust_engine.record_success(agent)
+
+    def _record_arbitration(self, decision: Dict[str, Any]) -> None:
+        try:
+            with self._arbitration_log_path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(decision, sort_keys=True))
+                handle.write("\n")
+        except OSError as exc:
+            logger.error("Failed to persist arbitration decision: %s", exc)
+            warning_payload = {
+                "error": str(exc),
+                "decision": decision,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            }
+            correlation = decision.get("correlation_id", str(uuid.uuid4()))
+            self._publish("qa_arbitration_log_error", warning_payload, correlation)
+
+    def _broadcast_macro_states(self, states: Iterable[MacroState], correlation_id: Optional[str] = None) -> None:
+        """Publish macro states and emit block/unblock signals for orchestration."""
+
+        for state in states:
+            payload = self._macro_state_payload(state, correlation_id)
+            corr = payload.get("correlation_id", str(uuid.uuid4()))
+            self._publish("macro_state", payload, corr)
+            event_name = "macro_blocked" if state.blocked else "macro_unblocked"
+            self._publish(event_name, payload, corr)
+
+    def _sanitize_event_payload(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        if not isinstance(data, Mapping):
+            return {}
+        sanitized: Dict[str, Any] = {"correlation_id": str(data.get("correlation_id") or uuid.uuid4())}
+        agent = data.get("agent")
+        if isinstance(agent, str) and agent.strip():
+            sanitized["agent"] = agent.strip()
+        metric = data.get("metric")
+        if isinstance(metric, str) and metric.strip():
+            sanitized["metric"] = metric.strip()
+        status = data.get("status")
+        if isinstance(status, str) and status.strip():
+            normalized_status = self._normalize_status(status)
+            if normalized_status:
+                sanitized["status"] = normalized_status
+        value = self._coerce_float(data.get("value"))
+        if value is not None:
+            sanitized["value"] = value
+        threshold = self._coerce_float(data.get("threshold"))
+        if threshold is not None:
+            sanitized["threshold"] = threshold
+        return sanitized
+
+    @staticmethod
+    def _sanitize_macro_definition(data: Dict[str, Any]) -> Dict[str, Any]:
+        if not isinstance(data, Mapping):
+            return {}
+        allowed_keys = {"macro", "schema_version", "dependencies"}
+        sanitized = {key: data.get(key) for key in allowed_keys}
+        dependencies = sanitized.get("dependencies")
+        if isinstance(dependencies, Mapping):
+            sanitized["dependencies"] = {str(dep): str(version) for dep, version in dependencies.items()}
+        else:
+            sanitized["dependencies"] = {}
+        schema_version = sanitized.get("schema_version")
+        if schema_version is not None:
+            sanitized["schema_version"] = str(schema_version)
+        sanitized["correlation_id"] = str(data.get("correlation_id") or uuid.uuid4())
+        return sanitized
+
+    @staticmethod
+    def _sanitize_dependency_update(data: Dict[str, Any]) -> Dict[str, Any]:
+        if not isinstance(data, Mapping):
+            return {}
+        allowed_keys = {"dependency", "schema_version"}
+        sanitized = {key: data.get(key) for key in allowed_keys}
+        dependency = sanitized.get("dependency")
+        if dependency is not None:
+            sanitized["dependency"] = str(dependency)
+        schema_version = sanitized.get("schema_version")
+        if schema_version is not None:
+            sanitized["schema_version"] = str(schema_version)
+        sanitized["correlation_id"] = str(data.get("correlation_id") or uuid.uuid4())
+        return sanitized
+
+    @staticmethod
+    def _infer_status(event_type: str) -> str:
+        if event_type == "qa_failure":
+            return "fail"
+        if event_type == "qa_success":
+            return "pass"
+        return "unknown"
+
+    @staticmethod
+    def _normalize_status(status: str) -> Optional[str]:
+        normalized = status.strip().lower()
+        mapping = {
+            "pass": "pass",
+            "passed": "pass",
+            "success": "pass",
+            "succeeded": "pass",
+            "ok": "pass",
+            "fail": "fail",
+            "failed": "fail",
+            "failure": "fail",
+            "error": "fail",
+            "disabled": "disabled",
+        }
+        return mapping.get(normalized, normalized or None)
+
+    def _coerce_float(self, value: Any) -> Optional[float]:
+        if isinstance(value, (int, float)):
+            return float(value)
+        return None
+
+    def _build_arbitration_payload(
+        self,
+        decision: ArbitrationDecision,
+        trust_snapshot: Dict[str, float],
+        correlation_id: str,
+    ) -> Dict[str, Any]:
+        rationale = dict(decision.rationale)
+        top_weight = rationale.get("scores", [{}])[0].get("weight", 0.0) if rationale.get("scores") else 0.0
+        second_weight = rationale.get("scores", [{}])[1].get("weight", 0.0) if len(rationale.get("scores", [])) > 1 else 0.0
+        rationale["trust_gap"] = top_weight - second_weight
+        payload = {
+            "metric": decision.metric,
+            "winner": decision.winner,
+            "participants": decision.participants,
+            "rationale": rationale,
+            "trust_snapshot": trust_snapshot,
+            "decided_at": datetime.now(timezone.utc).isoformat(),
+            "correlation_id": correlation_id,
+        }
+        return payload
+
+    def _macro_state_payload(self, state: MacroState, correlation_id: Optional[str] = None) -> Dict[str, Any]:
+        payload = {
+            "macro": state.macro,
+            "schema_version": state.schema_version,
+            "dependencies": state.dependencies,
+            "blocked": state.blocked,
+            "reason": state.reason,
+            "diff": state.diff,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "correlation_id": correlation_id or str(uuid.uuid4()),
+        }
+        return payload
+
+    def _publish(self, event_type: str, payload: Dict[str, Any], correlation_id: str) -> None:
+        enriched = dict(payload)
+        enriched.setdefault("correlation_id", correlation_id)
+        self.event_bus.publish(event_type, enriched, correlation_id=correlation_id)
+
+
+# === Error & Edge Case Handling ===
+# Unknown agents are ignored by the trust engine; missing metrics skip arbitration and fallbacks.
+# Macro definitions without names are ignored; dependency updates require dependency and schema values.
+# Arbitration log failures emit a diagnostic event for downstream observability.
+
+
+# === Performance / Resource Considerations ===
+# Thread-safe updates rely on an ``RLock`` covering trust and macro state mutations. The asynchronous event
+# bus prevents slow subscribers from blocking arbitration, and arbitration logs append JSON lines for audit
+# trails while macro states emit targeted updates with diff metadata.
+
+
+# === Exports / Public API ===
+__all__ = ["MetaAgent"]

--- a/meta_agent/qa_event_bus.py
+++ b/meta_agent/qa_event_bus.py
@@ -1,0 +1,165 @@
+"""Asynchronous publish/subscribe event bus for QA signals with observability."""
+
+# === Imports / Dependencies ===
+from __future__ import annotations
+
+import threading
+import time
+import uuid
+from collections import defaultdict
+from dataclasses import dataclass
+from queue import Queue, Empty
+from typing import Any, Callable, DefaultDict, Dict, List, Optional
+
+
+# === Types, Interfaces, Contracts, Schema ===
+QAEventCallback = Callable[[str, Dict[str, Any]], None]
+
+
+@dataclass
+class _QueuedEvent:
+    """Internal representation of a queued event."""
+
+    event_type: str
+    payload: Dict[str, Any]
+    correlation_id: str
+    enqueued_at: float
+
+
+class QAEventBus:
+    """Background-dispatched event bus that prevents subscriber stalls."""
+
+    def __init__(self, worker_count: int = 1) -> None:
+        if worker_count <= 0:
+            raise ValueError("worker_count must be positive")
+        self._subscribers: DefaultDict[str, List[QAEventCallback]] = defaultdict(list)
+        self._lock = threading.RLock()
+        self._queue: "Queue[Optional[_QueuedEvent]]" = Queue()
+        self._workers: List[threading.Thread] = []
+        self._shutdown = threading.Event()
+        self._metrics = {
+            "published": 0,
+            "delivered": 0,
+            "failed": 0,
+            "dropped": 0,
+        }
+        self._metrics_lock = threading.Lock()
+        for index in range(worker_count):
+            worker = threading.Thread(target=self._worker, name=f"qa-event-worker-{index}", daemon=True)
+            worker.start()
+            self._workers.append(worker)
+
+    def subscribe(self, event_type: str, callback: QAEventCallback) -> None:
+        """Register ``callback`` to receive events of ``event_type``."""
+
+        if not event_type:
+            raise ValueError("event_type must be provided")
+        if not callable(callback):
+            raise TypeError("callback must be callable")
+        with self._lock:
+            if callback not in self._subscribers[event_type]:
+                self._subscribers[event_type].append(callback)
+
+    def unsubscribe(self, event_type: str, callback: QAEventCallback) -> None:
+        """Remove ``callback`` from subscribers of ``event_type``."""
+
+        with self._lock:
+            callbacks = self._subscribers.get(event_type)
+            if not callbacks:
+                return
+            try:
+                callbacks.remove(callback)
+            except ValueError:
+                return
+            if not callbacks:
+                self._subscribers.pop(event_type, None)
+
+    def publish(self, event_type: str, payload: Dict[str, Any], correlation_id: Optional[str] = None) -> None:
+        """Publish ``payload`` for ``event_type`` to all subscribers asynchronously."""
+
+        if payload is None:
+            raise ValueError("payload must not be None")
+        if not isinstance(payload, dict):
+            raise TypeError("payload must be a dictionary")
+        correlation = correlation_id or str(uuid.uuid4())
+        enriched_payload = dict(payload)
+        enriched_payload.setdefault("correlation_id", correlation)
+        event = _QueuedEvent(
+            event_type=event_type,
+            payload=enriched_payload,
+            correlation_id=correlation,
+            enqueued_at=time.perf_counter(),
+        )
+        with self._metrics_lock:
+            self._metrics["published"] += 1
+        self._queue.put(event)
+
+    def wait_for_idle(self, timeout: Optional[float] = None) -> bool:
+        """Block until all queued tasks complete or ``timeout`` seconds elapse."""
+
+        deadline = None if timeout is None else time.monotonic() + timeout
+        while True:
+            if self._queue.unfinished_tasks == 0:
+                return True
+            if deadline is not None and time.monotonic() >= deadline:
+                return False
+            time.sleep(0.01)
+
+    def get_metrics(self) -> Dict[str, int]:
+        """Return counters describing bus activity."""
+
+        with self._metrics_lock:
+            return dict(self._metrics)
+
+    def shutdown(self) -> None:
+        """Signal worker threads to exit after draining the queue."""
+
+        self._shutdown.set()
+        for _ in self._workers:
+            self._queue.put(None)  # type: ignore[arg-type]
+        for worker in self._workers:
+            worker.join(timeout=1.0)
+
+    def _worker(self) -> None:
+        while not self._shutdown.is_set():
+            try:
+                item = self._queue.get(timeout=0.1)
+            except Empty:
+                continue
+            if item is None:
+                self._queue.task_done()
+                break
+            try:
+                callbacks = self._get_callbacks(item.event_type)
+                for callback in callbacks:
+                    try:
+                        callback(item.event_type, dict(item.payload))
+                        with self._metrics_lock:
+                            self._metrics["delivered"] += 1
+                    except Exception:
+                        with self._metrics_lock:
+                            self._metrics["failed"] += 1
+                if not callbacks:
+                    with self._metrics_lock:
+                        self._metrics["dropped"] += 1
+            finally:
+                self._queue.task_done()
+
+    def _get_callbacks(self, event_type: str) -> List[QAEventCallback]:
+        with self._lock:
+            return list(self._subscribers.get(event_type, ()))
+
+
+# === Error & Edge Case Handling ===
+# Validation ensures event types are provided, callbacks are callable, and payloads are dictionaries.
+# The worker loop guards against subscriber exceptions to keep the bus running, and shutdown drains
+# queued events before exiting.
+
+
+# === Performance / Resource Considerations ===
+# Asynchronous workers decouple publishers from subscribers, preventing individual callbacks from
+# blocking unrelated pipelines. Metrics offer lightweight observability for queue throughput.
+
+
+# === Exports / Public API ===
+__all__ = ["QAEventBus", "QAEventCallback"]

--- a/meta_agent/qa_rules_loader.py
+++ b/meta_agent/qa_rules_loader.py
@@ -1,0 +1,62 @@
+"""Loader utilities for governance rules that influence arbitration decisions."""
+
+# === Imports / Dependencies ===
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional
+
+
+# === Types, Interfaces, Contracts, Schema ===
+class GovernanceRules:
+    """Immutable view over governance priorities per metric and agent."""
+
+    def __init__(self, priorities: Optional[Mapping[str, Mapping[str, float]]] = None) -> None:
+        self._priorities: Dict[str, Dict[str, float]] = {}
+        if priorities:
+            for metric, agents in priorities.items():
+                self._priorities[metric] = {
+                    str(agent): float(weight) for agent, weight in agents.items()
+                }
+
+    def get_priority(self, metric: Optional[str], agent: Optional[str]) -> float:
+        """Return governance priority for ``agent`` on ``metric`` (defaults to ``1.0``)."""
+
+        if not metric or not agent:
+            return 1.0
+        return self._priorities.get(metric, {}).get(agent, 1.0)
+
+    def as_dict(self) -> Dict[str, Dict[str, float]]:
+        """Expose priorities for debugging and audits."""
+
+        return {metric: dict(agents) for metric, agents in self._priorities.items()}
+
+
+def load_governance_rules(path: Optional[Path] = None) -> GovernanceRules:
+    """Load governance rules from ``path`` or default location if available."""
+
+    search_paths = []
+    if path is not None:
+        search_paths.append(Path(path))
+    search_paths.append(Path("config/governance_rules.json"))
+    for candidate in search_paths:
+        if candidate.is_file():
+            try:
+                data = json.loads(candidate.read_text(encoding="utf-8"))
+                return GovernanceRules(data.get("priorities", {}))
+            except (OSError, ValueError, TypeError, AttributeError):
+                break
+    return GovernanceRules()
+
+
+# === Error & Edge Case Handling ===
+# Invalid or missing rule files fall back to empty governance data, effectively using neutral priorities.
+
+
+# === Performance / Resource Considerations ===
+# Rule files are loaded eagerly once per process invocation; the resulting structure is a small nested dict.
+
+
+# === Exports / Public API ===
+__all__ = ["GovernanceRules", "load_governance_rules"]

--- a/meta_agent/tests/test_arbitration_engine.py
+++ b/meta_agent/tests/test_arbitration_engine.py
@@ -1,0 +1,42 @@
+"""ArbitrationEngine conflict resolution tests."""
+
+# === Imports / Dependencies ===
+from __future__ import annotations
+
+from meta_agent.arbitration_engine import ArbitrationDecision, ArbitrationEngine
+
+
+# === Tests ===
+
+def test_resolve_conflict_with_priority() -> None:
+    """Higher governance priority should outweigh raw trust."""
+
+    engine = ArbitrationEngine()
+    engine.governance.get_priority = lambda metric, agent: {"A": 1.5, "B": 1.0}.get(agent, 1.0)
+    conflicts = [
+        {"agent": "A", "metric": "latency"},
+        {"agent": "B", "metric": "latency"},
+    ]
+    decision = engine.resolve_conflict(conflicts, {"A": 1.0, "B": 1.2})
+    assert isinstance(decision, ArbitrationDecision)
+    assert decision.winner == "A"
+    assert decision.rationale["method"] == "trust_priority_weighting"
+
+
+def test_default_agent_on_empty_conflicts() -> None:
+    """Missing conflicts should resolve to the neutral "unknown" agent."""
+
+    engine = ArbitrationEngine()
+    decision = engine.resolve_conflict([], {"A": 1.0})
+    assert decision.winner == "unknown"
+
+
+def test_collect_ready_conflicts_after_stale_timeout() -> None:
+    """Single events should resolve once the staleness horizon is exceeded."""
+
+    engine = ArbitrationEngine(stale_after=0.0)
+    engine.add_event({"agent": "solo", "metric": "uptime"})
+    conflicts = engine.collect_ready_conflicts("uptime")
+    assert conflicts, "Stale single event should be returned for resolution"
+    assert conflicts[0]["agent"] == "solo"
+    assert "event_id" in conflicts[0]

--- a/meta_agent/tests/test_drift_detector.py
+++ b/meta_agent/tests/test_drift_detector.py
@@ -1,0 +1,64 @@
+"""Tests for DriftDetector sliding window drift logic."""
+
+# === Imports / Dependencies ===
+from __future__ import annotations
+
+from meta_agent.drift_detector import DriftDetector
+
+
+# === Tests ===
+
+def test_is_drift_detects_repeated_failures() -> None:
+    """Two failures within the window should trigger drift detection."""
+
+    detector = DriftDetector(window_size=3, threshold=2)
+    detector.record_event("agent-A", "latency", "fail")
+    detector.record_event("agent-A", "latency", "fail")
+    assert detector.is_drift()
+
+
+def test_no_drift_with_insufficient_fails() -> None:
+    """Single failure must not trigger drift when threshold requires more."""
+
+    detector = DriftDetector(window_size=3, threshold=2)
+    detector.record_event("agent-A", "latency", "fail")
+    assert not detector.is_drift()
+
+
+def test_propose_without_drift_raises() -> None:
+    """Requesting an amendment without drift should raise an error."""
+
+    detector = DriftDetector(window_size=3, threshold=2)
+    try:
+        detector.propose_amendment()
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("Expected RuntimeError when proposing without drift")
+
+
+def test_propose_amendment_contains_context() -> None:
+    """Amendment proposals should include agent and metric context."""
+
+    detector = DriftDetector(window_size=3, threshold=2)
+    detector.record_event("agent-A", "latency", "fail")
+    detector.record_event("agent-A", "latency", "fail")
+    assert detector.is_drift()
+    proposal = detector.propose_amendment()
+    assert proposal["action"] == "review"
+    assert proposal["agent"] == "agent-A"
+    assert proposal["metric"] == "latency"
+    assert proposal["severity"] in {"moderate", "high"}
+    assert proposal["fail_count"] >= 2
+    assert "QA.md" in proposal["recommended_documents"]
+
+
+def test_disabled_events_request_agents_doc() -> None:
+    """Repeated disables should reference AGENTS.md for remediation guidance."""
+
+    detector = DriftDetector(window_size=3, threshold=2)
+    detector.record_event("agent-A", "availability", "disabled")
+    detector.record_event("agent-A", "availability", "disabled")
+    assert detector.is_drift()
+    proposal = detector.propose_amendment()
+    assert "AGENTS.md" in proposal["recommended_documents"]

--- a/meta_agent/tests/test_macro_dependency_manager.py
+++ b/meta_agent/tests/test_macro_dependency_manager.py
@@ -1,0 +1,65 @@
+"""Unit tests for MacroDependencyManager compatibility orchestration."""
+
+# === Imports / Dependencies ===
+from __future__ import annotations
+
+import pytest
+
+from pathlib import Path
+
+from meta_agent.macro_dependency_manager import MacroDependencyManager
+
+
+# === Tests ===
+
+def test_register_macro_blocks_until_dependency_known() -> None:
+    """Macros should be blocked until dependencies have known schemas."""
+
+    manager = MacroDependencyManager()
+    state = manager.register_macro("analytics", "1.0", {"catalog": "2.0"})
+    assert state.blocked
+    assert state.reason == "dependency catalog schema unknown"
+    assert manager.get_blocked_macros()["analytics"] == state.reason
+    assert "initialized_at" in state.diff
+
+
+def test_dependency_updates_toggle_block_state() -> None:
+    """Dependency schema updates should unblock or re-block macros based on compatibility."""
+
+    manager = MacroDependencyManager()
+    manager.register_macro("analytics", "1.0", {"catalog": "2.0"})
+    updates = manager.update_dependency_schema("catalog", "2.0")
+    assert updates and updates[-1].blocked is False
+    assert updates[-1].diff["blocked"]["after"] is False
+    assert manager.is_blocked("analytics") is False
+
+    updates = manager.update_dependency_schema("catalog", "3.0")
+    assert updates and updates[-1].blocked is True
+    assert "schema mismatch" in (updates[-1].reason or "")
+    assert manager.get_block_reason("analytics") == updates[-1].reason
+
+
+def test_persistence_round_trip(tmp_path: Path) -> None:
+    """Manager should persist macro state and dependency versions to disk."""
+
+    storage = tmp_path / "macros.json"
+    manager = MacroDependencyManager(storage)
+    manager.register_macro("analytics", "1.0", {"catalog": "2.0"})
+    manager.update_dependency_schema("catalog", "2.0")
+
+    reloaded = MacroDependencyManager(storage)
+    assert reloaded.is_blocked("analytics") is False
+    state = reloaded.get_state("analytics")
+    assert state.dependencies["catalog"] == "2.0"
+
+
+def test_register_macro_requires_name() -> None:
+    """Attempting to register an unnamed macro should raise a validation error."""
+
+    manager = MacroDependencyManager()
+    with pytest.raises(ValueError):
+        manager.register_macro("", "1.0", {})
+
+
+# === Performance / Resource Considerations ===
+# Tests cover only logical correctness; performance characteristics are validated indirectly via targeted evaluations.

--- a/meta_agent/tests/test_meta_agent_v2.py
+++ b/meta_agent/tests/test_meta_agent_v2.py
@@ -1,0 +1,179 @@
+"""Integration tests for MetaAgent v2 orchestration."""
+
+# === Imports / Dependencies ===
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import pytest
+
+from meta_agent.arbitration_engine import ArbitrationEngine
+from meta_agent.drift_detector import DriftDetector
+from meta_agent.fallback_manager import FallbackManager
+from meta_agent.macro_dependency_manager import MacroDependencyManager
+from meta_agent.meta_agent_v2 import MetaAgent
+from meta_agent.qa_event_bus import QAEventBus
+from meta_agent.trust_engine import TrustEngine
+
+
+# === Fixtures ===
+@pytest.fixture()
+def meta_stack(tmp_path: Path) -> Dict[str, object]:
+    """Construct a MetaAgent with in-memory dependencies for tests."""
+
+    trust_path = tmp_path / "trust.json"
+    log_path = tmp_path / "arbitrations.jsonl"
+    fallback_calls: List[Tuple[float, float]] = []
+
+    def latency_fallback(value: float, threshold: float) -> None:
+        fallback_calls.append((value, threshold))
+
+    trust_engine = TrustEngine(trust_path)
+    arbitration = ArbitrationEngine()
+    drift = DriftDetector(window_size=3, threshold=2)
+    fallback = FallbackManager({"latency": latency_fallback})
+    macro_manager = MacroDependencyManager()
+    bus = QAEventBus()
+    agent = MetaAgent(trust_engine, arbitration, drift, fallback, macro_manager, bus, log_path)
+    return {
+        "agent": agent,
+        "bus": bus,
+        "fallback_calls": fallback_calls,
+        "log_path": log_path,
+        "macro_manager": macro_manager,
+    }
+
+
+# === Tests ===
+
+def test_arbitration_prefers_high_trust(meta_stack: Dict[str, object]) -> None:
+    """When conflicts arise, the higher-trust agent should win the decision."""
+
+    bus: QAEventBus = meta_stack["bus"]  # type: ignore[assignment]
+    agent: MetaAgent = meta_stack["agent"]  # type: ignore[assignment]
+    decisions: List[Dict[str, object]] = []
+    bus.subscribe("qa_arbitration", lambda event_type, payload: decisions.append(payload))
+    agent.trust_engine.trust_scores.update({"alpha": 1.2, "beta": 0.8})
+    bus.publish(
+        "qa_failure",
+        {"agent": "beta", "metric": "latency", "value": 320.0, "threshold": 300.0},
+    )
+    bus.publish(
+        "qa_success",
+        {"agent": "alpha", "metric": "latency", "value": 250.0, "threshold": 300.0},
+    )
+    assert bus.wait_for_idle(timeout=1.0)
+    assert decisions, "Arbitration decision should be emitted"
+    assert decisions[-1]["winner"] == "alpha"
+    assert decisions[-1]["rationale"]["confidence"] >= 0
+    log_path: Path = meta_stack["log_path"]  # type: ignore[assignment]
+    assert log_path.exists()
+    log_entries = [line for line in log_path.read_text().splitlines() if line.strip()]
+    assert any("\"winner\": \"alpha\"" in entry for entry in log_entries)
+
+
+def test_trust_updates_on_failure_and_success(meta_stack: Dict[str, object]) -> None:
+    """MetaAgent should adjust trust after failure and success events."""
+
+    bus: QAEventBus = meta_stack["bus"]  # type: ignore[assignment]
+    agent: MetaAgent = meta_stack["agent"]  # type: ignore[assignment]
+    initial = agent.trust_engine.get_trust_scores().get("gamma", 1.0)
+    bus.publish(
+        "qa_failure",
+        {"agent": "gamma", "metric": "accuracy", "value": 0.5, "threshold": 0.9},
+    )
+    assert bus.wait_for_idle(timeout=1.0)
+    after_failure = agent.trust_engine.get_trust_scores()["gamma"]
+    assert after_failure < initial
+    bus.publish(
+        "qa_success",
+        {"agent": "gamma", "metric": "accuracy", "value": 0.95, "threshold": 0.9},
+    )
+    assert bus.wait_for_idle(timeout=1.0)
+    after_success = agent.trust_engine.get_trust_scores()["gamma"]
+    assert after_success > after_failure
+
+
+def test_success_synonym_updates_trust(meta_stack: Dict[str, object]) -> None:
+    """Status synonyms like 'success' should promote trust just like 'pass'."""
+
+    bus: QAEventBus = meta_stack["bus"]  # type: ignore[assignment]
+    agent: MetaAgent = meta_stack["agent"]  # type: ignore[assignment]
+    initial = agent.trust_engine.get_trust_scores().get("theta", 1.0)
+    bus.publish(
+        "qa_success",
+        {"agent": "theta", "metric": "accuracy", "value": 0.98, "threshold": 0.9, "status": "success"},
+    )
+    assert bus.wait_for_idle(timeout=1.0)
+    after_success = agent.trust_engine.get_trust_scores()["theta"]
+    assert after_success > initial
+
+
+def test_macro_dependency_blocking(meta_stack: Dict[str, object]) -> None:
+    """Macro manager should block on incompatibility and unblock when schemas align."""
+
+    bus: QAEventBus = meta_stack["bus"]  # type: ignore[assignment]
+    agent: MetaAgent = meta_stack["agent"]  # type: ignore[assignment]
+    states: List[Dict[str, object]] = []
+    bus.subscribe("macro_blocked", lambda event_type, payload: states.append({"event": event_type, **payload}))
+    bus.subscribe("macro_unblocked", lambda event_type, payload: states.append({"event": event_type, **payload}))
+
+    bus.publish(
+        "macro_definition",
+        {
+            "macro": "reporting",
+            "schema_version": "1.0",
+            "dependencies": {"inventory": "2.0"},
+        },
+    )
+    assert bus.wait_for_idle(timeout=1.0)
+    assert states, "Macro definition should emit a state event"
+    assert states[-1]["event"] == "macro_blocked"
+    assert states[-1]["reason"] == "dependency inventory schema unknown"
+    assert agent.macro_manager.is_blocked("reporting")
+
+    bus.publish("macro_dependency_update", {"dependency": "inventory", "schema_version": "2.0"})
+    assert bus.wait_for_idle(timeout=1.0)
+    assert states[-1]["event"] == "macro_unblocked"
+    assert agent.macro_manager.is_blocked("reporting") is False
+
+    bus.publish("macro_dependency_update", {"dependency": "inventory", "schema_version": "3.0"})
+    assert bus.wait_for_idle(timeout=1.0)
+    assert states[-1]["event"] == "macro_blocked"
+    assert "schema mismatch" in str(states[-1]["reason"])
+
+
+def test_drift_detection_emits_proposal(meta_stack: Dict[str, object]) -> None:
+    """Repeated failures should publish a drift amendment proposal."""
+
+    bus: QAEventBus = meta_stack["bus"]  # type: ignore[assignment]
+    drift_events: List[Dict[str, object]] = []
+    bus.subscribe("qa_drift", lambda event_type, payload: drift_events.append(payload))
+    bus.publish(
+        "qa_failure",
+        {"agent": "delta", "metric": "latency", "value": 340.0, "threshold": 300.0},
+    )
+    bus.publish(
+        "qa_failure",
+        {"agent": "delta", "metric": "latency", "value": 360.0, "threshold": 300.0},
+    )
+    assert bus.wait_for_idle(timeout=1.0)
+    assert drift_events
+    proposal = drift_events[-1]
+    assert proposal["reason"] == "repeated test failures"
+    assert proposal["metric"] == "latency"
+    assert "severity" in proposal
+
+
+def test_fallback_trigger_invoked(meta_stack: Dict[str, object]) -> None:
+    """Fallback manager should be invoked when thresholds are exceeded."""
+
+    bus: QAEventBus = meta_stack["bus"]  # type: ignore[assignment]
+    fallback_calls: List[Tuple[float, float]] = meta_stack["fallback_calls"]  # type: ignore[assignment]
+    bus.publish(
+        "qa_failure",
+        {"agent": "epsilon", "metric": "latency", "value": 400.0, "threshold": 300.0},
+    )
+    assert bus.wait_for_idle(timeout=1.0)
+    assert fallback_calls == [(400.0, 300.0)]

--- a/meta_agent/tests/test_trust_engine.py
+++ b/meta_agent/tests/test_trust_engine.py
@@ -1,0 +1,51 @@
+"""Tests for TrustEngine persistence and Bayesian updates."""
+
+# === Imports / Dependencies ===
+from __future__ import annotations
+
+from pathlib import Path
+
+from meta_agent.trust_engine import TrustEngine
+
+
+# === Tests ===
+
+def test_initial_load_empty(tmp_path: Path) -> None:
+    """TrustEngine should start with no scores when storage is empty."""
+
+    path = tmp_path / "trust.json"
+    engine = TrustEngine(path)
+    assert engine.trust_scores == {}
+
+
+def test_record_failure_and_success(tmp_path: Path) -> None:
+    """Failures reduce trust while successes increase it with bounds applied."""
+
+    path = tmp_path / "trust.json"
+    engine = TrustEngine(path)
+    engine.record_failure("agent-A")
+    assert engine.trust_scores["agent-A"] == 0.9
+    engine.record_success("agent-A")
+    assert engine.trust_scores["agent-A"] > 0.9
+
+
+def test_persistence(tmp_path: Path) -> None:
+    """Trust scores persist across engine restarts."""
+
+    path = tmp_path / "trust.json"
+    engine = TrustEngine(path)
+    engine.record_failure("agent-A")
+    engine = TrustEngine(path)
+    assert "agent-A" in engine.trust_scores
+
+
+def test_flush_compacts_journal(tmp_path: Path) -> None:
+    """Explicit flush should persist snapshot and clear the journal."""
+
+    path = tmp_path / "trust.json"
+    engine = TrustEngine(path, flush_interval=100)
+    engine.record_failure("agent-A")
+    assert engine.journal_path.exists()
+    engine.flush()
+    assert path.exists()
+    assert not engine.journal_path.exists()

--- a/meta_agent/trust_engine.py
+++ b/meta_agent/trust_engine.py
@@ -1,0 +1,170 @@
+"""Trust score engine with append-only durability and Bayesian-style updates."""
+
+# === Imports / Dependencies ===
+from __future__ import annotations
+
+import json
+import os
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+import contextlib
+
+
+# === Types, Interfaces, Contracts, Schema ===
+@dataclass(frozen=True)
+class _JournalEntry:
+    """Structured representation of a trust score mutation."""
+
+    agent: str
+    score: float
+    event: str
+    timestamp: str
+
+
+class TrustEngine:
+    """Maintain agent trust scores backed by durable journaled storage."""
+
+    def __init__(self, storage_path: Path, flush_interval: int = 10) -> None:
+        self.storage_path = storage_path
+        self.journal_path = storage_path.with_suffix(f"{storage_path.suffix}.journal")
+        self.trust_scores: Dict[str, float] = {}
+        self._flush_interval = max(1, flush_interval)
+        self._pending_writes = 0
+        self._lock = threading.RLock()
+        self._ensure_storage_dir()
+        self.load()
+
+    def _ensure_storage_dir(self) -> None:
+        self.storage_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def load(self) -> None:
+        """Load trust snapshot and replay journal to reconstruct state."""
+
+        with self._lock:
+            self.trust_scores = self._load_snapshot()
+            for entry in self._read_journal():
+                self.trust_scores[entry.agent] = entry.score
+
+    def _load_snapshot(self) -> Dict[str, float]:
+        try:
+            raw_text = self.storage_path.read_text(encoding="utf-8")
+        except (FileNotFoundError, OSError):
+            return {}
+        try:
+            data = json.loads(raw_text)
+        except (ValueError, TypeError):
+            return {}
+        if not isinstance(data, dict):
+            return {}
+        snapshot: Dict[str, float] = {}
+        for agent, score in data.items():
+            try:
+                snapshot[str(agent)] = float(score)
+            except (TypeError, ValueError):
+                continue
+        return snapshot
+
+    def _read_journal(self) -> Iterable[_JournalEntry]:
+        try:
+            lines = self.journal_path.read_text(encoding="utf-8").splitlines()
+        except FileNotFoundError:
+            return []
+        except OSError:
+            return []
+        entries = []
+        for line in lines:
+            if not line.strip():
+                continue
+            try:
+                payload = json.loads(line)
+                agent = str(payload["agent"])
+                score = float(payload["score"])
+                event = str(payload.get("event", "update"))
+                timestamp = str(payload.get("timestamp", ""))
+            except (ValueError, TypeError, KeyError):
+                continue
+            entries.append(_JournalEntry(agent=agent, score=score, event=event, timestamp=timestamp))
+        return entries
+
+    def save(self) -> None:
+        """Persist the current state to a compact snapshot and truncate the journal."""
+
+        self.flush()
+
+    def flush(self) -> None:
+        """Explicitly persist a snapshot and clear the journal."""
+
+        with self._lock:
+            serialized = json.dumps(self.trust_scores, sort_keys=True)
+            temp_path = self.storage_path.with_suffix(f"{self.storage_path.suffix}.tmp")
+            try:
+                temp_path.write_text(serialized, encoding="utf-8")
+                os.replace(temp_path, self.storage_path)
+                if self.journal_path.exists():
+                    self.journal_path.unlink()
+                self._pending_writes = 0
+            except OSError:
+                # If persistence fails we keep the journal for replay and remove temp file if present.
+                with contextlib.suppress(FileNotFoundError, OSError):
+                    temp_path.unlink()
+
+    def record_failure(self, agent: str) -> None:
+        """Demote trust for ``agent`` in response to a failure event."""
+
+        self._record(agent, multiplier=0.9, minimum=0.1, maximum=1.5, event="failure")
+
+    def record_success(self, agent: str) -> None:
+        """Promote trust for ``agent`` when a success event is observed."""
+
+        self._record(agent, multiplier=1.05, minimum=0.1, maximum=1.5, event="success")
+
+    def _record(self, agent: Optional[str], multiplier: float, minimum: float, maximum: float, event: str) -> None:
+        if not agent:
+            return
+        with self._lock:
+            score = self.trust_scores.get(agent, 1.0)
+            new_score = max(min(score * multiplier, maximum), minimum)
+            self.trust_scores[agent] = new_score
+            self._append_journal(agent, new_score, event)
+            self._pending_writes += 1
+            if self._pending_writes >= self._flush_interval:
+                self._pending_writes = 0
+                self.flush()
+
+    def _append_journal(self, agent: str, score: float, event: str) -> None:
+        entry = {
+            "agent": agent,
+            "score": score,
+            "event": event,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        try:
+            with self.journal_path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(entry, sort_keys=True))
+                handle.write("\n")
+        except OSError:
+            # Journaling failure leaves state in-memory; snapshot on next flush will recover.
+            pass
+
+    def get_trust_scores(self) -> Dict[str, float]:
+        """Return a copy of current trust scores for arbitration."""
+
+        with self._lock:
+            return dict(self.trust_scores)
+
+
+# === Error & Edge Case Handling ===
+# Missing or corrupt snapshots or journal entries revert gracefully to empty defaults. Journal write
+# failures leave state in memory until the next successful flush, preserving durability through replay.
+
+
+# === Performance / Resource Considerations ===
+# Journaling performs append-only writes and batches snapshot compaction every ``flush_interval`` events.
+# Thread locks guard concurrent updates while keeping read access lightweight.
+
+
+# === Exports / Public API ===
+__all__ = ["TrustEngine"]


### PR DESCRIPTION
## Summary
- move the meta agent orchestration modules, documentation, and tests into a dedicated `meta_agent/` package directory
- add a package `__init__` that re-exports the primary orchestration types and update intra-package imports to use the new namespace
- update the pytest suites to import from the `meta_agent` package so test coverage continues to exercise the refactored layout

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d28f11ceac832186c3edb43730b20d