### PR TITLE
fix: add task remediation wiring

### DIFF
--- a/U-DIG-IT/runner_project/src/execution/task_manager.py
+++ b/U-DIG-IT/runner_project/src/execution/task_manager.py
@@ -4,23 +4,49 @@ from __future__ import annotations
 
 import asyncio
 import threading
+from concurrent.futures import Future
+from contextlib import suppress
+from contextvars import copy_context
 from datetime import datetime, timezone
 from typing import Any, Callable, Coroutine, Dict, Optional
 from uuid import uuid4
 
-from ..errors import TaskError
+from ..errors import RunnerError, TaskError
 from ..types import Task, TaskCreation, TaskList, TaskStatus
 from ..utils.logger import get_logger
 
 LOGGER = get_logger("task_manager")
 
 
-class TaskManager:
-    """Manage asynchronous tasks and their results."""
+def _default_retry_budget() -> int:
+    """Derive the retry budget from configuration when available."""
 
-    def __init__(self) -> None:
+    try:
+        from ..config import get_config
+    except Exception:  # pragma: no cover - configuration import failure
+        return 0
+    try:
+        config = get_config()
+    except Exception:  # pragma: no cover - configuration resolution failure
+        return 0
+    return max(0, int(config.max_task_failures) - 1)
+
+
+class TaskManager:
+    """Manage asynchronous tasks, supporting optional automatic retries."""
+
+    def __init__(self, max_retries: Optional[int] = None) -> None:
         self._tasks: Dict[str, Task] = {}
         self._lock = threading.Lock()
+        self._loop_lock = threading.Lock()
+        if max_retries is None:
+            retry_budget = _default_retry_budget()
+        else:
+            retry_budget = max(0, max_retries)
+        self._max_retries = retry_budget
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._thread: Optional[threading.Thread] = None
+        self._start_loop()
 
     async def create_task(
         self, coro_factory: Callable[[], Coroutine[Any, Any, Any]]
@@ -39,20 +65,110 @@ class TaskManager:
                 error=None,
             )
 
-        loop = asyncio.get_running_loop()
+        context = copy_context()
 
-        def execute() -> None:
-            self._set_status(task_id, TaskStatus.RUNNING)
-            try:
-                result = asyncio.run(coro_factory())
-            except Exception as exc:  # noqa: BLE001
-                LOGGER.exception("Task %s failed", task_id)
-                self._set_failure(task_id, exc)
-            else:
-                self._set_result(task_id, result)
+        async def runner() -> None:
+            attempt = 0
+            while True:
+                self._set_status(task_id, TaskStatus.RUNNING)
+                try:
+                    result = await context.run(coro_factory)
+                except asyncio.CancelledError:  # pragma: no cover - currently unused
+                    self._set_failure(task_id, TaskError("Task was cancelled"))
+                    return
+                except Exception as exc:  # noqa: BLE001
+                    should_retry = attempt < self._max_retries and not isinstance(exc, RunnerError)
+                    if should_retry:
+                        LOGGER.warning(
+                            "Task %s failed on attempt %s/%s: %s",
+                            task_id,
+                            attempt + 1,
+                            self._max_retries + 1,
+                            exc,
+                        )
+                        self._set_status(task_id, TaskStatus.PENDING)
+                        attempt += 1
+                        await asyncio.sleep(0)
+                        continue
+                    if isinstance(exc, RunnerError):
+                        LOGGER.warning("Task %s failed: %s", task_id, exc)
+                    else:
+                        LOGGER.exception("Task %s failed on final attempt", task_id)
+                    self._set_failure(task_id, exc)
+                    return
+                else:
+                    self._set_result(task_id, result)
+                    return
 
-        loop.run_in_executor(None, execute)
+        def _log_future(fut: Future) -> None:  # pragma: no cover - defensive logging
+            exc = fut.exception()
+            if exc is not None:
+                LOGGER.exception("Task runner failed", exc_info=exc)
+
+        with self._loop_lock:
+            loop = self._loop
+        if loop is None:
+            raise TaskError("Task manager event loop is not running")
+        try:
+            future = asyncio.run_coroutine_threadsafe(runner(), loop)
+        except RuntimeError as exc:  # pragma: no cover - defensive guard
+            raise TaskError("Task manager event loop is not running") from exc
+        future.add_done_callback(_log_future)
         return TaskCreation(task_id=task_id, status=TaskStatus.PENDING)
+
+    @staticmethod
+    def _run_loop(loop: asyncio.AbstractEventLoop) -> None:
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_forever()
+        finally:
+            pending = asyncio.all_tasks(loop)
+            for task in pending:
+                task.cancel()
+            with suppress(Exception):
+                loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+            loop.close()
+
+    def _start_loop(self) -> None:
+        loop = asyncio.new_event_loop()
+        thread = threading.Thread(
+            target=self._run_loop,
+            args=(loop,),
+            name="task-manager-loop",
+            daemon=True,
+        )
+        thread.start()
+        with self._loop_lock:
+            self._loop = loop
+            self._thread = thread
+
+    def _stop_loop(self) -> None:
+        with self._loop_lock:
+            loop = self._loop
+            thread = self._thread
+            self._loop = None
+            self._thread = None
+        if loop is None or thread is None:
+            return
+        if loop.is_running():
+            loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=2.0)
+
+    def restart(self) -> None:
+        """Restart the background event loop used to execute tasks."""
+
+        LOGGER.warning("Restarting task manager event loop after remediation")
+        self._stop_loop()
+        self._start_loop()
+
+    def shutdown(self) -> None:
+        """Stop the background event loop."""
+
+        self._stop_loop()
+
+    @property
+    def max_retries(self) -> int:
+        return self._max_retries
 
     def _set_status(self, task_id: str, status: TaskStatus) -> None:
         with self._lock:

--- a/U-DIG-IT/runner_project/tests/test_resilience.py
+++ b/U-DIG-IT/runner_project/tests/test_resilience.py
@@ -1,6 +1,33 @@
+import asyncio
+import threading
+
 import pytest
 
+from src.agents.orchestrator import Orchestrator
+from src.types import TaskList
 from src.utils.observer import HealthObserver
+
+
+class _StubTaskManager:
+    def __init__(self) -> None:
+        self.restart_event = threading.Event()
+        self.restart_calls = 0
+
+    async def create_task(self, coro_factory):  # pragma: no cover - not exercised
+        raise NotImplementedError
+
+    async def list_tasks(self) -> TaskList:
+        return TaskList(tasks=[])
+
+    async def get_task(self, task_id: str):  # pragma: no cover - not exercised
+        return None
+
+    async def wait_for(self, task_id: str):  # pragma: no cover - not exercised
+        return None
+
+    def restart(self) -> None:
+        self.restart_calls += 1
+        self.restart_event.set()
 
 
 @pytest.mark.asyncio
@@ -20,3 +47,42 @@ async def test_health_observer_recovers() -> None:
     observer.record_success("tasks")
     report = await observer.run_checks()
     assert report.status == "healthy"
+
+
+@pytest.mark.asyncio
+async def test_health_observer_triggers_remediation() -> None:
+    observer = HealthObserver(max_failures=1)
+    event = asyncio.Event()
+
+    async def failing_check() -> dict[str, str]:
+        return {"status": "unhealthy", "detail": "boom"}
+
+    observer.register_check("tasks", failing_check)
+
+    async def remediation() -> None:
+        event.set()
+
+    observer.register_remediation("tasks", remediation)
+
+    observer.record_failure("tasks")
+    await asyncio.sleep(0)
+    await observer.run_checks()
+
+    await asyncio.wait_for(event.wait(), timeout=1)
+    assert observer.remediation_history()
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_registers_task_remediation() -> None:
+    manager = _StubTaskManager()
+    observer = HealthObserver(max_failures=1)
+    orchestrator = Orchestrator(manager=manager, observer=observer)
+
+    observer.record_failure("tasks")
+    await observer.run_checks()
+
+    assert await asyncio.to_thread(manager.restart_event.wait, 1.0)
+    assert manager.restart_calls == 1
+    await asyncio.sleep(0)
+    assert observer.remediation_history()
+    assert observer.failure_counts().get("tasks", 0) == 0

--- a/U-DIG-IT/runner_project/tests/test_task_manager.py
+++ b/U-DIG-IT/runner_project/tests/test_task_manager.py
@@ -1,7 +1,9 @@
+import asyncio
+
 import pytest
 
 from src.execution.task_manager import TaskManager
-from src.types import TaskStatus
+from src.types import Task, TaskStatus
 
 
 @pytest.mark.asyncio
@@ -30,3 +32,67 @@ async def test_task_manager_failure():
     assert task is not None
     assert task.status == TaskStatus.FAILED
     assert task.error == "boom"
+
+
+@pytest.mark.asyncio
+async def test_task_manager_auto_retry() -> None:
+    attempts = 0
+    manager = TaskManager(max_retries=1)
+
+    async def job():
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("transient failure")
+        return {"result": "ok"}
+
+    creation = await manager.create_task(job)
+    task = await manager.wait_for(creation.task_id)
+
+    assert attempts == 2
+    assert task is not None
+    assert task.status == TaskStatus.COMPLETED
+    assert task.result == {"result": "ok"}
+    assert task.error is None
+
+
+@pytest.mark.asyncio
+async def test_task_manager_restart_recovers_event_loop() -> None:
+    manager = TaskManager()
+
+    await asyncio.to_thread(manager.restart)
+
+    async def job() -> str:
+        return "ok"
+
+    creation = await manager.create_task(job)
+    task = await manager.wait_for(creation.task_id)
+
+    assert task is not None
+    assert task.status == TaskStatus.COMPLETED
+    assert task.result == "ok"
+    assert task.error is None
+
+
+def test_task_manager_survives_event_loop_shutdown() -> None:
+    manager = TaskManager()
+
+    async def job() -> str:
+        await asyncio.sleep(0)
+        return "ok"
+
+    async def schedule() -> str:
+        creation = await manager.create_task(job)
+        return creation.task_id
+
+    task_id = asyncio.run(schedule())
+
+    async def await_result() -> Task:
+        task = await manager.wait_for(task_id)
+        assert task is not None
+        return task
+
+    task = asyncio.run(await_result())
+
+    assert task.status == TaskStatus.COMPLETED
+    assert task.result == "ok"


### PR DESCRIPTION
## Summary
- restart the task manager loop when the resilience observer fires by wiring the remediation hook through the orchestrator
- add restart/shutdown capabilities to the task manager so remediation can recover the background loop safely
- cover the new behaviour with regression tests for task manager restarts and orchestrator-triggered remediation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4543f74a883218f7aa682e980e806