### PR TITLE
feat: activate plugin runtime integrations

### DIFF
--- a/rentalos-ai/plugins/energy_optimizer/plugin.json
+++ b/rentalos-ai/plugins/energy_optimizer/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "energy-optimizer",
-  "version": "0.9.1",
-  "description": "Matches surplus energy supply with demand and tracks carbon offsets across the portfolio.",
-  "permissions": ["carbon:report", "energy:trade"],
-  "webhooks": [],
-  "entrypoint": "plugins.energy_optimizer.main",
-  "categories": ["sustainability", "marketplace"],
-  "enabled": false,
-  "signature": "16d4db099b091a7ef96b04526fada7c17ef0953a60711dd6e84d66ea0721b58e"
+  "version": "0.9.0",
+  "description": "Optimises energy trades by balancing carbon impact and pricing.",
+  "permissions": ["energy:trade", "esg:write"],
+  "webhooks": ["https://energy.example.com/trade"],
+  "entrypoint": "backend.plugins.energy_optimizer:setup_plugin",
+  "categories": ["energy", "sustainability"],
+  "enabled": true,
+  "signature": "0d5716835354a75c798d839df6994f986f4dc3272214703c911c9f4f0b2544b6"
 }

--- a/rentalos-ai/plugins/equitable_pricing/plugin.json
+++ b/rentalos-ai/plugins/equitable_pricing/plugin.json
@@ -4,7 +4,7 @@
   "description": "Applies fairness-aware adjustments and provides transparency reports for pricing decisions.",
   "permissions": ["fairness:review", "pricing:read"],
   "webhooks": ["https://fairness.example.com/hook"],
-  "entrypoint": "plugins.equitable_pricing.main",
+  "entrypoint": "backend.plugins.equitable_pricing:setup_plugin",
   "categories": ["analytics", "fairness"],
   "enabled": true,
   "signature": "6e581a119df3160c226b633cf97f38b0a5491ccc44464a3cbc2d829479633a96"

--- a/rentalos-ai/src/backend/plugins/__init__.py
+++ b/rentalos-ai/src/backend/plugins/__init__.py
@@ -1,0 +1,17 @@
+"""Runtime primitives for RentalOS-AI plugins."""
+
+from .runtime import (
+    EnergyAdvisorResult,
+    EnergyTradeContext,
+    PluginRuntime,
+    PricingAdjustment,
+    PricingContext,
+)
+
+__all__ = [
+    "EnergyAdvisorResult",
+    "EnergyTradeContext",
+    "PluginRuntime",
+    "PricingAdjustment",
+    "PricingContext",
+]

--- a/rentalos-ai/src/backend/plugins/energy_optimizer.py
+++ b/rentalos-ai/src/backend/plugins/energy_optimizer.py
@@ -1,0 +1,45 @@
+"""Energy optimisation plugin providing demand-response recommendations."""
+
+from __future__ import annotations
+
+from .runtime import EnergyAdvisorResult, EnergyTradeContext, PluginRuntime
+
+BULK_PURCHASE_THRESHOLD = 15.0
+EXPORT_PREMIUM_THRESHOLD = 10.0
+
+
+def _optimise_trade(context: EnergyTradeContext) -> EnergyAdvisorResult | None:
+    """Return dynamic pricing and carbon adjustments for a trade."""
+
+    price_adjustment = 0.0
+    carbon_adjustment = 0.0
+    notes: list[str] = []
+
+    if context.direction.lower() == "buy":
+        carbon_adjustment -= context.kilowatt_hours * 0.03
+        notes.append("offset demand with community solar credits")
+        if context.kilowatt_hours >= BULK_PURCHASE_THRESHOLD:
+            price_adjustment -= 0.01
+            notes.append("applied bulk purchase incentive")
+    elif context.direction.lower() == "sell":
+        carbon_adjustment -= context.kilowatt_hours * 0.05
+        notes.append("registered renewable energy certificates")
+        if context.kilowatt_hours >= EXPORT_PREMIUM_THRESHOLD:
+            price_adjustment += 0.012
+            notes.append("added premium for high-capacity export")
+
+    if not notes:
+        return None
+
+    return EnergyAdvisorResult(
+        label="demand_response",
+        message="; ".join(notes),
+        price_adjustment=round(price_adjustment, 4),
+        carbon_adjustment=round(carbon_adjustment, 4),
+    )
+
+
+def setup_plugin(runtime: PluginRuntime) -> None:
+    """Register the optimisation logic with the runtime."""
+
+    runtime.register_energy_advisor(_optimise_trade)

--- a/rentalos-ai/src/backend/plugins/equitable_pricing.py
+++ b/rentalos-ai/src/backend/plugins/equitable_pricing.py
@@ -1,0 +1,56 @@
+"""Fairness-focused pricing plugin."""
+
+from __future__ import annotations
+
+from statistics import fmean
+
+from .runtime import PluginRuntime, PricingAdjustment, PricingContext
+
+
+def _compute_affordability_adjustment(context: PricingContext) -> PricingAdjustment | None:
+    """Return a fairness discount when occupancy spikes or ESG scores excel."""
+
+    modifiers: list[str] = []
+    adjustment = 0.0
+
+    if context.occupancy >= 0.95:
+        adjustment -= min(context.base_price * 0.04, 30.0)
+        modifiers.append("capping rent under peak occupancy")
+
+    if context.esg_score >= 85:
+        adjustment -= 5.0
+        modifiers.append("rewarding sustainability leadership")
+    elif context.esg_score < 60:
+        adjustment += min(context.base_price * 0.02, 18.0)
+        modifiers.append("funding ESG remediation")
+
+    if not modifiers:
+        return None
+
+    return PricingAdjustment(
+        label="fairness_adjustment",
+        amount=round(adjustment, 2),
+        rationale="; ".join(modifiers),
+    )
+
+
+def _stability_buffer(context: PricingContext) -> PricingAdjustment | None:
+    """Encourage pricing stability over longer durations."""
+
+    if context.duration < 14:
+        return None
+
+    window = [context.base_price * multiplier for multiplier in (0.98, 1.0, 1.02, 1.01)]
+    averaged = fmean(window)
+    delta = averaged - context.base_price
+    if abs(delta) < 1:
+        return None
+    rationale = "promoting rate stability for extended stays"
+    return PricingAdjustment(label="stability_buffer", amount=round(delta, 2), rationale=rationale)
+
+
+def setup_plugin(runtime: PluginRuntime) -> None:
+    """Register pricing adjusters for the fairness plugin."""
+
+    runtime.register_pricing_adjuster(_compute_affordability_adjustment)
+    runtime.register_pricing_adjuster(_stability_buffer)

--- a/rentalos-ai/src/backend/plugins/runtime.py
+++ b/rentalos-ai/src/backend/plugins/runtime.py
@@ -1,0 +1,69 @@
+"""Plugin runtime dataclasses and registration helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, List, Optional
+
+
+@dataclass(frozen=True)
+class PricingContext:
+    """Context describing the current pricing computation."""
+
+    asset_id: int
+    base_price: float
+    occupancy: float
+    esg_score: float
+    duration: int
+
+
+@dataclass(frozen=True)
+class PricingAdjustment:
+    """Represents a pricing delta contributed by a plugin."""
+
+    label: str
+    amount: float
+    rationale: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class EnergyTradeContext:
+    """Context for optimisation of an energy trade."""
+
+    asset_id: int
+    kilowatt_hours: float
+    direction: str
+    market_price: float
+
+
+@dataclass(frozen=True)
+class EnergyAdvisorResult:
+    """Actionable recommendation emitted by an energy plugin."""
+
+    label: str
+    message: str
+    price_adjustment: float = 0.0
+    carbon_adjustment: float = 0.0
+
+
+PricingAdjuster = Callable[[PricingContext], Optional[PricingAdjustment]]
+EnergyAdvisor = Callable[[EnergyTradeContext], Optional[EnergyAdvisorResult]]
+
+
+class PluginRuntime:
+    """Mutable registry of callbacks exposed to plugin entrypoints."""
+
+    def __init__(self, plugin_name: str) -> None:
+        self.plugin_name = plugin_name
+        self.pricing_adjusters: List[PricingAdjuster] = []
+        self.energy_advisors: List[EnergyAdvisor] = []
+
+    def register_pricing_adjuster(self, adjuster: PricingAdjuster) -> None:
+        """Register a callback that returns an optional pricing adjustment."""
+
+        self.pricing_adjusters.append(adjuster)
+
+    def register_energy_advisor(self, advisor: EnergyAdvisor) -> None:
+        """Register a callback that augments energy trades."""
+
+        self.energy_advisors.append(advisor)

--- a/rentalos-ai/src/backend/services/energy_service.py
+++ b/rentalos-ai/src/backend/services/energy_service.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import List
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
+from ..plugins.runtime import EnergyTradeContext
 from ..utils.energy_utils import carbon_intensity
 from ..utils.logger import get_logger
+from . import api_service
 
 logger = get_logger(__name__)
 
@@ -23,20 +25,36 @@ class EnergyTrade(BaseModel):
     price_per_kwh: float
     carbon_impact: float
     executed_at: datetime
+    recommendations: List[str] = Field(default_factory=list)
 
 
 def record_energy_trade(
     asset_id: int, kilowatt_hours: float, direction: str, price_per_kwh: float
 ) -> EnergyTrade:
     carbon = carbon_intensity(kilowatt_hours, kilowatt_hours / 5 if kilowatt_hours else 0)
+    context = EnergyTradeContext(
+        asset_id=asset_id,
+        kilowatt_hours=kilowatt_hours,
+        direction=direction,
+        market_price=price_per_kwh,
+    )
+    recommendations: List[str] = []
+    adjusted_price = price_per_kwh
+    for plugin_name, advice in api_service.collect_energy_recommendations(context):
+        adjusted_price += advice.price_adjustment
+        carbon += advice.carbon_adjustment
+        note = f"{plugin_name}:{advice.label} - {advice.message}"
+        recommendations.append(note)
+    carbon = max(carbon, 0.0)
     trade = EnergyTrade(
         id=len(_ENERGY_TRADES) + 1,
         asset_id=asset_id,
         kilowatt_hours=kilowatt_hours,
         direction=direction,
-        price_per_kwh=price_per_kwh,
-        carbon_impact=carbon,
+        price_per_kwh=round(adjusted_price, 4),
+        carbon_impact=round(carbon, 4),
         executed_at=datetime.now(UTC),
+        recommendations=recommendations,
     )
     _ENERGY_TRADES.append(trade)
     logger.info("Recorded energy trade", extra={"asset_id": asset_id, "direction": direction})

--- a/rentalos-ai/src/backend/tests/unit/test_energy_service.py
+++ b/rentalos-ai/src/backend/tests/unit/test_energy_service.py
@@ -5,3 +5,4 @@ def test_record_energy_trade():
     trade = record_energy_trade(3, 20.0, "buy", 0.18)
     assert trade.carbon_impact >= 0
     assert list_energy_trades()
+    assert trade.recommendations


### PR DESCRIPTION
## Summary
- add runtime primitives for RentalOS-AI plugins and hook the new equitable pricing and energy optimizer entrypoints
- load plugin entrypoints during manifest discovery and surface pricing/energy adjustments through the pricing and energy services
- extend unit tests to cover runtime loading, plugin-driven price components, and energy trade recommendations

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68d47db3c4ec8321a35133520c51bee3