### PR TITLE
feat: add calibrated probabilistic qa

### DIFF
--- a/config/governance.json
+++ b/config/governance.json
@@ -18,7 +18,12 @@
   },
   "drift_detection": {
     "window_size": 5,
-    "failure_threshold": 3
+    "failure_threshold": 3,
+    "psi_threshold": 0.2,
+    "ks_threshold": 0.1,
+    "kl_threshold": 0.05,
+    "min_samples": 50,
+    "bin_count": 10
   },
   "fallbacks": {
     "latency": "macro_id_latency_fallback",

--- a/config/governance.schema.json
+++ b/config/governance.schema.json
@@ -54,6 +54,26 @@
         "failure_threshold": {
           "type": "integer",
           "minimum": 1
+        },
+        "psi_threshold": {
+          "type": "number",
+          "minimum": 0
+        },
+        "ks_threshold": {
+          "type": "number",
+          "minimum": 0
+        },
+        "kl_threshold": {
+          "type": "number",
+          "minimum": 0
+        },
+        "min_samples": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "bin_count": {
+          "type": "integer",
+          "minimum": 2
         }
       },
       "additionalProperties": false

--- a/docs/QA_ENGINE.md
+++ b/docs/QA_ENGINE.md
@@ -2,31 +2,57 @@
 
 ## Purpose
 
-Explain how probabilistic evaluation complements deterministic QA rules by introducing confidence-aware decisions.
+Explain how probabilistic evaluation complements deterministic QA rules by introducing confidence-aware decisions, calibrated probabilities, and governance-aligned thresholds.
 
 ## Key Concepts
 
 - **Distributions** – Metrics represented by mean and standard deviation to model variability.
+- **Calibration** – Platt-scaling produces well-calibrated probabilities from historical QA outcomes.
 - **Z-Scores** – Normalise thresholds relative to distribution parameters.
 - **Pass Probability** – Converts z-scores to probabilities for comparisons against governance confidence targets.
-- **Confidence Intervals** – Provide bounds on expected metric behaviour for planning.
+- **Confidence Reports** – Summarise expected win-rate, Brier score, calibration error, and bootstrap confidence intervals.
 
 ## Usage
 
 ```python
-from qa_engine import evaluate_metric
+from qa_engine import (
+    confidence_report,
+    evaluate_calibrated_metric,
+    platt_calibration,
+)
 
-latency_distribution = {"mean": 240.0, "std": 25.0}
-if evaluate_metric(255.0, latency_distribution, confidence=0.95):
-    print("Latency within expectations")
-else:
-    print("Investigate latency regression")
+# Historical QA measurements and pass/fail outcomes
+latency_scores = [240.0, 242.0, 238.0, 260.0, 280.0]
+latency_passes = [1, 1, 1, 0, 0]
+calibration = platt_calibration(latency_scores, latency_passes, min_samples=5)
+
+# Evaluate a fresh latency value against Codex governance targets
+passed, report, probability = evaluate_calibrated_metric(
+    value=250.0,
+    calibration=calibration,
+    historical_scores=latency_scores,
+    historical_labels=latency_passes,
+    confidence=0.95,
+)
+
+print("Probability of passing:", probability)
+print("Meets governance threshold:", passed)
+print("Report:", report.as_dict())
+
+# Generate a confidence report for dashboards or CI logs
+dashboard_report = confidence_report(
+    calibration.predict(latency_scores),
+    latency_passes,
+    confidence_level=0.95,
+)
 ```
+
+`config/qa_policies.json` defines target confidences for governed metrics. Updating those thresholds keeps CI enforcement and documentation in sync.
 
 ## CLI & Automation
 
-- Run `python scripts/validate_configs.py` before commits to ensure probabilistic policies align with schemas.
-- CI executes `tests/test_probabilistic_qa.py` to verify statistical helpers.
+- Run `python scripts/validate_configs.py` before commits to ensure probabilistic policies align with schemas (`qa_policies.json`).
+- CI executes `tests/test_probabilistic_qa.py` and `tests/test_statistics_helpers.py` to verify statistical helpers, calibration logic, and governance alignment.
 
 ## Extension Ideas
 

--- a/meta_agent/__init__.py
+++ b/meta_agent/__init__.py
@@ -2,7 +2,7 @@
 
 from .arbitration_engine import ArbitrationDecision, ArbitrationEngine
 from .config_loader import ConfigLoader
-from .drift_detector import DriftDetector
+from .drift_detector import DriftDetector, DriftMetricResult, DriftReport
 from .fallback_manager import FallbackManager
 from .logger import Logger
 from .macro_dependency_manager import MacroDependencyManager, MacroState
@@ -17,6 +17,8 @@ __all__ = [
     "ArbitrationEngine",
     "ConfigLoader",
     "DriftDetector",
+    "DriftMetricResult",
+    "DriftReport",
     "FallbackManager",
     "Logger",
     "MacroDependencyManager",

--- a/meta_agent/drift_detector.py
+++ b/meta_agent/drift_detector.py
@@ -1,28 +1,181 @@
-"""Sliding window drift detection for QA metrics and governance rules."""
+"""Sliding window and statistical drift detection utilities."""
 
 # === Imports / Dependencies ===
 from __future__ import annotations
 
+import math
 from collections import defaultdict, deque
-from typing import Any, Deque, Dict, List, Optional, Tuple
+from dataclasses import dataclass, field
+from typing import Any, Deque, Dict, Iterable, List, Optional, Sequence, Tuple
+
+import numpy as np
 
 
 # === Types, Interfaces, Contracts, Schema ===
-class DriftDetector:
-    """Track metric outcomes and flag repeated failures that suggest drift."""
+@dataclass(frozen=True)
+class DriftMetricResult:
+    """Result for a single drift metric evaluation."""
 
-    def __init__(self, window_size: int = 5, threshold: int = 3) -> None:
+    metric: str
+    score: float
+    threshold: float
+    drift_detected: bool
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Return a serialisable representation of the metric result."""
+
+        return {
+            "metric": self.metric,
+            "score": self.score,
+            "threshold": self.threshold,
+            "drift_detected": self.drift_detected,
+        }
+
+
+@dataclass(frozen=True)
+class DriftReport:
+    """Structured drift report containing metric-level outcomes."""
+
+    results: List[DriftMetricResult] = field(default_factory=list)
+    drift_detected: bool = False
+    reference_size: int = 0
+    live_size: int = 0
+    details: Dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Return a serialisable dictionary view of the report."""
+
+        return {
+            "drift_detected": self.drift_detected,
+            "metrics": [result.as_dict() for result in self.results],
+            "reference_size": self.reference_size,
+            "live_size": self.live_size,
+            "details": dict(self.details),
+        }
+
+
+def _coerce_numeric(values: Iterable[float]) -> np.ndarray:
+    """Return numeric, finite values from ``values`` as a NumPy array."""
+
+    cleaned: List[float] = []
+    for value in values:
+        try:
+            numeric = float(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(numeric):
+            cleaned.append(numeric)
+    return np.asarray(cleaned, dtype=float)
+
+
+def _resolve_edges(reference: np.ndarray, live: np.ndarray, bins: int) -> np.ndarray:
+    """Compute histogram edges covering both reference and live arrays."""
+
+    bins = max(2, int(bins))
+    if reference.size == 0 and live.size == 0:
+        return np.linspace(0.0, 1.0, bins + 1)
+    candidate_min = float(
+        min(([reference.min()] if reference.size else []) + ([live.min()] if live.size else []))
+    )
+    candidate_max = float(
+        max(([reference.max()] if reference.size else []) + ([live.max()] if live.size else []))
+    )
+    if candidate_min == candidate_max:
+        candidate_min -= 0.5
+        candidate_max += 0.5
+    return np.linspace(candidate_min, candidate_max, bins + 1)
+
+
+def population_stability_index(reference: np.ndarray, live: np.ndarray, bins: int) -> float:
+    """Return the population stability index between ``reference`` and ``live``."""
+
+    if reference.size == 0 or live.size == 0:
+        return 0.0
+    edges = _resolve_edges(reference, live, bins)
+    ref_counts, _ = np.histogram(reference, bins=edges)
+    live_counts, _ = np.histogram(live, bins=edges)
+    total_ref = ref_counts.sum()
+    total_live = live_counts.sum()
+    if total_ref == 0 or total_live == 0:
+        return 0.0
+    epsilon = 1e-12
+    expected = ref_counts / total_ref
+    actual = live_counts / total_live
+    ratio = (actual + epsilon) / (expected + epsilon)
+    psi = np.sum((actual - expected) * np.log(ratio))
+    return float(abs(psi))
+
+
+def kolmogorov_smirnov_statistic(reference: np.ndarray, live: np.ndarray) -> float:
+    """Return the Kolmogorov-Smirnov statistic for the two samples."""
+
+    if reference.size == 0 or live.size == 0:
+        return 0.0
+    combined = np.concatenate([reference, live])
+    combined.sort()
+    ref_sorted = np.sort(reference)
+    live_sorted = np.sort(live)
+    ref_cdf = np.searchsorted(ref_sorted, combined, side="right") / ref_sorted.size
+    live_cdf = np.searchsorted(live_sorted, combined, side="right") / live_sorted.size
+    return float(np.max(np.abs(ref_cdf - live_cdf)))
+
+
+def kl_divergence(reference: np.ndarray, live: np.ndarray, bins: int) -> float:
+    """Return the KL divergence ``D_live||reference`` using shared histogram bins."""
+
+    if reference.size == 0 or live.size == 0:
+        return 0.0
+    edges = _resolve_edges(reference, live, bins)
+    ref_counts, _ = np.histogram(reference, bins=edges)
+    live_counts, _ = np.histogram(live, bins=edges)
+    total_ref = ref_counts.sum()
+    total_live = live_counts.sum()
+    if total_ref == 0 or total_live == 0:
+        return 0.0
+    epsilon = 1e-12
+    ref_prob = (ref_counts + epsilon) / (total_ref + epsilon * len(ref_counts))
+    live_prob = (live_counts + epsilon) / (total_live + epsilon * len(live_counts))
+    divergence = float(np.sum(live_prob * np.log(live_prob / ref_prob)))
+    return max(divergence, 0.0)
+
+
+class DriftDetector:
+    """Track metric outcomes and flag repeated failures or statistical drift."""
+
+    def __init__(
+        self,
+        window_size: int = 5,
+        threshold: int = 3,
+        *,
+        psi_threshold: float = 0.2,
+        ks_threshold: float = 0.1,
+        kl_threshold: float = 0.1,
+        min_samples: int = 50,
+        bin_count: int = 10,
+    ) -> None:
         if window_size <= 0:
             raise ValueError("window_size must be positive")
         if threshold <= 0:
             raise ValueError("threshold must be positive")
+        if min_samples <= 0:
+            raise ValueError("min_samples must be positive")
+        if bin_count < 2:
+            raise ValueError("bin_count must be at least 2")
         self.window_size = window_size
         self.threshold = threshold
+        self.min_samples = min_samples
+        self.bin_count = bin_count
         self.history: Dict[Tuple[str, str], Deque[str]] = defaultdict(
             lambda: deque(maxlen=self.window_size)
         )
         self._last_drift: Optional[Dict[str, Any]] = None
+        self._last_report: Optional[DriftReport] = None
         self._proposals: List[Dict[str, Any]] = []
+        self._distribution_thresholds = {
+            "psi": float(psi_threshold),
+            "ks": float(ks_threshold),
+            "kl": float(kl_threshold),
+        }
 
     def record_event(self, agent: Optional[str], metric: Optional[str], status: str) -> None:
         """Record ``status`` for ``agent`` and ``metric`` in the sliding window."""
@@ -34,6 +187,55 @@ class DriftDetector:
         metadata = self._evaluate_window(agent, metric, window)
         if metadata:
             self._last_drift = metadata
+
+    def detect_distribution_drift(
+        self,
+        reference: Sequence[float] | Iterable[float],
+        live: Sequence[float] | Iterable[float],
+        *,
+        metric_name: str = "distribution",
+    ) -> DriftReport:
+        """Evaluate statistical drift using PSI, KS-test, and KL divergence."""
+
+        ref_array = _coerce_numeric(reference)
+        live_array = _coerce_numeric(live)
+        details: Dict[str, Any] = {
+            "min_samples": self.min_samples,
+        }
+        if ref_array.size < self.min_samples or live_array.size < self.min_samples:
+            details.update(
+                {
+                    "insufficient_data": True,
+                    "reference_size": int(ref_array.size),
+                    "live_size": int(live_array.size),
+                }
+            )
+            report = DriftReport([], False, int(ref_array.size), int(live_array.size), details)
+            self._last_report = report
+            return report
+
+        bin_count = max(2, min(self.bin_count, int(ref_array.size), int(live_array.size)))
+        details["bin_count"] = bin_count
+        psi_score = population_stability_index(ref_array, live_array, bin_count)
+        ks_score = kolmogorov_smirnov_statistic(ref_array, live_array)
+        kl_score = kl_divergence(ref_array, live_array, bin_count)
+        results = [
+            self._build_metric_result("psi", psi_score),
+            self._build_metric_result("ks", ks_score),
+            self._build_metric_result("kl", kl_score),
+        ]
+        drift_detected = any(result.drift_detected for result in results)
+        report = DriftReport(
+            results,
+            drift_detected,
+            int(ref_array.size),
+            int(live_array.size),
+            details,
+        )
+        self._last_report = report
+        if drift_detected:
+            self._register_statistical_drift(metric_name, report)
+        return report
 
     def is_drift(self) -> bool:
         """Return ``True`` when any tracked metric crosses the failure threshold."""
@@ -53,19 +255,34 @@ class DriftDetector:
         if self._last_drift is None and not self.is_drift():
             raise RuntimeError("no drift detected to propose amendment")
         metadata = self._last_drift or {}
-        proposal = {
+        reason = metadata.get("reason")
+        if not reason:
+            reason = (
+                "distribution drift detected"
+                if metadata.get("kind") == "statistical"
+                else "repeated test failures"
+            )
+        proposal: Dict[str, Any] = {
             "action": "review",
-            "reason": "repeated test failures",
+            "reason": reason,
             "agent": metadata.get("agent"),
             "metric": metadata.get("metric"),
-            "severity": metadata.get("severity"),
+            "severity": metadata.get("severity", "moderate"),
             "fail_count": metadata.get("fail_count", 0),
             "disabled_count": metadata.get("disabled_count", 0),
             "window_size": self.window_size,
             "threshold": self.threshold,
-            "recommended_documents": metadata.get("documents", ["QA.md"]),
+            "recommended_documents": metadata.get(
+                "documents", self._event_documents(metadata.get("disabled_count", 0))
+            ),
             "correlation_hint": metadata.get("correlation_hint"),
         }
+        if metadata.get("kind") == "statistical":
+            proposal["recommended_documents"] = metadata.get(
+                "documents", self._statistical_documents()
+            )
+            if self._last_report is not None:
+                proposal["drift_metrics"] = self._last_report.as_dict()
         self._proposals.append(proposal)
         self._last_drift = None
         return proposal
@@ -74,6 +291,53 @@ class DriftDetector:
         """Expose accumulated amendment proposals for auditing."""
 
         return list(self._proposals)
+
+    def _build_metric_result(self, metric: str, score: float) -> DriftMetricResult:
+        threshold = self._distribution_thresholds.get(metric, 0.0)
+        return DriftMetricResult(metric, float(score), threshold, float(score) > threshold)
+
+    def _register_statistical_drift(self, metric_name: str, report: DriftReport) -> None:
+        severity = self._severity_from_report(report)
+        metadata = {
+            "kind": "statistical",
+            "metric": metric_name,
+            "severity": severity,
+            "documents": self._statistical_documents(),
+            "fail_count": 0,
+            "disabled_count": 0,
+            "correlation_hint": metric_name,
+            "reason": "distribution drift detected",
+        }
+        if report.results:
+            metadata["report"] = report.as_dict()
+        self._last_drift = metadata
+
+    def _severity_from_report(self, report: DriftReport) -> str:
+        if not report.results:
+            return "moderate"
+        max_ratio = 0.0
+        for result in report.results:
+            if result.threshold <= 0:
+                continue
+            ratio = result.score / result.threshold
+            if ratio > max_ratio:
+                max_ratio = ratio
+        if max_ratio >= 2.0:
+            return "critical"
+        if max_ratio >= 1.25:
+            return "high"
+        return "moderate"
+
+    @staticmethod
+    def _event_documents(disabled_count: int) -> List[str]:
+        documents = ["QA.md"]
+        if disabled_count > 0:
+            documents.append("AGENTS.md")
+        return documents
+
+    @staticmethod
+    def _statistical_documents() -> List[str]:
+        return ["GOVERNANCE.md", "QA_ENGINE.md"]
 
     def _evaluate_window(
         self,
@@ -85,10 +349,9 @@ class DriftDetector:
         disabled_count = window.count("disabled")
         if fail_count >= self.threshold or disabled_count >= self.threshold:
             severity = "high" if fail_count >= self.threshold * 2 else "moderate"
-            documents = ["QA.md"]
-            if disabled_count >= self.threshold:
-                documents.append("AGENTS.md")
+            documents = self._event_documents(disabled_count)
             return {
+                "kind": "event",
                 "agent": agent,
                 "metric": metric,
                 "fail_count": fail_count,
@@ -96,6 +359,7 @@ class DriftDetector:
                 "severity": severity,
                 "documents": documents,
                 "correlation_hint": f"{agent}:{metric}",
+                "reason": "repeated test failures",
             }
         return None
 
@@ -103,11 +367,13 @@ class DriftDetector:
 # === Error & Edge Case Handling ===
 # Missing agent or metric identifiers are ignored. Invalid initialization parameters raise ``ValueError``.
 # Proposals are only generated when drift metadata exists to avoid empty recommendations.
+# Statistical drift gracefully handles insufficient samples and non-numeric values.
 
 
 # === Performance / Resource Considerations ===
 # Memory usage grows with ``window_size`` × number of (agent, metric) pairs. Operations are O(window_size).
+# Statistical evaluations rely on NumPy vectorisation for sub-second execution across thousands of samples.
 
 
 # === Exports / Public API ===
-__all__ = ["DriftDetector"]
+__all__ = ["DriftDetector", "DriftReport", "DriftMetricResult"]

--- a/meta_agent/engine.py
+++ b/meta_agent/engine.py
@@ -94,6 +94,11 @@ class MetaAgent:
         drift = DriftDetector(
             window_size=int(drift_cfg.get("window_size", 5)),
             threshold=int(drift_cfg.get("failure_threshold", 3)),
+            psi_threshold=float(drift_cfg.get("psi_threshold", 0.2)),
+            ks_threshold=float(drift_cfg.get("ks_threshold", 0.1)),
+            kl_threshold=float(drift_cfg.get("kl_threshold", 0.05)),
+            min_samples=int(drift_cfg.get("min_samples", 50)),
+            bin_count=int(drift_cfg.get("bin_count", 10)),
         )
         fallback = FallbackManager(fallbacks)
         macro_manager = MacroDependencyManager()

--- a/meta_agent/tests/test_drift_detector.py
+++ b/meta_agent/tests/test_drift_detector.py
@@ -3,10 +3,13 @@
 # === Imports / Dependencies ===
 from __future__ import annotations
 
+import numpy as np
+
 from meta_agent.drift_detector import DriftDetector
 
 
 # === Tests ===
+
 
 def test_is_drift_detects_repeated_failures() -> None:
     """Two failures within the window should trigger drift detection."""
@@ -62,3 +65,58 @@ def test_disabled_events_request_agents_doc() -> None:
     assert detector.is_drift()
     proposal = detector.propose_amendment()
     assert "AGENTS.md" in proposal["recommended_documents"]
+
+
+def test_distribution_drift_detects_shift() -> None:
+    """Distributional drift should generate a proposal with metric details."""
+
+    detector = DriftDetector(
+        window_size=3,
+        threshold=2,
+        psi_threshold=0.05,
+        ks_threshold=0.05,
+        kl_threshold=0.01,
+        min_samples=30,
+    )
+    rng = np.random.default_rng(42)
+    reference = rng.normal(loc=0.0, scale=1.0, size=300)
+    live = rng.normal(loc=2.5, scale=1.0, size=300)
+    report = detector.detect_distribution_drift(reference, live, metric_name="latency")
+    assert report.drift_detected
+    assert any(result.metric == "psi" and result.drift_detected for result in report.results)
+    proposal = detector.propose_amendment()
+    assert proposal["metric"] == "latency"
+    assert proposal["reason"] == "distribution drift detected"
+    assert proposal["recommended_documents"] == ["GOVERNANCE.md", "QA_ENGINE.md"]
+    metrics_payload = proposal.get("drift_metrics", {})
+    assert metrics_payload.get("drift_detected") is True
+    assert metrics_payload.get("reference_size") == 300
+    assert metrics_payload.get("live_size") == 300
+
+
+def test_distribution_drift_respects_min_samples() -> None:
+    """Insufficient data should not trigger drift and should provide context."""
+
+    detector = DriftDetector(min_samples=10)
+    report = detector.detect_distribution_drift([1.0, 1.1], [1.5, 1.6], metric_name="quality")
+    assert report.drift_detected is False
+    assert report.details.get("insufficient_data") is True
+    assert report.details.get("reference_size") == 2
+    assert report.details.get("live_size") == 2
+
+
+def test_distribution_drift_handles_similar_distributions() -> None:
+    """Similar distributions with relaxed thresholds should not flag drift."""
+
+    detector = DriftDetector(
+        psi_threshold=1.0,
+        ks_threshold=1.0,
+        kl_threshold=1.0,
+        min_samples=20,
+    )
+    rng = np.random.default_rng(123)
+    reference = rng.normal(loc=0.0, scale=1.0, size=200)
+    live = rng.normal(loc=0.1, scale=1.05, size=200)
+    report = detector.detect_distribution_drift(reference, live, metric_name="latency")
+    assert report.drift_detected is False
+    assert all(result.drift_detected is False for result in report.results)

--- a/qa_engine/__init__.py
+++ b/qa_engine/__init__.py
@@ -4,13 +4,41 @@
 # Aggregates helper modules that interpret QA metrics as probability
 # distributions for trust-aware decision making.
 
-from .probabilistic_qa import evaluate_metric, pass_probability, z_score
-from .statistics_helpers import mean_confidence_interval, percentile, sample_mean_std
+from .probabilistic_qa import (
+    CalibrationResult,
+    QAConfidenceReport,
+    apply_calibration,
+    brier_score,
+    confidence_report,
+    evaluate_calibrated_metric,
+    evaluate_metric,
+    expected_calibration_error,
+    pass_probability,
+    platt_calibration,
+    z_score,
+)
+from .statistics_helpers import (
+    bootstrap_confidence_interval,
+    clamp_probability,
+    mean_confidence_interval,
+    percentile,
+    sample_mean_std,
+)
 
 __all__ = [
+    "CalibrationResult",
+    "QAConfidenceReport",
+    "apply_calibration",
+    "brier_score",
+    "confidence_report",
+    "evaluate_calibrated_metric",
     "evaluate_metric",
+    "expected_calibration_error",
     "pass_probability",
+    "platt_calibration",
     "z_score",
+    "bootstrap_confidence_interval",
+    "clamp_probability",
     "mean_confidence_interval",
     "percentile",
     "sample_mean_std",

--- a/qa_engine/probabilistic_qa.py
+++ b/qa_engine/probabilistic_qa.py
@@ -1,20 +1,88 @@
-"""Functions for interpreting QA metrics as probability distributions."""
-
-# === Header & Purpose ===
-# Translate deterministic QA metrics into probabilistic signals using standard
-# normal approximations so that governance policies can reason about confidence
-# and uncertainty when enforcing thresholds.
-
-# === Imports / Dependencies ===
 from __future__ import annotations
 
-import math
-from typing import Dict
+"""Probabilistic QA utilities offering calibration and confidence scoring."""
 
-from .statistics_helpers import cumulative_standard_normal
+# === Header & Purpose ===
+# Translate deterministic QA metrics into probabilistic signals and provide
+# calibrated confidence reports that can be enforced by governance policies.
+
+# === Imports / Dependencies ===
+
+import math
+from dataclasses import dataclass
+from typing import Dict, Optional, Sequence, Tuple, Union
+
+import numpy as np
+
+from .statistics_helpers import (
+    bootstrap_confidence_interval,
+    clamp_probability,
+    cumulative_standard_normal,
+)
 
 
 # === Types, Interfaces, Contracts ===
+@dataclass(frozen=True)
+class CalibrationResult:
+    """Logistic calibration parameters derived from Platt scaling."""
+
+    intercept: float
+    slope: float
+    iterations: int
+    converged: bool
+    loss: float
+
+    def predict(self, scores: Union[Sequence[float], float]) -> np.ndarray:
+        """Return calibrated probabilities for ``scores``."""
+
+        array = np.asarray(scores, dtype=float)
+        logits = np.clip(self.intercept + self.slope * array, -50.0, 50.0)
+        return _sigmoid(logits)
+
+    def as_dict(self) -> Dict[str, Union[bool, float, int]]:
+        """Return a serialisable representation of the calibration."""
+
+        return {
+            "intercept": float(self.intercept),
+            "slope": float(self.slope),
+            "iterations": int(self.iterations),
+            "converged": bool(self.converged),
+            "loss": float(self.loss),
+        }
+
+
+@dataclass(frozen=True)
+class QAConfidenceReport:
+    """Summary of calibrated QA performance."""
+
+    mean_probability: float
+    lower_bound: float
+    upper_bound: float
+    observed_rate: float
+    brier_score: float
+    calibration_error: float
+    samples: int
+
+    def meets_confidence(self, target: float) -> bool:
+        """Return ``True`` when the lower bound satisfies ``target``."""
+
+        return self.lower_bound >= target
+
+    def as_dict(self) -> Dict[str, Union[float, int]]:
+        """Return a serialisable representation of the report."""
+
+        return {
+            "mean_probability": float(self.mean_probability),
+            "lower_bound": float(self.lower_bound),
+            "upper_bound": float(self.upper_bound),
+            "observed_rate": float(self.observed_rate),
+            "brier_score": float(self.brier_score),
+            "calibration_error": float(self.calibration_error),
+            "samples": int(self.samples),
+        }
+
+# === Core Logic / Implementation ===
+
 def z_score(mean: float, std_dev: float, threshold: float) -> float:
     """Compute the z-score comparing ``threshold`` against a normal distribution."""
 
@@ -30,7 +98,16 @@ def pass_probability(z: float) -> float:
 
 
 def evaluate_metric(value: float, distribution: Dict[str, float], confidence: float) -> bool:
-    """Determine whether ``value`` meets ``confidence`` given distribution moments."""
+    """Determine whether ``value`` satisfies ``confidence`` using available signals."""
+
+    if "calibration" in distribution:
+        calibration = _ensure_calibration(distribution["calibration"])
+        probability = float(calibration.predict([value])[0])
+        return probability >= confidence
+
+    probability = float(distribution.get("probability", float("nan")))
+    if math.isfinite(probability):
+        return probability >= confidence
 
     mean = float(distribution.get("mean", value))
     std = float(distribution.get("std", 0.0))
@@ -39,14 +116,271 @@ def evaluate_metric(value: float, distribution: Dict[str, float], confidence: fl
     return probability >= confidence
 
 
+def platt_calibration(
+    scores: Sequence[float],
+    labels: Sequence[Union[bool, int, float]],
+    *,
+    min_samples: int = 10,
+    max_iter: int = 100,
+    tol: float = 1e-6,
+    regularization: float = 1e-6,
+) -> CalibrationResult:
+    """Return Platt scaling parameters for ``scores`` and binary ``labels``."""
+
+    score_array, label_array = _prepare_training_data(scores, labels)
+    if score_array.size < min_samples:
+        raise ValueError("insufficient samples for calibration")
+
+    positives = float(label_array.sum())
+    negatives = float(label_array.size - positives)
+    if positives == 0.0 or negatives == 0.0:
+        prior = clamp_probability((positives + 1.0) / (label_array.size + 2.0))
+        intercept = math.log(prior / (1.0 - prior))
+        probabilities = np.full(label_array.shape, prior, dtype=float)
+        loss = _log_loss(probabilities, label_array, regularization, np.array([intercept, 0.0]))
+        return CalibrationResult(intercept=intercept, slope=0.0, iterations=0, converged=True, loss=loss)
+
+    design = np.column_stack([np.ones_like(score_array), score_array])
+    weights = np.zeros(2, dtype=float)
+    converged = False
+    iterations_used = 0
+
+    for iteration in range(1, max_iter + 1):
+        logits = np.clip(design @ weights, -50.0, 50.0)
+        probabilities = _sigmoid(logits)
+        gradient = design.T @ (probabilities - label_array) + regularization * weights
+        W = probabilities * (1.0 - probabilities)
+        if np.all(W < 1e-12):
+            break
+        h00 = np.sum(W * design[:, 0] * design[:, 0]) + regularization
+        h01 = np.sum(W * design[:, 0] * design[:, 1])
+        h11 = np.sum(W * design[:, 1] * design[:, 1]) + regularization
+        hessian = np.array([[h00, h01], [h01, h11]])
+        try:
+            delta = np.linalg.solve(hessian, gradient)
+        except np.linalg.LinAlgError:
+            hessian += np.eye(2) * (regularization * 10.0)
+            delta = np.linalg.solve(hessian, gradient)
+        weights -= delta
+        iterations_used = iteration
+        if float(np.linalg.norm(delta, ord=2)) <= tol:
+            converged = True
+            break
+
+    logits = np.clip(design @ weights, -50.0, 50.0)
+    probabilities = _sigmoid(logits)
+    loss = _log_loss(probabilities, label_array, regularization, weights)
+    return CalibrationResult(
+        intercept=float(weights[0]),
+        slope=float(weights[1]),
+        iterations=iterations_used,
+        converged=converged,
+        loss=loss,
+    )
+
+
+def apply_calibration(
+    scores: Sequence[float], calibration: Union[CalibrationResult, Dict[str, float]]
+) -> np.ndarray:
+    """Return calibrated probabilities for ``scores``."""
+
+    calibration_result = _ensure_calibration(calibration)
+    return calibration_result.predict(scores)
+
+
+def brier_score(probabilities: Sequence[float], labels: Sequence[Union[bool, int, float]]) -> float:
+    """Return the Brier score for ``probabilities`` against ``labels``."""
+
+    prob_array, label_array = _align_probabilities(probabilities, labels)
+    if prob_array.size == 0:
+        return 0.0
+    diff = prob_array - label_array
+    return float(np.mean(diff * diff))
+
+
+def expected_calibration_error(
+    probabilities: Sequence[float],
+    labels: Sequence[Union[bool, int, float]],
+    *,
+    bins: int = 10,
+) -> float:
+    """Return the Expected Calibration Error (ECE) for ``probabilities``."""
+
+    if bins <= 0:
+        raise ValueError("bins must be positive")
+    prob_array, label_array = _align_probabilities(probabilities, labels)
+    if prob_array.size == 0:
+        return 0.0
+    edges = np.linspace(0.0, 1.0, bins + 1)
+    ece = 0.0
+    total = float(prob_array.size)
+    for index in range(bins):
+        lower = edges[index]
+        upper = edges[index + 1]
+        if index == bins - 1:
+            mask = (prob_array >= lower) & (prob_array <= upper)
+        else:
+            mask = (prob_array >= lower) & (prob_array < upper)
+        if not np.any(mask):
+            continue
+        bin_prob = float(np.mean(prob_array[mask]))
+        bin_acc = float(np.mean(label_array[mask]))
+        weight = float(np.sum(mask)) / total
+        ece += weight * abs(bin_prob - bin_acc)
+    return float(ece)
+
+
+def confidence_report(
+    probabilities: Sequence[float],
+    labels: Sequence[Union[bool, int, float]],
+    *,
+    confidence_level: float = 0.95,
+    bootstrap_iterations: int = 1000,
+    bins: int = 10,
+    random_state: Optional[int] = None,
+) -> QAConfidenceReport:
+    """Return a confidence report aggregating calibration quality metrics."""
+
+    prob_array, label_array = _align_probabilities(probabilities, labels)
+    if prob_array.size == 0:
+        return QAConfidenceReport(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0)
+
+    mean_probability = float(np.mean(prob_array))
+    observed_rate = float(np.mean(label_array))
+    lower, upper = bootstrap_confidence_interval(
+        prob_array,
+        confidence=confidence_level,
+        iterations=bootstrap_iterations,
+        random_state=random_state,
+    )
+    brier = brier_score(prob_array, label_array)
+    ece = expected_calibration_error(prob_array, label_array, bins=bins)
+    return QAConfidenceReport(mean_probability, lower, upper, observed_rate, brier, ece, int(prob_array.size))
+
+
+def evaluate_calibrated_metric(
+    value: float,
+    calibration: Union[CalibrationResult, Dict[str, float]],
+    historical_scores: Sequence[float],
+    historical_labels: Sequence[Union[bool, int, float]],
+    *,
+    confidence: float = 0.95,
+    bootstrap_iterations: int = 1000,
+    bins: int = 10,
+    random_state: Optional[int] = None,
+) -> Tuple[bool, QAConfidenceReport, float]:
+    """Evaluate ``value`` against calibrated confidence targets."""
+
+    calibration_result = _ensure_calibration(calibration)
+    probability = float(calibration_result.predict([value])[0])
+    historical_probabilities = calibration_result.predict(historical_scores)
+    report = confidence_report(
+        historical_probabilities,
+        historical_labels,
+        confidence_level=confidence,
+        bootstrap_iterations=bootstrap_iterations,
+        bins=bins,
+        random_state=random_state,
+    )
+    meets = probability >= confidence and report.meets_confidence(confidence)
+    return meets, report, probability
+
+
+def _sigmoid(values: np.ndarray) -> np.ndarray:
+    return 1.0 / (1.0 + np.exp(-values))
+
+
+def _prepare_training_data(
+    scores: Sequence[float], labels: Sequence[Union[bool, int, float]]
+) -> Tuple[np.ndarray, np.ndarray]:
+    raw_scores = np.asarray(scores, dtype=float)
+    raw_labels = _coerce_labels(labels)
+    if raw_scores.size != raw_labels.size:
+        raise ValueError("scores and labels length mismatch")
+    mask = np.isfinite(raw_scores)
+    filtered_scores = raw_scores[mask]
+    filtered_labels = raw_labels[mask]
+    return filtered_scores, filtered_labels
+
+
+def _coerce_labels(labels: Sequence[Union[bool, int, float]]) -> np.ndarray:
+    coerced = np.empty(len(labels), dtype=float)
+    for index, label in enumerate(labels):
+        coerced[index] = 1.0 if bool(label) else 0.0
+    return coerced
+
+
+def _align_probabilities(
+    probabilities: Sequence[float], labels: Sequence[Union[bool, int, float]]
+) -> Tuple[np.ndarray, np.ndarray]:
+    prob_array = np.asarray(probabilities, dtype=float)
+    label_array = _coerce_labels(labels)
+    if prob_array.size != label_array.size:
+        raise ValueError("probabilities and labels length mismatch")
+    mask = np.isfinite(prob_array)
+    prob_array = np.clip(prob_array[mask], 0.0, 1.0)
+    label_array = label_array[mask]
+    return prob_array, label_array
+
+
+def _ensure_calibration(
+    calibration: Union[CalibrationResult, Dict[str, Union[bool, float, int]]]
+) -> CalibrationResult:
+    if isinstance(calibration, CalibrationResult):
+        return calibration
+    if not isinstance(calibration, dict):
+        raise TypeError("calibration must be a CalibrationResult or mapping")
+    try:
+        intercept = float(calibration["intercept"])
+        slope = float(calibration["slope"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("calibration mapping missing intercept/slope") from exc
+    iterations = int(calibration.get("iterations", 0))
+    converged = bool(calibration.get("converged", True))
+    loss = float(calibration.get("loss", 0.0))
+    return CalibrationResult(
+        intercept=intercept,
+        slope=slope,
+        iterations=iterations,
+        converged=converged,
+        loss=loss,
+    )
+
+
+def _log_loss(
+    probabilities: np.ndarray,
+    labels: np.ndarray,
+    regularization: float,
+    weights: np.ndarray,
+) -> float:
+    clipped = np.clip(probabilities, 1e-15, 1.0 - 1e-15)
+    loss = -np.sum(labels * np.log(clipped) + (1.0 - labels) * np.log(1.0 - clipped))
+    loss += 0.5 * regularization * float(np.sum(weights * weights))
+    return float(loss)
+
+
 # === Error & Edge Case Handling ===
-# - Zero variance distributions treat values above the mean as certain failures.
-# - Missing mean/std defaults to the observed value to avoid false positives.
+# - Calibration gracefully falls back to prior probabilities when classes are imbalanced.
+# - Probability alignment ignores non-finite values and clips to [0, 1].
+# - Evaluation defaults to distributional checks when calibration metadata is absent.
 
 
 # === Performance Considerations ===
-# - Functions operate in constant time and are safe for tight event loops.
+# - Calibration uses vectorised NumPy operations and converges in <100 iterations.
+# - Confidence reporting reuses bootstrap helpers for statistical guarantees.
 
 
 # === Exports / Public API ===
-__all__ = ["z_score", "pass_probability", "evaluate_metric"]
+__all__ = [
+    "CalibrationResult",
+    "QAConfidenceReport",
+    "apply_calibration",
+    "brier_score",
+    "confidence_report",
+    "evaluate_calibrated_metric",
+    "evaluate_metric",
+    "expected_calibration_error",
+    "pass_probability",
+    "platt_calibration",
+    "z_score",
+]

--- a/tests/test_probabilistic_qa.py
+++ b/tests/test_probabilistic_qa.py
@@ -8,10 +8,17 @@ from typing import List
 import pytest
 
 from qa_engine import (
+    QAConfidenceReport,
+    apply_calibration,
+    brier_score,
+    confidence_report,
+    evaluate_calibrated_metric,
     evaluate_metric,
+    expected_calibration_error,
     mean_confidence_interval,
     pass_probability,
     percentile,
+    platt_calibration,
     sample_mean_std,
     z_score,
 )
@@ -37,6 +44,69 @@ def test_evaluate_metric_uses_confidence_threshold() -> None:
     distribution = {"mean": 250.0, "std": 30.0}
     assert evaluate_metric(300.0, distribution, 0.9) is True
     assert evaluate_metric(310.0, distribution, 0.99) is False
+
+
+def test_platt_calibration_generates_monotonic_probabilities() -> None:
+    """Calibration should produce probabilities that respect ordering of scores."""
+
+    scores = [-3.0, -1.0, 0.0, 1.0, 3.0]
+    labels = [0, 0, 0, 1, 1]
+    calibration = platt_calibration(scores, labels, min_samples=5)
+    probabilities = apply_calibration(scores, calibration)
+    assert probabilities[0] < probabilities[1] < probabilities[2] < probabilities[-1]
+    assert 0.0 <= probabilities[0] < 0.5
+    assert 0.5 < probabilities[-1] <= 1.0
+
+
+def test_evaluate_metric_prefers_calibrated_probabilities() -> None:
+    """Calibration metadata within the distribution should drive evaluation."""
+
+    scores = [-1.0, 0.0, 1.0, 2.0]
+    labels = [0, 0, 1, 1]
+    calibration = platt_calibration(scores, labels, min_samples=4)
+    distribution = {"calibration": calibration.as_dict()}
+    assert evaluate_metric(2.0, distribution, 0.7) is True
+    assert evaluate_metric(-2.0, distribution, 0.7) is False
+
+
+def test_confidence_report_summarises_probabilities() -> None:
+    """Confidence report should expose probability averages and calibration metrics."""
+
+    probabilities = [0.8, 0.7, 0.9, 0.4]
+    labels = [1, 1, 1, 0]
+    report = confidence_report(probabilities, labels, confidence_level=0.9, bootstrap_iterations=200)
+    assert isinstance(report, QAConfidenceReport)
+    assert report.samples == 4
+    assert report.brier_score == pytest.approx(brier_score(probabilities, labels), rel=1e-6)
+    assert 0.0 <= report.calibration_error <= 0.5
+
+
+def test_evaluate_calibrated_metric_returns_report_tuple() -> None:
+    """Calibrated evaluation should surface probability, report, and pass/fail."""
+
+    scores = [-2.0, -1.0, 0.5, 1.5, 2.5]
+    labels = [0, 0, 1, 1, 1]
+    calibration = platt_calibration(scores, labels, min_samples=5)
+    passed, report, probability = evaluate_calibrated_metric(
+        1.0,
+        calibration,
+        scores,
+        labels,
+        confidence=0.6,
+        bootstrap_iterations=200,
+    )
+    assert isinstance(report, QAConfidenceReport)
+    assert isinstance(passed, bool)
+    assert 0.0 <= probability <= 1.0
+    assert report.meets_confidence(0.2) in {True, False}
+
+
+def test_expected_calibration_error_handles_perfect_calibration() -> None:
+    """ECE should be near zero when probabilities equal observed outcomes."""
+
+    probabilities = [0.0, 1.0, 0.0, 1.0]
+    labels = [0, 1, 0, 1]
+    assert expected_calibration_error(probabilities, labels, bins=2) == pytest.approx(0.0, abs=1e-9)
 
 
 def test_sample_mean_std_matches_manual_computation() -> None:

--- a/tests/test_statistics_helpers.py
+++ b/tests/test_statistics_helpers.py
@@ -1,0 +1,69 @@
+"""Unit tests for statistical helper utilities supporting probabilistic QA."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from qa_engine.statistics_helpers import (
+    bootstrap_confidence_interval,
+    clamp_probability,
+    mean_confidence_interval,
+    percentile,
+    sample_mean_std,
+)
+
+
+def test_clamp_probability_handles_invalid_inputs() -> None:
+    """Probabilities should be clamped within (0, 1) even for invalid inputs."""
+
+    assert clamp_probability(-0.5) == pytest.approx(1e-15)
+    assert clamp_probability(2.0) == pytest.approx(1.0 - 1e-15)
+    assert clamp_probability(float("nan")) == pytest.approx(0.5)
+    assert clamp_probability("0.75") == pytest.approx(0.75)
+
+
+def test_bootstrap_confidence_interval_single_value_is_degenerate() -> None:
+    """Bootstrap confidence should collapse when only one observation exists."""
+
+    low, high = bootstrap_confidence_interval([42.0])
+    assert low == pytest.approx(42.0)
+    assert high == pytest.approx(42.0)
+
+
+def test_bootstrap_confidence_interval_ignores_non_numeric_values() -> None:
+    """Bootstrap routine should ignore invalid entries and respect random state."""
+
+    low, high = bootstrap_confidence_interval(
+        [1.0, 2.0, 3.0, float("nan"), None],
+        confidence=0.8,
+        iterations=200,
+        random_state=123,
+    )
+    assert low <= high
+    assert 1.0 <= low <= 3.0
+    assert 1.0 <= high <= 3.0
+
+
+def test_sample_mean_std_filters_non_finite_values() -> None:
+    """Mean and standard deviation helpers should ignore non-finite entries."""
+
+    mean, std = sample_mean_std([1.0, 2.0, "3.0", float("nan")])
+    assert mean == pytest.approx(2.0)
+    assert std == pytest.approx(math.sqrt(1.0), rel=1e-6)
+
+
+def test_mean_confidence_interval_with_uniform_values() -> None:
+    """Confidence interval collapses to the mean for uniform data."""
+
+    low, high = mean_confidence_interval([10.0, 10.0, 10.0])
+    assert low == pytest.approx(high)
+    assert low == pytest.approx(10.0)
+
+
+def test_percentile_handles_sparse_values() -> None:
+    """Percentile helper should gracefully handle sparse sequences."""
+
+    assert percentile([float("nan"), 5.0, 15.0, 30.0], 50.0) == pytest.approx(15.0)
+    assert percentile([], 25.0) == pytest.approx(0.0)


### PR DESCRIPTION
## Summary
- add logistic calibration models, confidence reports, and governance-aware evaluation helpers to the probabilistic QA engine
- harden shared statistics helpers with input cleaning, bootstrap confidence intervals, and probability clamping
- document calibrated QA workflows and extend tests to cover calibration, reporting, and statistical utilities

## Testing
- pytest tests/test_probabilistic_qa.py tests/test_statistics_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68d3b9c6e00c83218c151602944ddc0c