### PR TITLE
chore: improve bootstrap caching and env automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 .pnpm-store/
 logs/
 .env
+.cache/
 dist/
 __pycache__/
 coverage/

--- a/README.md
+++ b/README.md
@@ -42,10 +42,12 @@ subset of the toolchain. If you want to hydrate additional pnpm workspaces (for 
 
 ### 2. Configure environment variables
 
-Copy `.env.example` into `.env` and adjust the values to match your environment. Curated profiles
-live under `config/environments/` (`.env.development`, `.env.cursor`, `.env.ci`) so you can quickly
-swap between a minimal setup and the Cursor-heavy automation stack. Review `docs/setup.md` for a
-complete option reference and avoid committing secrets.
+Copy `.env.example` into `.env` and adjust the values to match your environment. Regenerate the
+example file with `pnpm run env:example` whenever environment variables change to keep
+documentation, automation, and templates aligned. Curated profiles now live under
+`config/environments/` (`development.env`, `cursor.env`, `ci.env`) so you can quickly swap between a
+minimal setup and the Cursor-heavy automation stack. Review `docs/setup.md` for a complete option
+reference and avoid committing secrets.
 
 Knowledge ingestion watchers are now opt-in: leave `KNOWLEDGE_WATCH_INTERVAL` blank to skip polling
 and set it to a positive number to enable background reloads.

--- a/config/environments/ci.env
+++ b/config/environments/ci.env
@@ -1,0 +1,7 @@
+# Lean CI profile designed to minimise background activity during pipeline runs.
+NODE_ENV=test
+CURSOR_AUTO_INVOCATION_ENABLED=false
+KNOWLEDGE_AUTO_LOAD=false
+CURSOR_PERFORMANCE_MONITORING=false
+CURSOR_USAGE_TRACKING=false
+CURSOR_COMPLIANCE_REPORTING=false

--- a/config/environments/cursor.env
+++ b/config/environments/cursor.env
@@ -1,0 +1,10 @@
+# Cursor-forward profile mirroring hosted automation defaults.
+CURSOR_AUTO_INVOCATION_ENABLED=true
+CURSOR_MONITOR_INTERVAL=5
+CURSOR_FILE_PATTERNS="**/*.tsx,**/*.py,**/*.md,**/*.js,**/*.ts"
+KNOWLEDGE_AUTO_LOAD=true
+KNOWLEDGE_NDJSON_PATHS="Brain docs cleansed .ndjson,Bundle cleansed .ndjson"
+KNOWLEDGE_WATCH_INTERVAL=10
+CURSOR_PERFORMANCE_MONITORING=true
+CURSOR_USAGE_TRACKING=true
+CURSOR_COMPLIANCE_REPORTING=true

--- a/config/environments/development.env
+++ b/config/environments/development.env
@@ -1,0 +1,6 @@
+# Baseline development profile for running services locally without automation overlays.
+NODE_ENV=development
+PORT=4000
+CURSOR_AUTO_INVOCATION_ENABLED=false
+KNOWLEDGE_AUTO_LOAD=false
+KNOWLEDGE_WATCH_INTERVAL=

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "author": "Nick",
   "type": "module",
+  "packageManager": "pnpm@9.12.0",
   "main": "src/index.js",
   "bin": {
     "ask": "scripts/ask.js"
@@ -65,6 +66,7 @@
     "cursor:knowledge": "python scripts/bootstrap_knowledge.py",
     "cursor:integration": "python scripts/bootstrap_cursor_integration.py",
     "codex:status": "python scripts/codex_status.py",
+    "env:example": "python scripts/generate_env_example.py",
     "start": "node src/index.js"
   },
   "dependencies": {

--- a/scripts/bootstrap_dev.py
+++ b/scripts/bootstrap_dev.py
@@ -3,12 +3,44 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
+import json
 import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Sequence
+from typing import Any, Sequence
 from venv import EnvBuilder
+
+STATE_FILE = Path(".cache/bootstrap_state.json")
+
+
+def _load_state() -> dict[str, Any]:
+    if not STATE_FILE.exists():
+        return {}
+    try:
+        with STATE_FILE.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except json.JSONDecodeError:
+        return {}
+
+
+def _save_state(state: dict[str, Any]) -> None:
+    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with STATE_FILE.open("w", encoding="utf-8") as handle:
+        json.dump(state, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def _hash_files(paths: Sequence[Path]) -> str:
+    digest = hashlib.sha256()
+    for path in paths:
+        digest.update(path.as_posix().encode("utf-8"))
+        if path.exists():
+            with path.open("rb") as handle:
+                for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                    digest.update(chunk)
+    return digest.hexdigest()
 
 
 def _run(cmd: Sequence[str], *, env: dict[str, str] | None = None) -> None:
@@ -27,20 +59,71 @@ def _ensure_virtualenv(venv_path: Path) -> Path:
     return venv_path / "bin" / "python"
 
 
-def _bootstrap_node(*, frozen: bool) -> None:
+def _node_fingerprint() -> str:
+    return _hash_files([Path("package.json"), Path("pnpm-lock.yaml")])
+
+
+def _should_skip_node(state: dict[str, Any] | None, fingerprint: str) -> bool:
+    if state is None:
+        return False
+    if state.get("fingerprint") != fingerprint:
+        return False
+    return Path("node_modules").exists()
+
+
+def _bootstrap_node(*, frozen: bool, state: dict[str, Any] | None) -> dict[str, Any]:
+    fingerprint = _node_fingerprint()
+    if _should_skip_node(state, fingerprint):
+        print("Node dependencies already up to date – skipping pnpm install")
+        return {"fingerprint": fingerprint, "frozen": frozen}
+
     args = ["pnpm", "install"]
     if frozen:
         args.append("--frozen-lockfile")
     _run(args)
     _run(["pnpm", "exec", "husky", "install"])
+    return {"fingerprint": fingerprint, "frozen": frozen}
 
 
-def _bootstrap_python(venv_path: Path, *, extras: bool) -> None:
+def _python_fingerprint(*, extras: bool) -> str:
+    files = [Path("requirements.txt")]
+    if extras:
+        files.append(Path("requirements-dev.txt"))
+    return _hash_files(files)
+
+
+def _should_skip_python(
+    state: dict[str, Any] | None,
+    fingerprint: str,
+    venv_path: Path,
+    *,
+    extras: bool,
+) -> bool:
+    if state is None:
+        return False
+    if state.get("fingerprint") != fingerprint or state.get("extras") != extras:
+        return False
+    if os.name == "nt":
+        python_path = venv_path / "Scripts" / "python.exe"
+    else:
+        python_path = venv_path / "bin" / "python"
+    return python_path.exists()
+
+
+def _bootstrap_python(
+    venv_path: Path, *, extras: bool, state: dict[str, Any] | None
+) -> dict[str, Any]:
+    fingerprint = _python_fingerprint(extras=extras)
+    if _should_skip_python(state, fingerprint, venv_path, extras=extras):
+        print("Python environment already up to date – skipping pip installs")
+        return {"fingerprint": fingerprint, "extras": extras}
+
     python = _ensure_virtualenv(venv_path)
     _run([str(python), "-m", "pip", "install", "-r", "requirements.txt"])
     if extras:
         _run([str(python), "-m", "pip", "install", "-r", "requirements-dev.txt"])
     _run([str(python), "-m", "pre_commit", "install"])
+    return {"fingerprint": fingerprint, "extras": extras}
 
 
 def parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
@@ -76,12 +159,24 @@ def parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
+    state = _load_state()
+    updated_state = dict(state)
 
     if not args.skip_node:
-        _bootstrap_node(frozen=not args.no_frozen_lockfile)
+        updated_state["node"] = _bootstrap_node(
+            frozen=not args.no_frozen_lockfile,
+            state=state.get("node"),
+        )
 
     if not args.skip_python:
-        _bootstrap_python(args.venv, extras=not args.no_dev_extras)
+        updated_state["python"] = _bootstrap_python(
+            args.venv,
+            extras=not args.no_dev_extras,
+            state=state.get("python"),
+        )
+
+    if updated_state != state:
+        _save_state(updated_state)
 
     print("Bootstrap complete ✔")
     return 0

--- a/scripts/generate_env_example.py
+++ b/scripts/generate_env_example.py
@@ -1,0 +1,175 @@
+"""Generate the canonical `.env.example` file from a structured definition.
+
+The repository previously maintained environment variables manually which led to
+configuration drift across documentation and automation scripts. This utility
+keeps the example file in sync by treating the environment specification as a
+single source of truth. Run the script directly (or via `pnpm run env:example`)
+whenever variables change, and invoke it with `--check` in CI to ensure the file
+was regenerated.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+@dataclass(frozen=True)
+class EnvVar:
+    """Represents a single environment variable entry."""
+
+    name: str
+    default: str
+    comment: str | None = None
+
+
+@dataclass(frozen=True)
+class EnvSection:
+    """Logical grouping of related environment variables."""
+
+    title: str
+    variables: Sequence[EnvVar]
+    footer_comment: str | None = None
+
+
+ENV_SECTIONS: Sequence[EnvSection] = (
+    EnvSection(
+        "Core runtime",
+        (
+            EnvVar("PORT", "4000"),
+            EnvVar("NODE_ENV", "development"),
+            EnvVar("SESSION_SECRET", "replace-with-strong-secret"),
+        ),
+    ),
+    EnvSection(
+        "Credentials",
+        (
+            EnvVar("OPENAI_API_KEY", "changeme"),
+            EnvVar("CURSOR_API_KEY", ""),
+            EnvVar("CURSOR_API_URL", "https://api.cursor.sh"),
+        ),
+    ),
+    EnvSection(
+        "Machine learning experiment tracking",
+        (
+            EnvVar("MLFLOW_TRACKING_URI", "./results/mlruns"),
+            EnvVar("MLFLOW_REGISTRY_URI", "./results/mlruns"),
+            EnvVar("MLFLOW_EXPERIMENT_NAME", "CodexHUB-Baseline"),
+        ),
+    ),
+    EnvSection(
+        "Configuration locations",
+        (
+            EnvVar("PIPELINE_CONFIG_PATH", "config/default.yaml"),
+            EnvVar("GOVERNANCE_CONFIG_PATH", "config/governance.yaml"),
+            EnvVar("METRICS_CONFIG_PATH", "config/metrics.yaml"),
+        ),
+    ),
+    EnvSection(
+        "Observability outputs",
+        (
+            EnvVar("PERFORMANCE_RESULTS_DIR", "results/performance"),
+            EnvVar("AUDIT_LOG_DIR", "results/audit"),
+            EnvVar("MODEL_CARD_DIR", "docs/model_cards"),
+        ),
+    ),
+    EnvSection(
+        'Automation toggles (set to "true" to enable locally)',
+        (
+            EnvVar("CURSOR_AUTO_INVOCATION_ENABLED", "false"),
+            EnvVar("CURSOR_MONITOR_INTERVAL", "5"),
+            EnvVar("CURSOR_FILE_PATTERNS", '"**/*.tsx,**/*.py,**/*.md,**/*.js,**/*.ts"'),
+        ),
+    ),
+    EnvSection(
+        "Knowledge ingestion",
+        (
+            EnvVar("KNOWLEDGE_AUTO_LOAD", "false"),
+            EnvVar(
+                "KNOWLEDGE_NDJSON_PATHS",
+                '"Brain docs cleansed .ndjson,Bundle cleansed .ndjson"',
+            ),
+            EnvVar(
+                "KNOWLEDGE_WATCH_INTERVAL",
+                "",
+                comment="Leave blank (or set to a positive number) to enable filesystem watching.",
+            ),
+        ),
+    ),
+    EnvSection(
+        "Mobile controls",
+        (
+            EnvVar("MOBILE_CONTROL_ENABLED", "false"),
+            EnvVar("MOBILE_NOTIFICATIONS_ENABLED", "false"),
+            EnvVar("MOBILE_APP_PORT", "3001"),
+        ),
+    ),
+    EnvSection(
+        "Brain blocks integration",
+        (
+            EnvVar("BRAIN_BLOCKS_AUTO_LOAD", "false"),
+            EnvVar("BRAIN_BLOCKS_DATA_SOURCE", '"Brain docs cleansed .ndjson"'),
+            EnvVar("BRAIN_BLOCKS_QUERY_DEPTH", "summary"),
+        ),
+    ),
+    EnvSection(
+        "Performance monitoring",
+        (
+            EnvVar("CURSOR_PERFORMANCE_MONITORING", "false"),
+            EnvVar("CURSOR_USAGE_TRACKING", "false"),
+            EnvVar("CURSOR_COMPLIANCE_REPORTING", "false"),
+        ),
+    ),
+)
+
+
+def _render_section(section: EnvSection) -> list[str]:
+    lines: list[str] = [f"# {section.title}"]
+    for variable in section.variables:
+        if variable.comment:
+            for comment_line in variable.comment.splitlines():
+                lines.append(f"# {comment_line}".rstrip())
+        lines.append(f"{variable.name}={variable.default}")
+    if section.footer_comment:
+        for comment_line in section.footer_comment.splitlines():
+            lines.append(f"# {comment_line}".rstrip())
+    lines.append("")
+    return lines
+
+
+def render_env_file(sections: Iterable[EnvSection]) -> str:
+    lines: list[str] = []
+    for section in sections:
+        lines.extend(_render_section(section))
+    while lines and lines[-1] == "":
+        lines.pop()
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail if .env.example is not up to date",
+    )
+    args = parser.parse_args(argv)
+
+    rendered = render_env_file(ENV_SECTIONS)
+    target = Path(".env.example")
+    if args.check:
+        existing = target.read_text(encoding="utf-8") if target.exists() else ""
+        if existing != rendered:
+            print(".env.example is out of date. Run `python scripts/generate_env_example.py`.")
+            return 1
+        return 0
+
+    target.write_text(rendered, encoding="utf-8")
+    print("Wrote .env.example")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add pnpm metadata and a scriptable `.env.example` generator
- cache bootstrap installs for both pnpm and Python environments
- publish curated environment profiles and document the workflow

## Testing
- python -m compileall scripts
- python scripts/generate_env_example.py --check

------
https://chatgpt.com/codex/tasks/task_e_68d47dd35dac8321ba9911b1d2775049