### PR TITLE
[rentalos-ai] Implement stage 2 intelligence

### DIFF
--- a/rentalos-ai/README.md
+++ b/rentalos-ai/README.md
@@ -2,6 +2,9 @@
 
 RentalOS-AI is an intelligent operating system for the rental economy. Stage 1 establishes
 core backend services, a modular frontend foundation, and documentation that defines the architectural vision.
+Stage 2 evolves those foundations with data-informed pricing, predictive maintenance anomaly
+detection, and a programmable plugin marketplace that paves the way for third-party
+extensions.
 
 ## Getting Started
 
@@ -25,4 +28,15 @@ directory, and shared documentation is available under `docs`.
 ## Stage Tracking
 
 Use `python scripts/detect_stage.py` to determine the highest completed stage. Update `deploy_logs/changelog.md`
-after finishing each stage so the detector can track progress accurately.
+after finishing each stage so the detector can track progress accurately. Stage 2 adds a
+"Stage 2 complete" entry once predictive services and plugin orchestration are ready for
+experimentation.
+
+## Stage 2 Highlights
+
+- Pricing engine ingests rolling market snapshots and produces confidence-aware
+  recommendations.
+- Maintenance service analyses sensor windows for anomalies and promotes urgent tasks
+  into the generated schedule.
+- API service maintains an in-memory plugin registry that simulates marketplace workflows
+  and supports enable/disable lifecycle testing.

--- a/rentalos-ai/deploy_logs/changelog.md
+++ b/rentalos-ai/deploy_logs/changelog.md
@@ -1,3 +1,4 @@
 # Deployment & Decision Log
 
 - 2025-09-24T19:46:00.164153 UTC — Stage 1 complete: initialized structure, documentation, and deterministic services.
+- 2025-09-24T20:35:10Z — Stage 2 complete: introduced data-fed pricing forecasts, sensor anomaly scheduling, and plugin registry groundwork.

--- a/rentalos-ai/docs/architecture.md
+++ b/rentalos-ai/docs/architecture.md
@@ -3,6 +3,9 @@
 RentalOS-AI follows a modular monolith architecture that keeps backend services, orchestration logic,
 frontend presentation, and shared documentation in a single repository. Stage 1 establishes the key
 packages, data models, and request flows that later stages will expand with advanced AI and integrations.
+Stage 2 layers data feedback loops onto those foundations: market snapshots flow into the pricing
+service via the knowledge base, sensor rollups highlight anomalies for maintenance, and a plugin
+registry models the extension marketplace that external partners will eventually use.
 
 ## Backend Overview
 
@@ -19,8 +22,10 @@ core modules and sets up Tailwind-powered design primitives.
 ## Data Management
 
 SQLAlchemy models describe relational entities while Pydantic schemas ensure strict validation of API payloads.
-Future stages will integrate PostgreSQL, Redis caching, and a Neo4j knowledge graph. For Stage 1 we provide
-in-memory mock data for deterministic tests.
+The Stage 2 knowledge base upgrade retains an in-memory implementation but now tracks per-entity metric
+series, providing weighted averages, rolling confidence calculations, and snapshots for tests.
+Future stages will integrate PostgreSQL, Redis caching, and a Neo4j knowledge graph. For now we provide
+in-memory mock data that mimic those interfaces for deterministic tests.
 
 ## Observability & Security
 
@@ -29,6 +34,9 @@ handle hashing and token creation, and validators provide fairness and sanitatio
 
 ## Extensibility
 
-The orchestrator coordinates specialized agents that encapsulate AI-driven logic. Stage 1 supplies lightweight
-agents with deterministic responses, enabling tests and demonstrating how asynchronous orchestration will work in
-later stages.
+The orchestrator coordinates specialized agents that encapsulate AI-driven logic. Stage 2 preserves the
+deterministic agent responses but feeds them with richer pre-processing: pricing adjustments blend
+weighted historical rates, demand indexes, and sustainability modifiers before delegating to the agent
+layer, while maintenance agents receive severity hints derived from anomaly scores. The API service now
+hosts a plugin registry so third parties can register, enable, and disable integrations without altering
+core code paths.

--- a/rentalos-ai/docs/testing.md
+++ b/rentalos-ai/docs/testing.md
@@ -5,4 +5,13 @@ routes. Frontend tests verify that components render expected labels and that pa
 together. The testing harness uses `pytest` for Python modules and `vitest` with React Testing Library for
 TypeScript code.
 
+Stage 2 introduces data-driven verifications:
+
+- Pricing tests feed market snapshots into the knowledge base and assert that recommendations include
+  market adjustments with elevated confidence scores.
+- Maintenance tests establish sensor baselines, trigger anomalies, and ensure follow-up tasks surface in
+  generated schedules.
+- API tests simulate plugin registration, lifecycle toggles, and metadata summaries for marketplace-ready
+  integrations.
+
 Future stages will extend this foundation with performance, fairness, and resilience testing.

--- a/rentalos-ai/src/backend/orchestrator/knowledge_base.py
+++ b/rentalos-ai/src/backend/orchestrator/knowledge_base.py
@@ -1,21 +1,101 @@
-"""Placeholder knowledge base integration for Stage 2."""
+"""In-memory knowledge base used to mimic a Neo4j integration."""
 
 from __future__ import annotations
 
-from typing import Dict, List
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, MutableMapping, Sequence
+
+
+@dataclass
+class RelationshipRecord:
+    """Represents an edge in the lightweight knowledge graph."""
+
+    subject: str
+    predicate: str
+    target: str
+
+
+@dataclass
+class MetricSeries:
+    """Stores the latest metric values for an entity."""
+
+    values: List[float] = field(default_factory=list)
+
+    def append(self, value: float, max_points: int = 30) -> None:
+        self.values.append(float(value))
+        if len(self.values) > max_points:
+            # Retain a rolling window so calculations stay responsive.
+            del self.values[: len(self.values) - max_points]
+
+    def tail(self, limit: int | None = None) -> List[float]:
+        if limit is None:
+            return list(self.values)
+        if limit <= 0:
+            return []
+        return list(self.values[-limit:])
 
 
 class KnowledgeBaseClient:
-    """Lightweight in-memory knowledge base used for Stage 1 tests."""
+    """Lightweight graph client that mirrors core Neo4j queries."""
 
     def __init__(self) -> None:
-        self._relationships: Dict[str, List[str]] = {}
+        self._relationships: List[RelationshipRecord] = []
+        self._metrics: MutableMapping[str, MutableMapping[str, MetricSeries]] = {}
 
-    def add_relationship(self, key: str, value: str) -> None:
-        self._relationships.setdefault(key, []).append(value)
+    # ------------------------------------------------------------------
+    # Relationship helpers
+    # ------------------------------------------------------------------
+    def add_relationship(self, subject: str, predicate: str, target: str) -> None:
+        self._relationships.append(
+            RelationshipRecord(subject=subject, predicate=predicate, target=target)
+        )
 
-    def related(self, key: str) -> List[str]:
-        return list(self._relationships.get(key, []))
+    def related(self, subject: str, predicate: str | None = None) -> List[str]:
+        matches: Iterable[RelationshipRecord]
+        if predicate is None:
+            matches = (rel for rel in self._relationships if rel.subject == subject)
+        else:
+            matches = (
+                rel
+                for rel in self._relationships
+                if rel.subject == subject and rel.predicate == predicate
+            )
+        return [rel.target for rel in matches]
+
+    # ------------------------------------------------------------------
+    # Metric helpers
+    # ------------------------------------------------------------------
+    def record_metric(self, entity: str, metric: str, value: float) -> None:
+        entity_metrics = self._metrics.setdefault(entity, {})
+        series = entity_metrics.setdefault(metric, MetricSeries())
+        series.append(value)
+
+    def get_metric_series(self, entity: str, metric: str, limit: int | None = None) -> List[float]:
+        entity_metrics = self._metrics.get(entity)
+        if not entity_metrics:
+            return []
+        series = entity_metrics.get(metric)
+        if not series:
+            return []
+        return series.tail(limit)
+
+    def latest_metric(self, entity: str, metric: str) -> float | None:
+        series = self.get_metric_series(entity, metric, limit=1)
+        return series[-1] if series else None
+
+    def snapshot(self) -> Dict[str, Dict[str, Sequence[float]]]:
+        """Return a serializable snapshot for debugging and tests."""
+
+        return {
+            entity: {metric: list(series.values) for metric, series in metrics.items()}
+            for entity, metrics in self._metrics.items()
+        }
+
+    def clear(self) -> None:
+        """Remove all stored relationships and metrics (testing helper)."""
+
+        self._relationships.clear()
+        self._metrics.clear()
 
 
 knowledge_base = KnowledgeBaseClient()

--- a/rentalos-ai/src/backend/services/api_service.py
+++ b/rentalos-ai/src/backend/services/api_service.py
@@ -1,11 +1,91 @@
-"""API integration service reserved for Stage 2 enhancements."""
+"""API integration and plugin registry utilities."""
 
 from __future__ import annotations
 
-from typing import Dict
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, MutableMapping, Optional
 
 
-def list_plugins() -> Dict[str, str]:
-    """Return an empty plugin mapping for Stage 1."""
+@dataclass
+class Plugin:
+    """Represents a dynamically loadable plugin."""
 
-    return {}
+    name: str
+    version: str
+    description: str = ""
+    enabled: bool = True
+    permissions: List[str] = field(default_factory=list)
+    webhooks: List[str] = field(default_factory=list)
+
+    def as_dict(self) -> Dict[str, object]:
+        return {
+            "name": self.name,
+            "version": self.version,
+            "description": self.description,
+            "enabled": self.enabled,
+            "permissions": list(self.permissions),
+            "webhooks": list(self.webhooks),
+        }
+
+
+class PluginRegistry:
+    """In-memory registry that mimics a plugin marketplace."""
+
+    def __init__(self) -> None:
+        self._plugins: MutableMapping[str, Plugin] = {}
+
+    def register(self, plugin: Plugin) -> Plugin:
+        self._plugins[plugin.name] = plugin
+        return plugin
+
+    def enable(self, name: str) -> None:
+        plugin = self._plugins[name]
+        plugin.enabled = True
+
+    def disable(self, name: str) -> None:
+        plugin = self._plugins[name]
+        plugin.enabled = False
+
+    def get(self, name: str) -> Plugin:
+        return self._plugins[name]
+
+    def list(self) -> List[Plugin]:
+        return list(self._plugins.values())
+
+    def describe(self) -> Dict[str, Dict[str, object]]:
+        return {plugin.name: plugin.as_dict() for plugin in self._plugins.values()}
+
+
+registry = PluginRegistry()
+
+
+def register_plugin(
+    name: str,
+    version: str,
+    *,
+    description: str = "",
+    permissions: Optional[Iterable[str]] = None,
+    webhooks: Optional[Iterable[str]] = None,
+    enabled: bool = True,
+) -> Plugin:
+    """Register a plugin with metadata.
+
+    The registry allows test doubles to emulate a richer Stage 2 plugin
+    marketplace while keeping the implementation deterministic.
+    """
+
+    plugin = Plugin(
+        name=name,
+        version=version,
+        description=description,
+        permissions=list(permissions or []),
+        webhooks=list(webhooks or []),
+        enabled=enabled,
+    )
+    return registry.register(plugin)
+
+
+def list_plugins() -> Dict[str, Dict[str, object]]:
+    """Return all registered plugins."""
+
+    return registry.describe()

--- a/rentalos-ai/src/backend/services/maintenance_service.py
+++ b/rentalos-ai/src/backend/services/maintenance_service.py
@@ -1,13 +1,15 @@
-"""Predictive maintenance service."""
+"""Predictive maintenance service with anomaly detection."""
 
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import List
+from statistics import fmean, pstdev
+from typing import Dict, List, Sequence
 
 from pydantic import BaseModel, Field
 
 from ..orchestrator import dispatcher
+from ..orchestrator.knowledge_base import knowledge_base
 from ..utils.logger import get_logger
 from ..utils.scheduling import add_minutes
 
@@ -21,18 +23,58 @@ class MaintenanceTask(BaseModel):
     severity: str = Field(pattern="^(low|medium|high)$")
 
 
-async def generate_schedule(asset_id: int) -> List[MaintenanceTask]:
-    """Generate maintenance tasks using deterministic heuristics."""
+class SensorWindow(BaseModel):
+    """Represents a short aggregation of sensor samples."""
 
+    metric: str
+    samples: List[float]
+
+    def average(self) -> float:
+        return fmean(self.samples) if self.samples else 0.0
+
+    def stdev(self) -> float:
+        return pstdev(self.samples) if len(self.samples) > 1 else 0.0
+
+
+def detect_anomalies(windows: Sequence[SensorWindow], threshold: float = 1.5) -> Dict[str, float]:
+    """Return a mapping of metric -> anomaly score."""
+
+    scores: Dict[str, float] = {}
+    for window in windows:
+        baseline = knowledge_base.get_metric_series("sensor:" + window.metric, "avg", limit=12)
+        baseline_mean = fmean(baseline) if baseline else window.average()
+        if len(baseline) > 1:
+            baseline_stdev = pstdev(baseline)
+        elif baseline:
+            baseline_stdev = 0.1
+        else:
+            baseline_stdev = window.stdev() or 0.1
+        deviation = abs(window.average() - baseline_mean)
+        severity_ratio = window.stdev() / (baseline_stdev or 0.1)
+        score = max(deviation / baseline_stdev if baseline_stdev else 0.0, severity_ratio)
+        if score >= threshold:
+            scores[window.metric] = round(score, 2)
+        knowledge_base.record_metric("sensor:" + window.metric, "avg", window.average())
+    return scores
+
+
+async def generate_schedule(
+    asset_id: int, sensor_windows: Sequence[SensorWindow] | None = None
+) -> List[MaintenanceTask]:
+    """Generate maintenance tasks using deterministic heuristics plus anomalies."""
+
+    sensor_windows = sensor_windows or []
+    anomaly_scores = detect_anomalies(sensor_windows)
     now = datetime.utcnow()
+    severity = "medium" if anomaly_scores else "low"
     payload = {
         "asset_id": asset_id,
-        "sensor_alerts": 3,
+        "sensor_alerts": len(anomaly_scores),
         "tasks": ["inspect HVAC", "check sensors"],
     }
     agent_result = await dispatcher.dispatch("maintenance", payload)
-    severity = agent_result["data"]["severity"]
-    tasks = [
+    severity = max(severity, agent_result["data"]["severity"], key=["low", "medium", "high"].index)
+    base_tasks = [
         MaintenanceTask(
             asset_id=asset_id,
             scheduled_for=add_minutes(now, 60),
@@ -46,10 +88,22 @@ async def generate_schedule(asset_id: int) -> List[MaintenanceTask]:
             severity="low",
         ),
     ]
+
+    for metric, score in anomaly_scores.items():
+        base_tasks.append(
+            MaintenanceTask(
+                asset_id=asset_id,
+                scheduled_for=add_minutes(now, 30),
+                description=f"Investigate anomaly in {metric}",
+                severity="high" if score > 4 else "medium",
+            )
+        )
+
     logger.info(
-        "Generated maintenance schedule", extra={"asset_id": asset_id, "severity": severity}
+        "Generated maintenance schedule",
+        extra={"asset_id": asset_id, "anomalies": anomaly_scores},
     )
-    return tasks
+    return base_tasks
 
 
 def get_maintenance_history(asset_id: int) -> List[str]:

--- a/rentalos-ai/src/backend/services/pricing_service.py
+++ b/rentalos-ai/src/backend/services/pricing_service.py
@@ -1,13 +1,16 @@
-"""Pricing service implementing deterministic recommendations."""
+"""Pricing service implementing data-informed recommendations."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime
-from typing import Dict, List
+from statistics import pstdev
+from typing import Dict, Iterable, List
 
 from pydantic import BaseModel
 
 from ..orchestrator import dispatcher
+from ..orchestrator.knowledge_base import knowledge_base
 from ..utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -27,30 +30,110 @@ class PriceSuggestion(BaseModel):
     confidence: float
 
 
-async def calculate_price(asset_id: int, start_date: datetime, duration: int) -> Dict[str, object]:
-    """Generate a pricing recommendation for an asset."""
+@dataclass
+class MarketSnapshot:
+    """Represents recent demand signals for an asset."""
 
-    base_price = 110 + asset_id * 0.5
+    occupancy: float
+    demand_index: float
+    competitor_rate: float
+
+
+def ingest_market_snapshot(
+    asset_id: int, rate: float, occupancy: float, esg_score: float, demand_index: float
+) -> None:
+    """Persist signals to the knowledge base so pricing remains contextual."""
+
+    entity = f"asset:{asset_id}"
+    knowledge_base.record_metric(entity, "rate", rate)
+    knowledge_base.record_metric(entity, "occupancy", occupancy)
+    knowledge_base.record_metric(entity, "esg", esg_score)
+    knowledge_base.record_metric(entity, "demand", demand_index)
+
+
+def _weighted_average(values: Iterable[float]) -> float:
+    window = list(values)
+    if not window:
+        raise ValueError("values cannot be empty")
+    weights = list(range(1, len(window) + 1))
+    total_weight = sum(weights)
+    weighted_sum = sum(value * weight for value, weight in zip(window, weights, strict=False))
+    return weighted_sum / total_weight
+
+
+def _forecast_base_rate(asset_id: int) -> float:
+    series = knowledge_base.get_metric_series(f"asset:{asset_id}", "rate", limit=8)
+    if series:
+        try:
+            return _weighted_average(series)
+        except ValueError:
+            pass
+    return 110 + asset_id * 0.5
+
+
+def _latest_snapshot(asset_id: int) -> MarketSnapshot:
+    entity = f"asset:{asset_id}"
+    occupancy = knowledge_base.latest_metric(entity, "occupancy") or 0.9
+    competitor = knowledge_base.latest_metric(entity, "rate") or (
+        _forecast_base_rate(asset_id) * 1.05
+    )
+    demand_index = knowledge_base.latest_metric(entity, "demand") or 1.0
+    return MarketSnapshot(
+        occupancy=float(occupancy),
+        demand_index=float(demand_index),
+        competitor_rate=float(competitor),
+    )
+
+
+def _confidence_from_history(asset_id: int) -> float:
+    series = knowledge_base.get_metric_series(f"asset:{asset_id}", "rate", limit=8)
+    if len(series) < 2:
+        return 0.7
+    variability = pstdev(series)
+    # Higher variability reduces the confidence interval.
+    return max(0.55, 0.9 - min(variability / 100, 0.3))
+
+
+async def calculate_price(asset_id: int, start_date: datetime, duration: int) -> Dict[str, object]:
+    """Generate a pricing recommendation for an asset.
+
+    The routine analyses recent market signals from the knowledge base and
+    adjusts the deterministic Stage 1 model with demand and sustainability
+    context. This keeps the runtime light while reflecting data driven
+    behaviour expected from Stage 2.
+    """
+
+    base_price = _forecast_base_rate(asset_id)
+    snapshot = _latest_snapshot(asset_id)
+    esg_score = knowledge_base.latest_metric(f"asset:{asset_id}", "esg") or 75.0
+    sustainability_modifier = 1 + (esg_score - 70) / 500
+    demand_modifier = 1 + (snapshot.demand_index - 1.0) / 4
+    occupancy_modifier = 1 + (snapshot.occupancy - 0.85) / 5
+
+    adjusted_base = base_price * sustainability_modifier * demand_modifier * occupancy_modifier
     payload = {
         "asset_id": asset_id,
-        "base_price": base_price,
-        "occupancy": 0.9,
-        "sustainability_score": 78,
+        "base_price": adjusted_base,
+        "occupancy": snapshot.occupancy,
+        "sustainability_score": esg_score,
     }
     logger.info("Calculating price", extra={"asset_id": asset_id})
     agent_result = await dispatcher.dispatch("pricing", payload)
     suggested_price = agent_result["data"]["price"]
+    occupancy_component = round(adjusted_base - base_price, 2)
+    agent_component = round(suggested_price - adjusted_base, 2)
     components = [
-        PriceComponent(label="base", value=base_price),
-        PriceComponent(label="occupancy_adjustment", value=round(suggested_price - base_price, 2)),
+        PriceComponent(label="base", value=round(base_price, 2)),
+        PriceComponent(label="market_adjustment", value=occupancy_component),
+        PriceComponent(label="agent_adjustment", value=agent_component),
     ]
     suggestion = PriceSuggestion(
         asset_id=asset_id,
         start_date=start_date,
         duration=duration,
-        suggested_price=suggested_price,
+        suggested_price=round(suggested_price, 2),
         components=components,
-        confidence=agent_result["data"]["confidence"],
+        confidence=_confidence_from_history(asset_id),
     )
     return suggestion.model_dump()
 

--- a/rentalos-ai/src/backend/tests/unit/test_api_service.py
+++ b/rentalos-ai/src/backend/tests/unit/test_api_service.py
@@ -1,0 +1,26 @@
+from src.backend.services import api_service
+
+
+def test_register_plugin_persists_metadata():
+    api_service.registry = api_service.PluginRegistry()  # reset
+    plugin = api_service.register_plugin(
+        "green-energy",
+        "1.0.0",
+        description="Aggregates renewable energy providers",
+        permissions=["energy:read"],
+        webhooks=["https://example.com/hook"],
+        enabled=False,
+    )
+    assert plugin.enabled is False
+    summary = api_service.list_plugins()
+    assert "green-energy" in summary
+    assert summary["green-energy"]["permissions"] == ["energy:read"]
+
+
+def test_registry_enable_disable_cycle():
+    api_service.registry = api_service.PluginRegistry()  # reset
+    api_service.register_plugin("payments", "0.2.0")
+    api_service.registry.disable("payments")
+    assert api_service.list_plugins()["payments"]["enabled"] is False
+    api_service.registry.enable("payments")
+    assert api_service.list_plugins()["payments"]["enabled"] is True

--- a/rentalos-ai/src/backend/tests/unit/test_maintenance_service.py
+++ b/rentalos-ai/src/backend/tests/unit/test_maintenance_service.py
@@ -1,10 +1,36 @@
 import pytest
 
-from src.backend.services.maintenance_service import generate_schedule
+from src.backend.orchestrator.knowledge_base import knowledge_base
+from src.backend.services.maintenance_service import (
+    SensorWindow,
+    detect_anomalies,
+    generate_schedule,
+)
 
 
 @pytest.mark.asyncio
 async def test_generate_schedule_creates_tasks():
+    knowledge_base.clear()
     tasks = await generate_schedule(1)
     assert len(tasks) == 2
     assert tasks[0].asset_id == 1
+
+
+def test_detect_anomalies_flags_large_deviation():
+    knowledge_base.clear()
+    baseline_window = SensorWindow(metric="temperature", samples=[70, 71, 69])
+    detect_anomalies([baseline_window])  # establish baseline
+    anomalous = SensorWindow(metric="temperature", samples=[80, 81, 82])
+    scores = detect_anomalies([anomalous])
+    assert "temperature" in scores
+    assert scores["temperature"] >= 2
+
+
+@pytest.mark.asyncio
+async def test_generate_schedule_includes_anomaly_task():
+    knowledge_base.clear()
+    baseline = SensorWindow(metric="pressure", samples=[29, 30, 31])
+    anomalous = SensorWindow(metric="pressure", samples=[30, 31, 46])
+    tasks = await generate_schedule(2, sensor_windows=[baseline, anomalous])
+    descriptions = [task.description for task in tasks]
+    assert any("pressure" in desc for desc in descriptions)

--- a/rentalos-ai/src/backend/tests/unit/test_pricing_service.py
+++ b/rentalos-ai/src/backend/tests/unit/test_pricing_service.py
@@ -2,12 +2,26 @@ from datetime import datetime
 
 import pytest
 
-from src.backend.services.pricing_service import calculate_price
+from src.backend.orchestrator.knowledge_base import knowledge_base
+from src.backend.services.pricing_service import calculate_price, ingest_market_snapshot
 
 
 @pytest.mark.asyncio
 async def test_calculate_price_returns_components():
+    knowledge_base.clear()
     result = await calculate_price(1, datetime.utcnow(), 7)
     assert result["asset_id"] == 1
     assert result["suggested_price"] > 0
     assert any(component["label"] == "base" for component in result["components"])
+
+
+@pytest.mark.asyncio
+async def test_calculate_price_respects_market_snapshot():
+    knowledge_base.clear()
+    ingest_market_snapshot(asset_id=2, rate=200.0, occupancy=0.95, esg_score=85.0, demand_index=1.2)
+    ingest_market_snapshot(asset_id=2, rate=205.0, occupancy=0.96, esg_score=86.0, demand_index=1.1)
+    result = await calculate_price(2, datetime.utcnow(), 7)
+    assert result["suggested_price"] >= 200
+    assert result["confidence"] >= 0.7
+    component_labels = [component["label"] for component in result["components"]]
+    assert "market_adjustment" in component_labels


### PR DESCRIPTION
## Summary
- enrich the in-memory knowledge base with typed relationships, rolling metrics, and testing helpers
- augment pricing, maintenance, and API services with data-driven snapshots, anomaly detection, and a plugin registry plus new unit coverage
- document Stage 2 capabilities across the README, architecture, testing strategy, and deployment log

## Testing
- pytest -q
- flake8 src
- mypy --config-file mypy.ini -m src.backend.services.pricing_service -m src.backend.services.maintenance_service -m src.backend.services.api_service -m src.backend.tests.unit.test_pricing_service -m src.backend.tests.unit.test_maintenance_service -m src.backend.tests.unit.test_api_service
- npm test -- --watch=false *(fails: requires @vitejs/plugin-react from frontend workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d4546e576c8321a48ee8422d35dae8