### PR TITLE
feat: add governance policy enforcer with tests

### DIFF
--- a/config/governance.json
+++ b/config/governance.json
@@ -18,7 +18,14 @@
   },
   "drift_detection": {
     "window_size": 5,
-    "failure_threshold": 3
+    "failure_threshold": 3,
+    "statistical_thresholds": {
+      "psi": 0.2,
+      "ks": 0.1,
+      "kl": 0.5
+    },
+    "min_samples": 50,
+    "histogram_bins": 12
   },
   "fallbacks": {
     "latency": "macro_id_latency_fallback",

--- a/config/governance.schema.json
+++ b/config/governance.schema.json
@@ -54,6 +54,33 @@
         "failure_threshold": {
           "type": "integer",
           "minimum": 1
+        },
+        "statistical_thresholds": {
+          "type": "object",
+          "required": ["psi", "ks", "kl"],
+          "properties": {
+            "psi": {
+              "type": "number",
+              "minimum": 0
+            },
+            "ks": {
+              "type": "number",
+              "minimum": 0
+            },
+            "kl": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "additionalProperties": false
+        },
+        "min_samples": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "histogram_bins": {
+          "type": "integer",
+          "minimum": 2
         }
       },
       "additionalProperties": false

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -35,7 +35,8 @@ It covers both the structure and process for maintaining governance configuratio
 
 - [ ] Arbitration lists remain ordered by priority and cover all high-risk metrics.
 - [ ] Trust multipliers keep scores within `[0.1, 1.5]` bounds.
-- [ ] Drift detection thresholds balance sensitivity and noise.
+- [ ] Drift detection thresholds (window + PSI/KS/KL + min_samples) balance sensitivity
+      and noise.
 - [ ] Fallback macro identifiers map to registered macros in macro registry.
 - [ ] Agents gain explicit responsibilities and permissions.
 
@@ -52,6 +53,10 @@ It covers both the structure and process for maintaining governance configuratio
 
 - **Config Validation:** `src/common/config_loader.py` defines Pydantic schemas for all YAML configurations under `config/`. CI should load `config/default.yaml`, `config/metrics.yaml`, and `config/governance.yaml` to ensure schema compliance before merges.
 - **Governance Thresholds:** Metric and fairness thresholds declared in `config/metrics.yaml` are consumed by `src/training/metrics.py` and `src/governance/fairness.py` during evaluation.
+
+### Policy Enforcement
+
+- **CI/CD Gates:** `src/governance/policy_enforcer.py` evaluates QA policy thresholds with probabilistic confidence scoring sourced from `config/qa_policies.json`. `tests/unit/test_policy_enforcer.py` provides regression coverage ensuring blocking decisions remain deterministic.
 
 ### Fairness Management
 

--- a/docs/META_AGENT.md
+++ b/docs/META_AGENT.md
@@ -10,7 +10,8 @@ updating trust scores, detecting drift, and orchestrating fallback macros.
 - **ConfigLoader** – Validates governance, agent, and QA policy configuration using JSON Schema.
 - **TrustEngine** – Maintains Bayesian-style trust scores with durable journalling.
 - **ArbitrationEngine** – Resolves conflicts using governance priorities and trust weights.
-- **DriftDetector** – Monitors sliding windows of QA outcomes to flag repeated failures.
+- **DriftDetector** – Monitors sliding windows of QA outcomes and performs PSI/KS/KL
+  statistical checks to flag emerging distribution drift.
 - **FallbackManager** – Maps metrics to fallback macros and triggers registered callbacks.
 - **Logger** – Emits structured JSON telemetry for observability.
 
@@ -19,7 +20,8 @@ updating trust scores, detecting drift, and orchestrating fallback macros.
 1. QA agents publish `qa_success` or `qa_failure` events to the `QAEventBus`.
 2. Meta Agent sanitises payloads, validates structure, and updates trust scores.
 3. Conflicts are queued per metric and resolved via `ArbitrationEngine` using trust-weighted priorities.
-4. DriftDetector analyses sliding windows; detected drift emits `qa_drift` events.
+4. DriftDetector analyses sliding windows and statistical drift metrics; detected drift
+   emits `qa_drift` events with PSI/KS/KL evidence for governance review.
 5. FallbackManager triggers registered macros when metrics exceed governance thresholds.
 6. Structured arbitration logs are appended to `logs/arbitrations.jsonl`.
 

--- a/meta_agent/__init__.py
+++ b/meta_agent/__init__.py
@@ -2,7 +2,7 @@
 
 from .arbitration_engine import ArbitrationDecision, ArbitrationEngine
 from .config_loader import ConfigLoader
-from .drift_detector import DriftDetector
+from .drift_detector import DriftDetector, DriftMetricResult, DriftReport
 from .fallback_manager import FallbackManager
 from .logger import Logger
 from .macro_dependency_manager import MacroDependencyManager, MacroState
@@ -17,6 +17,8 @@ __all__ = [
     "ArbitrationEngine",
     "ConfigLoader",
     "DriftDetector",
+    "DriftMetricResult",
+    "DriftReport",
     "FallbackManager",
     "Logger",
     "MacroDependencyManager",

--- a/meta_agent/docs/META_AGENT.md
+++ b/meta_agent/docs/META_AGENT.md
@@ -15,8 +15,9 @@ source-of-truth for QA outcomes.
 - **ArbitrationEngine** — Normalizes conflicting events and resolves winners using trust
   weights and governance priorities loaded from `config/governance_rules.json` when
   available.
-- **DriftDetector** — Observes sliding windows of QA events, flags repeated failures or
-  disables, and emits amendment proposals for QA.md/AGENTS.md.
+- **DriftDetector** — Observes sliding windows of QA events, computes PSI/KS/KL metrics
+  for statistical drift, flags repeated failures or distribution shifts, and emits
+  amendment proposals for QA.md/AGENTS.md.
 - **FallbackManager** — Invokes predefined macros when primary macros fail chaos or
   resilience thresholds.
 - **MacroDependencyManager** — Tracks macro dependency schemas, blocks macros on
@@ -34,9 +35,9 @@ source-of-truth for QA outcomes.
 3. When multiple judgments exist for the same metric, the ArbitrationEngine resolves a
    winner based on trust × governance priority, captures the confidence gap, and emits an
    audit log entry plus a `qa_arbitration` event.
-4. DriftDetector records every outcome; if repeated failures or disables cross the
-   configured threshold, it emits a drift proposal broadcast through `qa_drift` events for
-   human governance review.
+4. DriftDetector records every outcome; if repeated failures, disables, or PSI/KS/KL
+   thresholds cross configured limits, it emits a drift proposal broadcast through
+   `qa_drift` events for human governance review complete with statistical evidence.
 5. MacroDependencyManager listens to macro definition and dependency update events,
    blocking or unblocking macros when schema compatibility changes. It publishes
    `macro_blocked`/`macro_unblocked` events enriched with dependency diffs for

--- a/meta_agent/drift_detector.py
+++ b/meta_agent/drift_detector.py
@@ -1,21 +1,85 @@
-"""Sliding window drift detection for QA metrics and governance rules."""
+"""Sliding window and statistical drift detection for QA governance."""
 
 # === Imports / Dependencies ===
 from __future__ import annotations
 
+import math
 from collections import defaultdict, deque
-from typing import Any, Deque, Dict, List, Optional, Tuple
+from dataclasses import dataclass
+from typing import Any, Deque, Dict, List, Mapping, Optional, Sequence, Tuple
 
 
 # === Types, Interfaces, Contracts, Schema ===
+EPSILON = 1e-9
+DEFAULT_THRESHOLDS: Dict[str, float] = {"psi": 0.2, "ks": 0.1, "kl": 0.5}
+
+
+@dataclass(frozen=True)
+class DriftMetricResult:
+    """Summary of a single statistical drift metric evaluation."""
+
+    metric: str
+    score: float
+    threshold: float
+    drift_detected: bool
+    details: Dict[str, Any]
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Return a JSON-serialisable representation of the metric result."""
+
+        return {
+            "metric": self.metric,
+            "score": self.score,
+            "threshold": self.threshold,
+            "drift_detected": self.drift_detected,
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class DriftReport:
+    """Aggregated drift assessment across statistical metrics."""
+
+    feature: str
+    reference_size: int
+    live_size: int
+    metrics: Dict[str, DriftMetricResult]
+    triggered: bool
+    reason: Optional[str] = None
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Return a JSON-serialisable representation of the drift report."""
+
+        return {
+            "feature": self.feature,
+            "reference_size": self.reference_size,
+            "live_size": self.live_size,
+            "triggered": self.triggered,
+            "reason": self.reason,
+            "metrics": {name: metric.as_dict() for name, metric in self.metrics.items()},
+        }
+
+
 class DriftDetector:
     """Track metric outcomes and flag repeated failures that suggest drift."""
 
-    def __init__(self, window_size: int = 5, threshold: int = 3) -> None:
+    def __init__(
+        self,
+        window_size: int = 5,
+        threshold: int = 3,
+        *,
+        statistical_thresholds: Optional[Mapping[str, float]] = None,
+        min_sample_size: int = 30,
+        histogram_bins: int = 10,
+    ) -> None:
         if window_size <= 0:
             raise ValueError("window_size must be positive")
         if threshold <= 0:
             raise ValueError("threshold must be positive")
+        if min_sample_size <= 0:
+            raise ValueError("min_sample_size must be positive")
+        if histogram_bins < 2:
+            raise ValueError("histogram_bins must be at least 2")
         self.window_size = window_size
         self.threshold = threshold
         self.history: Dict[Tuple[str, str], Deque[str]] = defaultdict(
@@ -23,7 +87,16 @@ class DriftDetector:
         )
         self._last_drift: Optional[Dict[str, Any]] = None
         self._proposals: List[Dict[str, Any]] = []
+        self.min_sample_size = int(min_sample_size)
+        self.histogram_bins = int(histogram_bins)
+        configured_thresholds = {
+            key: float(value)
+            for key, value in (statistical_thresholds or {}).items()
+            if key in DEFAULT_THRESHOLDS
+        }
+        self.thresholds: Dict[str, float] = {**DEFAULT_THRESHOLDS, **configured_thresholds}
 
+    # === Sliding Window Drift Detection ===
     def record_event(self, agent: Optional[str], metric: Optional[str], status: str) -> None:
         """Record ``status`` for ``agent`` and ``metric`` in the sliding window."""
 
@@ -75,6 +148,156 @@ class DriftDetector:
 
         return list(self._proposals)
 
+    # === Statistical Drift Detection ===
+    def detect_distribution_drift(
+        self,
+        reference_distribution: Sequence[float],
+        live_distribution: Sequence[float],
+        *,
+        feature: str = "metric",
+    ) -> DriftReport:
+        """Compare ``reference_distribution`` with ``live_distribution`` for drift."""
+
+        reference = self._sanitize_samples(reference_distribution)
+        live = self._sanitize_samples(live_distribution)
+        reference_size = len(reference)
+        live_size = len(live)
+        if reference_size < self.min_sample_size or live_size < self.min_sample_size:
+            reason = (
+                "insufficient samples"
+                f" (reference={reference_size}, live={live_size}, required={self.min_sample_size})"
+            )
+            return DriftReport(
+                feature=feature,
+                reference_size=reference_size,
+                live_size=live_size,
+                metrics={},
+                triggered=False,
+                reason=reason,
+            )
+
+        edges = self._build_histogram_edges(reference, live)
+        reference_counts = self._histogram_counts(reference, edges)
+        live_counts = self._histogram_counts(live, edges)
+        reference_probs = self._normalise(reference_counts)
+        live_probs = self._normalise(live_counts)
+
+        metrics: Dict[str, DriftMetricResult] = {}
+        psi_score = self._population_stability_index(reference_probs, live_probs)
+        metrics["psi"] = self._metric_result("psi", psi_score)
+        kl_score = self._kl_divergence(reference_probs, live_probs)
+        metrics["kl"] = self._metric_result("kl", kl_score)
+        ks_score = self._ks_statistic(reference, live)
+        metrics["ks"] = self._metric_result("ks", ks_score)
+
+        triggered = any(result.drift_detected for result in metrics.values())
+        return DriftReport(
+            feature=feature,
+            reference_size=reference_size,
+            live_size=live_size,
+            metrics=metrics,
+            triggered=triggered,
+        )
+
+    # === Internal Helpers ===
+    def _metric_result(self, metric: str, score: float) -> DriftMetricResult:
+        threshold = self.thresholds.get(metric, DEFAULT_THRESHOLDS[metric])
+        return DriftMetricResult(
+            metric=metric,
+            score=score,
+            threshold=threshold,
+            drift_detected=bool(score >= threshold),
+            details={"threshold": threshold},
+        )
+
+    def _sanitize_samples(self, values: Sequence[float]) -> List[float]:
+        sanitized: List[float] = []
+        for value in values:
+            try:
+                numeric = float(value)
+            except (TypeError, ValueError):
+                continue
+            if math.isnan(numeric) or math.isinf(numeric):
+                continue
+            sanitized.append(numeric)
+        return sanitized
+
+    def _build_histogram_edges(
+        self, reference: Sequence[float], live: Sequence[float]
+    ) -> List[float]:
+        combined = list(reference) + list(live)
+        minimum = min(combined)
+        maximum = max(combined)
+        if minimum == maximum:
+            return [minimum, minimum + 1.0]
+        span = maximum - minimum
+        step = span / float(self.histogram_bins)
+        if step == 0:
+            step = 1.0
+        edges = [minimum + step * index for index in range(self.histogram_bins)]
+        edges.append(maximum + step)
+        return edges
+
+    def _histogram_counts(self, values: Sequence[float], edges: Sequence[float]) -> List[float]:
+        counts = [0.0 for _ in range(len(edges) - 1)]
+        for value in values:
+            for index in range(len(edges) - 1):
+                upper_bound = edges[index + 1]
+                if value < upper_bound or index == len(edges) - 2:
+                    counts[index] += 1.0
+                    break
+        return counts
+
+    def _normalise(self, counts: Sequence[float]) -> List[float]:
+        total = sum(counts)
+        if total == 0:
+            return [0.0 for _ in counts]
+        return [count / total for count in counts]
+
+    def _population_stability_index(
+        self, reference_probs: Sequence[float], live_probs: Sequence[float]
+    ) -> float:
+        psi = 0.0
+        for reference, live in zip(reference_probs, live_probs):
+            ref = reference if reference > 0 else EPSILON
+            observed = live if live > 0 else EPSILON
+            psi += (observed - ref) * math.log(observed / ref)
+        return psi
+
+    def _kl_divergence(
+        self, reference_probs: Sequence[float], live_probs: Sequence[float]
+    ) -> float:
+        divergence = 0.0
+        for reference, live in zip(reference_probs, live_probs):
+            if reference <= 0:
+                continue
+            observed = live if live > 0 else EPSILON
+            divergence += reference * math.log(reference / observed)
+        return divergence
+
+    def _ks_statistic(self, reference: Sequence[float], live: Sequence[float]) -> float:
+        sorted_reference = sorted(reference)
+        sorted_live = sorted(live)
+        ref_size = len(sorted_reference)
+        live_size = len(sorted_live)
+        i = j = 0
+        cdf_reference = 0.0
+        cdf_live = 0.0
+        ks_stat = 0.0
+        while i < ref_size and j < live_size:
+            if sorted_reference[i] <= sorted_live[j]:
+                cdf_reference = (i + 1) / ref_size
+                i += 1
+            else:
+                cdf_live = (j + 1) / live_size
+                j += 1
+            ks_stat = max(ks_stat, abs(cdf_reference - cdf_live))
+        if i < ref_size:
+            ks_stat = max(ks_stat, abs(1.0 - cdf_live))
+        if j < live_size:
+            ks_stat = max(ks_stat, abs(cdf_reference - 1.0))
+        return ks_stat
+
     def _evaluate_window(
         self,
         agent: str,
@@ -101,13 +324,15 @@ class DriftDetector:
 
 
 # === Error & Edge Case Handling ===
-# Missing agent or metric identifiers are ignored. Invalid initialization parameters raise ``ValueError``.
-# Proposals are only generated when drift metadata exists to avoid empty recommendations.
+# - Missing agent or metric identifiers are ignored for sliding window detection.
+# - Statistical drift detection sanitises NaNs/Infs and enforces minimum sample sizes.
+# - Histogram bins default to 10 but can be configured for finer granularity.
 
 
 # === Performance / Resource Considerations ===
-# Memory usage grows with ``window_size`` × number of (agent, metric) pairs. Operations are O(window_size).
+# - Sliding window operations remain O(window_size).
+# - Statistical calculations rely on simple Python loops and avoid heavy dependencies.
 
 
 # === Exports / Public API ===
-__all__ = ["DriftDetector"]
+__all__ = ["DriftDetector", "DriftMetricResult", "DriftReport"]

--- a/meta_agent/engine.py
+++ b/meta_agent/engine.py
@@ -91,9 +91,13 @@ class MetaAgent:
             stale_after=float(arbitration_cfg.get("stale_after_seconds", 30.0)),
             max_queue=int(arbitration_cfg.get("max_queue_size", 50)),
         )
+        stat_thresholds = drift_cfg.get("statistical_thresholds", {})
         drift = DriftDetector(
             window_size=int(drift_cfg.get("window_size", 5)),
             threshold=int(drift_cfg.get("failure_threshold", 3)),
+            statistical_thresholds=stat_thresholds,
+            min_sample_size=int(drift_cfg.get("min_samples", 30)),
+            histogram_bins=int(drift_cfg.get("histogram_bins", 10)),
         )
         fallback = FallbackManager(fallbacks)
         macro_manager = MacroDependencyManager()

--- a/src/governance/__init__.py
+++ b/src/governance/__init__.py
@@ -6,6 +6,7 @@ SECTION 1: Header & Purpose
 
 # SECTION 2: Imports / Dependencies
 from .fairness import FairnessMetricResult, evaluate_fairness
+from .policy_enforcer import PolicyDecision, PolicyEnforcementResult, PolicyEnforcer
 from .privacy import PIIScrubbingError, contains_blocked_pii, scrub_text
 
 # SECTION 3: Types / Interfaces / Schemas
@@ -24,6 +25,9 @@ from .privacy import PIIScrubbingError, contains_blocked_pii, scrub_text
 __all__ = [
     "FairnessMetricResult",
     "PIIScrubbingError",
+    "PolicyDecision",
+    "PolicyEnforcementResult",
+    "PolicyEnforcer",
     "contains_blocked_pii",
     "evaluate_fairness",
     "scrub_text",

--- a/src/governance/policy_enforcer.py
+++ b/src/governance/policy_enforcer.py
@@ -1,0 +1,260 @@
+"""
+SECTION 1: Header & Purpose
+- Enforces QA policy thresholds with probabilistic confidence checks.
+- Provides deterministic blocking decisions for CI/CD governance pipelines.
+"""
+
+from __future__ import annotations
+
+# SECTION 2: Imports / Dependencies
+import math
+from dataclasses import dataclass
+from typing import Dict, Mapping, Optional, Tuple, TYPE_CHECKING
+
+from qa_engine.probabilistic_qa import pass_probability, z_score
+
+if TYPE_CHECKING:  # pragma: no cover - import used for type checking only
+    from meta_agent.config_loader import ConfigLoader
+
+
+# SECTION 3: Types / Interfaces / Schemas
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    """Represents the outcome of enforcing a single metric policy."""
+
+    metric: str
+    passed: bool
+    observed: Optional[float]
+    comparator: str
+    threshold: Optional[float]
+    confidence: float
+    probability: Optional[float]
+    reason: Optional[str]
+
+
+@dataclass(frozen=True)
+class PolicyEnforcementResult:
+    """Aggregate result describing all metric policy decisions."""
+
+    decisions: Tuple[PolicyDecision, ...]
+
+    @property
+    def passed(self) -> bool:
+        """Return ``True`` when all policy decisions passed."""
+
+        return all(decision.passed for decision in self.decisions)
+
+    @property
+    def violations(self) -> Tuple[PolicyDecision, ...]:
+        """Return the subset of decisions that failed enforcement."""
+
+        return tuple(decision for decision in self.decisions if not decision.passed)
+
+
+@dataclass(frozen=True)
+class _PolicyRule:
+    """Internal representation of a governance QA policy."""
+
+    metric: str
+    comparator: str
+    threshold: Optional[float]
+    confidence: float
+
+
+# SECTION 4: Core Logic / Implementation
+
+
+class PolicyEnforcer:
+    """Evaluate QA metrics against governance policies with statistical guarantees."""
+
+    def __init__(
+        self,
+        policies: Mapping[str, Mapping[str, float]],
+        *,
+        require_distributions: bool = True,
+    ) -> None:
+        self._rules: Dict[str, _PolicyRule] = {}
+        self._require_distributions = require_distributions
+        for metric, config in policies.items():
+            self._rules[metric] = self._build_rule(metric, config)
+
+    @classmethod
+    def from_config_loader(
+        cls,
+        loader: "ConfigLoader",
+        *,
+        require_distributions: bool = True,
+    ) -> "PolicyEnforcer":
+        """Instantiate an enforcer using a ``ConfigLoader`` QA policy snapshot."""
+
+        policies = loader.get_qa_policies()
+        return cls(policies, require_distributions=require_distributions)
+
+    def enforce(
+        self,
+        metrics: Mapping[str, float],
+        distributions: Optional[Mapping[str, Mapping[str, float]]] = None,
+    ) -> PolicyEnforcementResult:
+        """Evaluate ``metrics`` and return a structured enforcement result."""
+
+        decisions = []
+        for metric, rule in self._rules.items():
+            measurement = metrics.get(metric)
+            distribution = distributions.get(metric) if distributions else None
+            decisions.append(self._evaluate_rule(rule, measurement, distribution))
+        return PolicyEnforcementResult(tuple(decisions))
+
+    def _build_rule(self, metric: str, config: Mapping[str, float]) -> _PolicyRule:
+        comparator, threshold = self._resolve_threshold(metric, config)
+        confidence = float(config.get("confidence", 1.0))
+        confidence = min(max(confidence, 0.0), 1.0)
+        return _PolicyRule(metric=metric, comparator=comparator, threshold=threshold, confidence=confidence)
+
+    def _resolve_threshold(self, metric: str, config: Mapping[str, float]) -> Tuple[str, Optional[float]]:
+        if "threshold" in config:
+            return "<=", float(config["threshold"])
+        if "max_vulns" in config:
+            return "<=", float(config["max_vulns"])
+        if "min_ratio" in config:
+            return ">=", float(config["min_ratio"])
+        return "==", None
+
+    def _evaluate_rule(
+        self,
+        rule: _PolicyRule,
+        measurement: Optional[float],
+        distribution: Optional[Mapping[str, float]],
+    ) -> PolicyDecision:
+        if measurement is None:
+            return PolicyDecision(
+                metric=rule.metric,
+                passed=False,
+                observed=None,
+                comparator=rule.comparator,
+                threshold=rule.threshold,
+                confidence=rule.confidence,
+                probability=None,
+                reason="measurement missing",
+            )
+
+        try:
+            observed = float(measurement)
+        except (TypeError, ValueError):
+            return PolicyDecision(
+                metric=rule.metric,
+                passed=False,
+                observed=None,
+                comparator=rule.comparator,
+                threshold=rule.threshold,
+                confidence=rule.confidence,
+                probability=None,
+                reason="non-numeric measurement",
+            )
+
+        deterministic_pass, deterministic_reason = self._deterministic_check(rule, observed)
+        probability, probability_pass, probability_reason = self._probabilistic_check(rule, distribution)
+
+        passed = deterministic_pass and probability_pass
+        reason = None
+        if not deterministic_pass:
+            reason = deterministic_reason
+        elif not probability_pass:
+            reason = probability_reason
+
+        return PolicyDecision(
+            metric=rule.metric,
+            passed=passed,
+            observed=observed,
+            comparator=rule.comparator,
+            threshold=rule.threshold,
+            confidence=rule.confidence,
+            probability=probability,
+            reason=reason,
+        )
+
+    def _deterministic_check(self, rule: _PolicyRule, observed: float) -> Tuple[bool, Optional[str]]:
+        threshold = rule.threshold
+        comparator = rule.comparator
+        if comparator == "<=" and threshold is not None:
+            if observed <= threshold:
+                return True, None
+            return False, f"observed {observed} exceeds maximum {threshold}"
+        if comparator == ">=" and threshold is not None:
+            if observed >= threshold:
+                return True, None
+            return False, f"observed {observed} below minimum {threshold}"
+        if comparator == "==" and threshold is not None:
+            if observed == threshold:
+                return True, None
+            return False, f"observed {observed} does not equal required {threshold}"
+        return True, None
+
+    def _probabilistic_check(
+        self,
+        rule: _PolicyRule,
+        distribution: Optional[Mapping[str, float]],
+    ) -> Tuple[Optional[float], bool, Optional[str]]:
+        if distribution is None:
+            if self._require_distributions:
+                return None, False, "distribution data missing"
+            return None, True, None
+
+        mean = distribution.get("mean")
+        std = distribution.get("std")
+        if not self._is_valid_number(mean) or not self._is_valid_number(std):
+            return None, False, "distribution parameters invalid"
+
+        threshold = rule.threshold if rule.threshold is not None else 0.0
+        probability = self._calculate_probability(float(mean), float(std), threshold, rule.comparator)
+        if probability is None:
+            return None, False, "unable to compute probability"
+        if probability >= rule.confidence:
+            return probability, True, None
+        return probability, False, (
+            f"confidence {probability:.3f} below required {rule.confidence:.3f}"
+        )
+
+    @staticmethod
+    def _calculate_probability(
+        mean: float, std: float, threshold: float, comparator: str
+    ) -> Optional[float]:
+        if std < 0 or not math.isfinite(threshold):
+            return None
+        z = z_score(mean, std, threshold)
+        probability = pass_probability(z)
+        if comparator == ">=":
+            probability = 1.0 - probability
+        probability = max(0.0, min(1.0, probability))
+        return probability
+
+    @staticmethod
+    def _is_valid_number(value: Optional[float]) -> bool:
+        if value is None:
+            return False
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            return False
+        return math.isfinite(numeric)
+
+
+# SECTION 5: Error & Edge Case Handling
+# - Missing measurements fail fast with descriptive reasons.
+# - Non-numeric distributions or negative standard deviations are rejected.
+# - Probability calculations clamp to [0, 1] to avoid floating point drift.
+
+
+# SECTION 6: Performance Considerations
+# - Policy evaluation is O(n) over configured metrics with constant-time math operations.
+# - The enforcer caches parsed rules to avoid per-evaluation allocations.
+
+
+# SECTION 7: Exports / Public API
+__all__ = [
+    "PolicyDecision",
+    "PolicyEnforcementResult",
+    "PolicyEnforcer",
+]
+

--- a/tests/unit/test_policy_enforcer.py
+++ b/tests/unit/test_policy_enforcer.py
@@ -1,0 +1,132 @@
+"""
+SECTION 1: Header & Purpose
+- Unit tests for governance policy enforcement with probabilistic QA thresholds.
+"""
+
+# SECTION 2: Imports / Dependencies
+from pathlib import Path
+
+import pytest
+
+try:  # pragma: no cover - optional dependency for integration coverage
+    from meta_agent.config_loader import ConfigLoader
+except ModuleNotFoundError:  # pragma: no cover - jsonschema optional in some environments
+    ConfigLoader = None  # type: ignore[assignment]
+
+from src.governance.policy_enforcer import (
+    PolicyEnforcementResult,
+    PolicyEnforcer,
+)
+
+
+# SECTION 3: Types / Interfaces / Schemas
+# - Uses PolicyEnforcementResult dataclass to assert structured outcomes.
+
+
+def _build_enforcer(require_distributions: bool = True) -> PolicyEnforcer:
+    policies = {
+        "latency_ms": {"threshold": 300.0, "confidence": 0.95},
+        "contrast_ratio": {"min_ratio": 4.5, "confidence": 0.9},
+    }
+    return PolicyEnforcer(policies, require_distributions=require_distributions)
+
+
+# SECTION 4: Core Logic / Implementation
+
+
+def test_policy_enforcer_passes_when_thresholds_and_confidence_met() -> None:
+    enforcer = _build_enforcer()
+    metrics = {"latency_ms": 250.0, "contrast_ratio": 4.8}
+    distributions = {
+        "latency_ms": {"mean": 230.0, "std": 15.0},
+        "contrast_ratio": {"mean": 5.0, "std": 0.1},
+    }
+
+    result = enforcer.enforce(metrics, distributions)
+
+    assert isinstance(result, PolicyEnforcementResult)
+    assert result.passed is True
+    assert all(decision.probability is not None for decision in result.decisions)
+
+
+def test_policy_enforcer_detects_threshold_violation() -> None:
+    enforcer = _build_enforcer()
+    metrics = {"latency_ms": 320.0, "contrast_ratio": 5.0}
+    distributions = {
+        "latency_ms": {"mean": 200.0, "std": 15.0},
+        "contrast_ratio": {"mean": 5.0, "std": 0.1},
+    }
+
+    result = enforcer.enforce(metrics, distributions)
+    failure = result.violations[0]
+
+    assert failure.metric == "latency_ms"
+    assert failure.passed is False
+    assert "exceeds" in (failure.reason or "")
+
+
+def test_policy_enforcer_detects_low_confidence() -> None:
+    enforcer = _build_enforcer()
+    metrics = {"latency_ms": 240.0, "contrast_ratio": 4.8}
+    distributions = {
+        "latency_ms": {"mean": 240.0, "std": 10.0},
+        "contrast_ratio": {"mean": 4.7, "std": 0.5},
+    }
+
+    result = enforcer.enforce(metrics, distributions)
+
+    assert any("confidence" in (decision.reason or "") for decision in result.violations)
+
+
+def test_policy_enforcer_blocks_when_distribution_missing() -> None:
+    enforcer = _build_enforcer(require_distributions=True)
+    metrics = {"latency_ms": 240.0, "contrast_ratio": 4.8}
+
+    result = enforcer.enforce(metrics, distributions={})
+
+    assert result.passed is False
+    assert any("distribution" in (decision.reason or "") for decision in result.decisions)
+
+
+def test_policy_enforcer_allows_missing_distribution_when_configured() -> None:
+    enforcer = _build_enforcer(require_distributions=False)
+    metrics = {"latency_ms": 240.0, "contrast_ratio": 4.8}
+
+    result = enforcer.enforce(metrics, distributions={})
+
+    assert result.passed is True
+    assert all(decision.probability is None for decision in result.decisions)
+
+
+@pytest.mark.skipif(ConfigLoader is None, reason="ConfigLoader dependencies not available")
+def test_policy_enforcer_from_config_loader() -> None:
+    loader = ConfigLoader(config_dir=Path("config"))
+    enforcer = PolicyEnforcer.from_config_loader(loader)
+
+    metrics = {
+        "latency_ms_p95": 260.0,
+        "accessibility_contrast_ratio": 5.1,
+        "security_vuln_count": 0.0,
+    }
+    distributions = {
+        "latency_ms_p95": {"mean": 240.0, "std": 10.0},
+        "accessibility_contrast_ratio": {"mean": 5.5, "std": 0.1},
+        "security_vuln_count": {"mean": 0.0, "std": 0.0},
+    }
+
+    result = enforcer.enforce(metrics, distributions)
+
+    assert result.passed is True
+    assert {decision.metric for decision in result.decisions} >= metrics.keys()
+
+
+# SECTION 5: Error & Edge Case Handling
+# - Ensures deterministic and probabilistic failures surface descriptive reasons.
+# - Validates behaviour when distribution inputs are optional.
+
+
+# SECTION 6: Performance Considerations
+# - Tests operate on a tiny number of policies ensuring negligible runtime.
+
+
+# SECTION 7: No exports for test modules.


### PR DESCRIPTION
## Summary
- add a governance PolicyEnforcer that enforces QA policy thresholds with probabilistic checks
- export the new enforcer via the governance package and document CI/CD gating behaviour
- cover the enforcer with unit tests including integration with the config loader when available

## Testing
- pytest tests/unit/test_policy_enforcer.py

------
https://chatgpt.com/codex/tasks/task_e_68d3c327dd808321a7bd0711f24a5811