### PR TITLE
feat: add Codex Meta-Intelligence stage 1 platform

### DIFF
--- a/codex-meta-intelligence/.eslintrc.json
+++ b/codex-meta-intelligence/.eslintrc.json
@@ -1,0 +1,25 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "project": ["./tsconfig.json"],
+    "tsconfigRootDir": "./"
+  },
+  "plugins": ["@typescript-eslint", "import"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:import/recommended",
+    "plugin:import/typescript",
+    "prettier"
+  ],
+  "rules": {
+    "import/order": ["error", { "alphabetize": { "order": "asc" }, "newlines-between": "always" }],
+    "@typescript-eslint/explicit-member-accessibility": ["error", { "accessibility": "no-public" }],
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }
+    ]
+  },
+  "ignorePatterns": ["dist", "node_modules"]
+}

--- a/codex-meta-intelligence/.husky/pre-commit
+++ b/codex-meta-intelligence/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+. "$(dirname "$0")/../node_modules/husky/lib/runner.sh"
+pnpm lint
+pnpm test

--- a/codex-meta-intelligence/AGENTS.md
+++ b/codex-meta-intelligence/AGENTS.md
@@ -1,0 +1,36 @@
+# Codex Meta-Intelligence Project Instructions
+
+## Environment Setup
+
+- Use **pnpm** for JavaScript and TypeScript dependency management inside this project (`pnpm install --ignore-workspace-root-check`).
+- Node.js 18+ and pnpm 8+ are required. Use `corepack enable` if pnpm is unavailable.
+- Install Python dependencies only when tests reference them; the Stage 1 stack runs entirely on Node.js/TypeScript.
+
+## Build & Stage Orchestration
+
+- The `build.sh` script governs all automated actions. Run it from the project root (`./build.sh`).
+- `stage.json` tracks the active stage. Do not edit it manually unless recovering from a failed build.
+
+## Testing & Quality Gates
+
+- Run `pnpm lint` for ESLint/Prettier checks and `pnpm test` for Jest unit tests before committing.
+- Execute `pnpm typecheck` to ensure TypeScript passes strict compilation.
+- Stage scripts may execute these commands automatically; rerun them locally when modifying logic.
+
+## Coding Standards
+
+- TypeScript code must use named exports where possible and avoid default exports.
+- Favor immutability and pure functions. Classes should expose explicit interfaces from `src/shared/types.ts`.
+- Keep files self-documented with descriptive comments and avoid TODO placeholders.
+- Tests belong under `tests/` and should verify both success and failure paths.
+
+## Logging & Telemetry
+
+- Use the shared logger utilities in `src/shared/utils.ts` for consistent logging.
+- When adding new metrics or traces, update `src/analytics/metrics.ts` and `src/analytics/tracing.ts`.
+
+## Pull Request Guidelines
+
+- Summaries must mention stage progression when `stage.json` changes.
+- Include references to relevant documentation markdown files when adding new capabilities.
+- Ensure CI scripts and build orchestrations remain idempotent and safe to re-run.

--- a/codex-meta-intelligence/README.md
+++ b/codex-meta-intelligence/README.md
@@ -1,0 +1,37 @@
+# Codex Meta-Intelligence Platform
+
+Codex Meta-Intelligence is a multi-agent operating system for software development. Stage 1 establishes the scaffolding for agents, macros, context fabric, knowledge management and compliance with OpenAI and Cursor integration guidelines.
+
+## Features (Stage 1)
+
+- Microservice-inspired architecture with dedicated directories for each subsystem.
+- Build orchestrator that executes linting, tests and type checks based on `stage.json`.
+- Agent framework with context-aware execution, AGENTS.md parsing and message bus hooks.
+- Knowledge, memory, protocol and context services providing deterministic behaviour and documentation.
+- QA, CI/CD, foresight, security, analytics and integration modules prepared for Stage 2 enhancements.
+
+## Getting Started
+
+```bash
+cd codex-meta-intelligence
+pnpm install --ignore-workspace-root-check
+pnpm build
+```
+
+## Development Workflow
+
+1. Modify or extend modules under `src/`.
+2. Update relevant specification markdown files when behaviour changes.
+3. Run quality gates:
+   - `pnpm lint`
+   - `pnpm test`
+   - `pnpm typecheck`
+4. Execute `./build.sh` to run stage tasks and optionally promote to the next stage.
+
+## Testing
+
+Jest tests reside in `tests/`. Stage 1 focuses on unit tests covering the agent framework, memory cache and pipeline orchestrator. Integration tests will be introduced in Stage 2.
+
+## Contributing
+
+Follow AGENTS.md guidelines for coding standards, logging conventions and pull request preparation. Document any new dependencies or configuration updates in this README.

--- a/codex-meta-intelligence/agent.md
+++ b/codex-meta-intelligence/agent.md
@@ -1,0 +1,44 @@
+# Agent Specifications
+
+## Overview
+
+The agent subsystem provides specialised autonomous workers that execute domain-specific tasks inside the Codex Meta-Intelligence platform. All agents inherit from a shared base class defined in `src/agent/index.ts`. Agents operate on top of the Execution Pipeline and respect the Harmony Protocol for conflict resolution.
+
+## Roles
+
+- **FrontendAgent** – Crafts user interfaces and design artefacts. Consumes UI-related tasks and validates styling via the styling cognition utilities.
+- **BackendAgent** – Implements APIs, services and infrastructure automation. Enforces security and dependency hygiene policies.
+- **KnowledgeAgent** – Manages ingestion and retrieval of knowledge blocks. Synchronises the knowledge store with context fabric components.
+- **QAAAgent** – Executes aesthetic, technical and narrative quality checks before deliverables progress to operators.
+- **RefinementAgent** – Applies iterative improvements to outputs. Integrates with styling cognition rules and QA feedback.
+
+## Contracts
+
+- **AgentConfig**: Unique identifier, role, concurrency limits, default timeout and accessible tool identifiers.
+- **AgentMessage**: Task envelope containing `taskId`, `macroId`, `payload`, `context`, merged `guidelines`, and metadata (timestamps, priority, origin).
+- **AgentResult**: Execution response containing status, optional error, produced artefacts, context updates, QA findings and metrics.
+
+Schemas for the contracts are exported from `src/agent/types.ts` and validated using Ajv. All interactions rely on JSON serialisable structures and explicit version fields to remain forward compatible.
+
+## Lifecycle
+
+1. The meta-agent schedules a task and posts an `AgentMessage` to the message bus.
+2. The receiving agent merges AGENTS.md guidance via `AgentGuidelineReader` and configures its runtime environment.
+3. The agent resolves context from the Context Fabric, executes domain logic and records telemetry.
+4. Results are emitted as `AgentResult` objects. Failures trigger retries or operator escalation according to protocol rules.
+
+## Error Handling & Resilience
+
+- Agents use typed error classes defined in `src/shared/types.ts`.
+- Timeouts, invalid payloads and context fetch errors are reported with actionable diagnostics.
+- Each agent exposes a heartbeat to the monitoring subsystem to enable liveness tracking.
+
+## Performance Considerations
+
+- Concurrency is constrained via semaphores to prevent resource exhaustion.
+- Long-running tasks periodically emit progress updates so the meta-agent can make pre-emptive scheduling decisions.
+- Outputs are streamed via async generators when large artefacts must be returned.
+
+## Public API
+
+Agents expose a `handleMessage` method that validates messages, invokes `execute`, and returns structured results. Utility methods support dry-run execution, environment bootstrapping and compliance verification with AGENTS.md and Cursor rules.

--- a/codex-meta-intelligence/build.sh
+++ b/codex-meta-intelligence/build.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT=$(cd "$(dirname "$0")" && pwd)
+STAGE_FILE="$PROJECT_ROOT/stage.json"
+PROMOTE_STAGE=${PROMOTE_STAGE:-1}
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required to run the build orchestrator" >&2
+  exit 1
+fi
+
+run_stage_one() {
+  echo "Executing Stage 1 tasks for Codex Meta-Intelligence"
+  echo "----------------------------------------------------"
+  cd "$PROJECT_ROOT"
+
+  if ! command -v pnpm >/dev/null 2>&1; then
+    echo "pnpm is required. Enable it via \`corepack enable\`." >&2
+    exit 1
+  fi
+
+  pnpm install --ignore-workspace-root-check
+  pnpm lint
+  pnpm test
+  pnpm typecheck
+}
+
+run_stage_two() {
+  echo "Stage 2 tasks are not yet implemented. Prepare advanced integrations before promoting." >&2
+  exit 2
+}
+
+run_stage_three() {
+  echo "Stage 3 tasks are not yet implemented. Complete prior stages first." >&2
+  exit 3
+}
+
+advance_stage() {
+  local next_stage
+  next_stage=$(jq '.stage + 1' "$STAGE_FILE")
+  tmp_file=$(mktemp)
+  jq ".stage = $next_stage | .completed |= . + {\"stage_$next_stage\": {\"timestamp\": \"$(date -u +%FT%TZ)\"}}" "$STAGE_FILE" > "$tmp_file"
+  mv "$tmp_file" "$STAGE_FILE"
+  echo "Promoted to stage $next_stage"
+}
+
+current_stage=$(jq -r '.stage' "$STAGE_FILE")
+
+case "$current_stage" in
+  1)
+    run_stage_one
+    if [[ "$PROMOTE_STAGE" == "1" ]]; then
+      advance_stage
+    fi
+    ;;
+  2)
+    run_stage_two
+    ;;
+  3)
+    run_stage_three
+    ;;
+  *)
+    echo "Unknown stage: $current_stage" >&2
+    exit 10
+    ;;
+esac

--- a/codex-meta-intelligence/cicd.md
+++ b/codex-meta-intelligence/cicd.md
@@ -1,0 +1,23 @@
+# CI/CD Specification
+
+## Objective
+
+Provide automated validation and deployment capabilities for Codex Meta-Intelligence deliverables while maintaining reproducibility and compliance.
+
+## Components
+
+- **Pipeline Controller (`src/cicd/pipeline.ts`)** – Declares build/test/deploy steps and orchestrates their execution.
+- **Test Harness (`src/cicd/tests.ts`)** – Bridges QA outputs with Jest or external frameworks.
+- **Linter Runner (`src/cicd/linters.ts`)** – Wraps ESLint, Prettier and additional linters.
+
+## Stage 1 Workflow
+
+1. Prepare workspace (install dependencies via pnpm).
+2. Execute linting and unit tests.
+3. Produce summary reports recorded in the memory subsystem.
+
+## Future Enhancements
+
+- Integrate GitHub Actions, Render deployments and container image promotion.
+- Implement caching, concurrency control and rollback strategies.
+- Add security scanning and compliance reporting.

--- a/codex-meta-intelligence/context.md
+++ b/codex-meta-intelligence/context.md
@@ -1,0 +1,31 @@
+# Context Fabric Specification
+
+## Purpose
+
+The context engine ingests, normalises, indexes, retrieves, composes, evaluates and persists contextual information for agents. Stage 1 provides a deterministic in-memory vector store and rule-based summarisation.
+
+## Layers
+
+- **Fabric (`src/context/fabric.ts`)** – Manages storage of context packets, embeddings and summaries. Supports ingest, normalise, index and persist operations.
+- **Orchestrator (`src/context/orchestrator.ts`)** – Handles retrieve, compose and evaluate flows, applying relevance scoring and quality gates.
+- **Governance (`src/context/governance.ts`)** – Enforces security policies, consent records and compliance checks for context usage.
+
+## Data Structures
+
+- `ContextPacket`: contains `id`, `source`, `content`, `summary`, `embedding`, `metadata` and `createdAt` timestamp.
+- `ContextRequest`: describes retrieval needs (roles, keywords, embedding, limit, filters).
+- `ContextResponse`: returns selected packets with scoring explanations.
+
+## Lifecycle
+
+1. **Ingest**: Raw inputs validated and enriched with metadata.
+2. **Normalise**: Text cleaned, truncated and summarised.
+3. **Index**: Embeddings generated (simple hashing in Stage 1) and stored in vector index.
+4. **Retrieve**: Query uses cosine-like similarity with fallback keyword search.
+5. **Compose**: Selected packets merged with deduplication and length budgeting.
+6. **Evaluate**: Governance policies verify sensitivity, freshness and fairness.
+7. **Persist**: Packets stored and optionally exported for long-term archives.
+
+## Security
+
+Governance layer enforces RBAC, data minimisation and redaction of sensitive fields. Policy violations trigger exceptions and operator alerts.

--- a/codex-meta-intelligence/cursor.md
+++ b/codex-meta-intelligence/cursor.md
@@ -1,0 +1,26 @@
+# Cursor Integration Blueprint
+
+## Objectives
+
+- Synchronise Cursor IDE configuration with Codex Meta-Intelligence agent workflows.
+- Enforce consistent rule merging between `.cursorrules` and AGENTS.md files.
+- Provide API bridges for file indexing, context sharing and compliance enforcement.
+
+## Integration Points
+
+- `src/cursor/adaptor.ts` communicates with Cursor APIs, harmonising rules and delivering context packets.
+- `src/cursor/sync.ts` manages bidirectional sync between local changes and cloud state, handling merge conflicts via the Harmony Protocol.
+
+## Operational Modes
+
+- **Agent Mode** – Executes macros and QA flows triggered from Cursor.
+- **Ask Mode** – Delegates to knowledge retrieval and summarisation pathways.
+- **Manual Mode** – Supports targeted file edits with guardrails and compliance checks.
+
+## Security & Privacy
+
+All outbound data is scrubbed using governance policies. Sensitive files may be redacted or replaced with summaries before leaving the execution environment. API credentials are loaded via environment variables and validated through enforcement utilities.
+
+## Roadmap
+
+Stage 2 adds full API support and cursor automation, while Stage 3 integrates UI feedback loops and plugin synchronisation.

--- a/codex-meta-intelligence/foresight.md
+++ b/codex-meta-intelligence/foresight.md
@@ -1,0 +1,26 @@
+# Foresight Engine Specification
+
+## Mission
+
+Predict resource consumption, success probability and risk for pending tasks by analysing historical memory records and macro outcomes.
+
+## Components
+
+- **ForesightEngine (`src/foresight/index.ts`)** – Public API orchestrating predictions and risk assessments.
+- **Analytics Module (`src/foresight/analytics.ts`)** – Provides statistical computations and summarisation helpers.
+- **Risk Module (`src/foresight/risk.ts`)** – Derives qualitative risk levels and mitigation recommendations.
+
+## Inputs
+
+- Historical task durations, QA issue counts and resource usage from memory subsystem.
+- Operator feedback scores and fairness metrics.
+- Macro definitions containing cost weights and stage complexity.
+
+## Outputs
+
+- `ForecastResult` with predicted durations, effort points and confidence intervals.
+- `RiskAssessment` summarising severity, likelihood and recommended mitigations.
+
+## Stage 1 Behaviour
+
+Implements deterministic heuristics: moving averages, weighted scoring and rule-based risk detection. Stage 2 introduces ML forecasting; Stage 3 integrates continuous learning.

--- a/codex-meta-intelligence/jest.config.js
+++ b/codex-meta-intelligence/jest.config.js
@@ -1,0 +1,19 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+export default {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  globals: {
+    'ts-jest': {
+      useESM: true,
+    },
+  },
+  moduleNameMapper: {
+    '^(.*)\\.js$': '$1',
+  },
+  roots: ['<rootDir>/tests'],
+  moduleFileExtensions: ['ts', 'js'],
+  collectCoverageFrom: ['src/**/*.ts'],
+  coverageDirectory: 'coverage',
+  clearMocks: true,
+};

--- a/codex-meta-intelligence/knowledge.md
+++ b/codex-meta-intelligence/knowledge.md
@@ -1,0 +1,35 @@
+# Knowledge System Specification
+
+## Purpose
+
+The knowledge subsystem maintains durable knowledge blocks, enabling agents to retrieve historical insights, code snippets and design references. Stage 1 relies on an in-memory store with deterministic indexing and validation.
+
+## Data Structures
+
+- **KnowledgeBlock** – Contains `id`, `content`, `metadata` (author, timestamp, tags, citations, source), `reliabilityScore` and optional `links` to related blocks.
+- **KnowledgeQuery** – Structured query comprising `keywords`, `tags`, optional embedding vector, `limit` and `sort` preferences.
+- **KnowledgeResponse** – List of matched blocks with confidence scores and traceability metadata.
+
+JSON Schemas in `src/knowledge/scaffolds.ts` enforce the structure of blocks and NDJSON ingestion pipelines.
+
+## Operations
+
+- `storeBlock(block)` – Validates schema compliance, ensures ID uniqueness and appends to the store.
+- `fetchBlock(id)` – Returns block by identifier.
+- `searchBlocks(query)` – Performs keyword/tag filtering with scoring heuristics and returns ranked results.
+
+## Persistence Strategy
+
+Stage 1 stores blocks in-memory with optional JSON export. Stage 2 integrates vector and graph databases. Stage 3 adds freshness monitoring and automatic updates.
+
+## Governance
+
+- All writes are logged to the memory subsystem for auditing.
+- Blocks track provenance and licensing to satisfy compliance checks.
+- Schema validation prevents injection and ensures consistent metadata.
+
+## Integration Points
+
+- Context Fabric uses the knowledge service for context ingestion.
+- Macros reference knowledge metadata when generating deliverables.
+- Operators can import NDJSON scaffolds through CLI interfaces.

--- a/codex-meta-intelligence/macro.md
+++ b/codex-meta-intelligence/macro.md
@@ -1,0 +1,38 @@
+# Macro Orchestration Blueprint
+
+## Purpose
+
+Macros coordinate multiple agents to satisfy complex objectives. They decompose prompts into sequenced or parallel agent invocations, enforce the Execution Pipeline and apply Harmony Protocol decisions when outputs conflict.
+
+## Definitions
+
+- **MacroDefinition** – Declares name, description, ordered stages, fallback macro, quality gates and telemetry labels.
+- **MacroContext** – Aggregates operator intent, AGENTS.md guidance, selected knowledge packets and run metadata.
+- **MacroResult** – Aggregated collection of agent results, execution timeline, QA summary and derived artefacts.
+
+TypeScript types and runtime schemas are located in `src/macro/types.ts`. Macros are authored declaratively in `src/macro/scripts.ts` with composable helper functions such as `sequence`, `parallel`, and `retryableStage`.
+
+## Execution Model
+
+1. The meta-agent invokes `runMacro` with a macro name and context.
+2. `MacroOrchestrator` loads the macro definition, validates it against schema contracts and resolves required agents.
+3. Each stage is executed via the Execution Pipeline. Draft outputs cascade into QA, Refinement, Elevation, Delivery and Deploy phases.
+4. Failures trigger fallback macros or retries with exponential backoff, as defined by macro metadata.
+5. Final results are persisted via the memory subsystem and forwarded to operators.
+
+## Error Handling
+
+- Invalid macros throw descriptive `MacroConfigurationError` exceptions.
+- Stage timeouts produce partial results but keep telemetry consistent.
+- Harmony Protocol decisions are logged to the memory subsystem for auditing.
+
+## Performance Considerations
+
+- Macros can spawn parallel branches when tasks are independent. Worker limits are derived from meta-agent scheduling policies.
+- Macro execution is fully asynchronous and supports streaming updates via EventEmitter events.
+
+## Extensibility
+
+- Additional macros can be defined by appending to `src/macro/scripts.ts`.
+- Custom pipeline stages may be implemented by extending `ExecutionStage` in `src/protocol/execution.ts`.
+- Variant comparisons are stored in markdown footnotes for operator review.

--- a/codex-meta-intelligence/memory.md
+++ b/codex-meta-intelligence/memory.md
@@ -1,0 +1,27 @@
+# Memory System Specification
+
+## Objectives
+
+Memory services capture episodic records, caches and operational logs to enable observability, retrospectives and foresight analytics.
+
+## Components
+
+- **Memory API (`src/memory/index.ts`)** – Stores and retrieves structured `MemoryRecord` objects.
+- **Logger (`src/memory/logs.ts`)** – Writes append-only logs with rotation, compression and encryption hooks.
+- **Cache (`src/memory/cache.ts`)** – Implements in-memory LRU cache with TTL enforcement for working memory scenarios.
+
+## Data Structures
+
+- `MemoryRecord`: contains `id`, `agentId`, `timestamp`, `dataType`, `payload`, `tags` and optional `sensitivity` metadata.
+- `LogEntry`: summarises pipeline actions with references to tasks and macros.
+- `CacheEntry`: stores short-lived computation results with expiry metadata.
+
+## Guarantees
+
+- All operations emit events consumed by analytics modules.
+- Encryption utilities ensure sensitive payloads remain protected.
+- Retrieval queries support filtering by date range, agent or tag.
+
+## Stage 1 Implementation
+
+The current implementation uses in-memory structures and Node file streams with rotation thresholds. Future stages will swap in durable storage without changing the public API.

--- a/codex-meta-intelligence/metaagent.md
+++ b/codex-meta-intelligence/metaagent.md
@@ -1,0 +1,40 @@
+# Meta-Agent Specification
+
+## Mission
+
+The meta-agent serves as the executive control plane for Codex Meta-Intelligence. It schedules tasks, selects macros, enforces policies and orchestrates agent execution to maintain reliability, fairness and compliance.
+
+## Core Components
+
+- **Scheduler (`src/metaagent/scheduler.ts`)** – Implements priority queues, fairness constraints and time-slicing for concurrent tasks.
+- **State Manager (`src/metaagent/state.ts`)** – Persists task metadata, agent registry information, telemetry snapshots and audit trails.
+- **Monitor (`src/metaagent/monitor.ts`)** – Collects metrics, health status and anomaly signals for escalation to operators.
+- **Orchestrator (`src/metaagent/index.ts`)** – Public entry point combining scheduler, macros and monitoring.
+
+## Task Lifecycle
+
+1. Operator or automation enqueues a `MetaTask` describing goals, requested macro and optional constraints.
+2. Scheduler prioritises tasks using weighted fairness; risk and foresight data adjust ordering.
+3. Macro orchestrator executes tasks; intermediate events are streamed to observers.
+4. On completion, results are recorded, context updates are persisted, and operators receive notifications via integration connectors.
+
+## Policy Enforcement
+
+Meta-agent validates AGENTS.md rules, Cursor compliance, security policies and fairness constraints before dispatching work. Policy failures trigger operator alerts and mark tasks as blocked.
+
+## Fault Tolerance
+
+- Heartbeat monitoring restarts stalled tasks with exponential backoff.
+- Dead-letter queues store failed macro runs for later inspection.
+- Distributed locks prevent duplicate scheduling across cluster deployments.
+
+## Extensibility
+
+- Additional scheduling strategies can plug into `SchedulerStrategy` interface.
+- Observers subscribe to `MetaAgentEvents` for real-time dashboards, Slack notifications or plugin actions.
+
+## Public API
+
+- `enqueueTask(metaTask: MetaTask): string` – adds a task and returns the generated identifier.
+- `cancelTask(taskId: string): boolean` – cancels running or queued tasks when safe.
+- `getState(): MetaStateSnapshot` – returns immutable view of scheduler queues, running tasks and metrics.

--- a/codex-meta-intelligence/openai-standards.md
+++ b/codex-meta-intelligence/openai-standards.md
@@ -1,0 +1,23 @@
+# OpenAI Standards Integration
+
+## Compliance Goals
+
+- Respect AGENTS.md hierarchy and merge order to ensure deterministic behaviour across Codex and Cursor environments.
+- Enforce OpenAI safety guidance covering privacy, intellectual property, fairness and transparency.
+- Provide auditable evidence (logs, citations, test results) for each automated change.
+
+## Implementation Summary
+
+- `src/agent/reader.ts` merges AGENTS.md files according to scope rules, caching results per directory and verifying command requirements.
+- `src/openai-standards/guidelines.ts` exposes helper functions to validate compliance, track executed checks and enforce footnote generation.
+- Build orchestration ensures linting, testing and typechecking before stage promotion, matching OpenAI trust and safety expectations.
+
+## Operator Responsibilities
+
+- Maintain AGENTS.md changelog entries for major rule updates.
+- Validate that any external assets or dependencies respect licensing constraints.
+- Review compliance reports generated during macro runs and escalate anomalies.
+
+## Future Enhancements
+
+Stage 2 introduces automated cross-checks with OpenAI policy APIs and Stage 3 adds interactive dashboards summarising compliance metrics.

--- a/codex-meta-intelligence/operator.md
+++ b/codex-meta-intelligence/operator.md
@@ -1,0 +1,24 @@
+# Operator Interface Specification
+
+## Objective
+
+Provide transparent and controllable interactions for human operators to supervise agent workflows, approve deliverables and intervene when necessary.
+
+## Components
+
+- **OperatorInterface (`src/operator/interface.ts`)** – CLI/automation entry point for commands and notifications.
+- **OperatorHooks (`src/operator/hooks.ts`)** – Binds operator actions to meta-agent decisions.
+- **OperatorUI (`src/operator/ui.ts`)** – Placeholder for future UI integration; Stage 1 defines interfaces and state contracts.
+
+## Capabilities
+
+- Enqueue new macro tasks with priority and policy overrides.
+- Approve, refine, expand or rollback deliverables.
+- Adjust fairness weights, risk tolerances and concurrency limits.
+- Receive notifications from integrations (Slack, email) and respond interactively.
+
+## Safety Mechanisms
+
+- Role-based access control ensures only authorised users may issue destructive commands.
+- Command validation prevents injection or malformed instructions.
+- All interactions are recorded in the memory log for auditing and compliance.

--- a/codex-meta-intelligence/package.json
+++ b/codex-meta-intelligence/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "codex-meta-intelligence",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint src tests",
+    "test": "jest",
+    "typecheck": "tsc --noEmit",
+    "prepare": "husky install"
+  },
+  "lint-staged": {
+    "src/**/*.{ts,tsx}": [
+      "eslint --fix"
+    ],
+    "tests/**/*.ts": [
+      "eslint --fix"
+    ]
+  },
+  "dependencies": {
+    "ajv": "^8.12.0",
+    "eventemitter3": "^5.0.1",
+    "lodash.merge": "^4.6.2"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.12",
+    "@types/lodash.merge": "^4.6.9",
+    "@types/node": "^20.11.30",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-import": "^2.29.1",
+    "husky": "^9.0.11",
+    "jest": "^29.7.0",
+    "lint-staged": "^15.2.2",
+    "prettier": "^3.2.5",
+    "ts-jest": "^29.1.2",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5"
+  }
+}

--- a/codex-meta-intelligence/protocol.md
+++ b/codex-meta-intelligence/protocol.md
@@ -1,0 +1,23 @@
+# Protocol Specification
+
+## Harmony Protocol
+
+The Harmony Protocol mediates conflicting proposals from agents. Proposals include change descriptions, priority, confidence score and citations. `resolveConflict` evaluates proposals using deterministic tiebreakers (priority, confidence, recency) and merges non-conflicting segments. When no safe resolution exists, it escalates to operators.
+
+## Execution Pipeline
+
+The pipeline enforces the Draft → Audit → Refinement → Elevation → Delivery → Deploy sequence. Each stage declares entry conditions, exit checks and rollback behaviour. Pipeline orchestration resides in `src/protocol/execution.ts`.
+
+## Styling Cognition
+
+Styling checks ensure outputs comply with U-DIG IT design laws: contrast, typography hierarchy, motion grammar, fairness and emotional resonance. The Stage 1 implementation evaluates basic numeric rules and produces warnings for violations.
+
+## Open Protocol Bridges
+
+- **MCP (Model Context Protocol)** – Tool registry describing callable functions and JSON schemas.
+- **ACP (Agent Communication Protocol)** – Structured envelopes with signature verification and version negotiation.
+- **A2A (Agent-to-Agent Discovery)** – Registry for capability advertisement and health status.
+- **ANP (Agent Network Protocol)** – Identity, authentication and authorisation for cross-organisation interaction.
+- **AG-UI** – API surface for UI integrations including dashboards and operator consoles.
+
+Stage 1 provides type definitions and validation utilities. Implementations evolve in later stages but remain spec-compliant from inception.

--- a/codex-meta-intelligence/qa.md
+++ b/codex-meta-intelligence/qa.md
@@ -1,0 +1,26 @@
+# Quality Assurance Specification
+
+## Purpose
+
+The QA subsystem ensures deliverables satisfy technical, aesthetic and narrative standards before reaching operators or deployment pipelines.
+
+## Architecture
+
+- **QAEngine (`src/qa/index.ts`)** – Coordinates sub-engines, aggregates results and enforces severity thresholds.
+- **AestheticChecks (`src/qa/aesthetic.ts`)** – Verifies accessibility, colour harmony and motion guidelines.
+- **TechnicalChecks (`src/qa/technical.ts`)** – Executes static analysis hooks, linting and test harness integration.
+- **NarrativeChecks (`src/qa/narrative.ts`)** – Evaluates storytelling clarity, tone alignment and fairness guidelines.
+
+## Outputs
+
+Each check returns `QAIssue` objects describing severity, description, impacted files and remediation advice. Aggregated `QAResult` objects summarise pass/fail status, statistics and references to supporting artefacts.
+
+## Integration
+
+- Execution Pipeline halts advancement when QA issues exceed configured thresholds.
+- Macros consult QA results to trigger refinement loops.
+- Operators view QA traces through the dashboard or CLI tools.
+
+## Stage 1 Behaviour
+
+Implementations compute deterministic heuristics and provide human-readable advice. Stage 2 will incorporate external tools and ML models. Stage 3 adds UI regression and plugin compliance tests.

--- a/codex-meta-intelligence/src/agent/index.ts
+++ b/codex-meta-intelligence/src/agent/index.ts
@@ -1,0 +1,278 @@
+import EventEmitter from 'eventemitter3';
+import { setTimeout as delay } from 'node:timers/promises';
+
+import {
+  AgentRole,
+  type AgentConfig,
+  type AgentMessage,
+  type AgentResult,
+} from '../shared/types.js';
+import { generateId, nowIso, type JsonValue } from '../shared/utils.js';
+import { DEFAULT_AGENT_TIMEOUT_MS } from '../shared/constants.js';
+import { AgentGuidelineReader } from './reader.js';
+import { validateAgentConfig, validateAgentMessage, validateAgentResult } from './types.js';
+
+interface AgentEvents {
+  start: [AgentMessage];
+  finish: [AgentResult];
+  error: [Error];
+}
+
+export abstract class BaseAgent extends EventEmitter<AgentEvents> {
+  protected readonly config: AgentConfig;
+
+  private readonly reader: AgentGuidelineReader;
+
+  private activeTasks = 0;
+
+  private readonly queue: Array<() => void> = [];
+
+  protected constructor(config: AgentConfig, reader = new AgentGuidelineReader()) {
+    super();
+    this.config = validateAgentConfig(config);
+    this.reader = reader;
+  }
+
+  protected abstract execute(message: AgentMessage): Promise<AgentResult>;
+
+  protected async beforeExecute(_message: AgentMessage): Promise<void> {}
+
+  protected async afterExecute(_message: AgentMessage, _result: AgentResult): Promise<void> {}
+
+  async handleMessage(message: AgentMessage): Promise<AgentResult> {
+    const validatedMessage = validateAgentMessage(message);
+    const acquired = await this.acquireSlot();
+    if (!acquired) {
+      throw new Error(`Agent ${this.config.id} failed to acquire execution slot`);
+    }
+
+    try {
+      const mergedGuidelines = await this.reader.mergeGuidelines(validatedMessage.metadata.source);
+      const enrichedMessage: AgentMessage = {
+        ...validatedMessage,
+        guidelines: mergedGuidelines,
+      };
+      this.emit('start', enrichedMessage);
+      await this.beforeExecute(enrichedMessage);
+      const controller = new AbortController();
+      const timeout = this.config.timeoutMs || DEFAULT_AGENT_TIMEOUT_MS;
+      const timer = delay(timeout, undefined, { signal: controller.signal }).then(() => {
+        throw new Error(`Agent ${this.config.id} timed out after ${timeout}ms`);
+      });
+      const runPromise = this.execute(enrichedMessage);
+      const result = await Promise.race([runPromise, timer]);
+      controller.abort();
+      const validatedResult = validateAgentResult({
+        ...result,
+        durationMs: result.durationMs ?? 0,
+      });
+      await this.afterExecute(enrichedMessage, validatedResult);
+      this.emit('finish', validatedResult);
+      return validatedResult;
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      this.emit('error', err);
+      const failure: AgentResult = {
+        taskId: validatedMessage.taskId,
+        status: 'error',
+        summary: err.message,
+        artifacts: {},
+        issues: [err.message],
+        contextUpdates: [],
+        durationMs: 0,
+        error: err.stack,
+      };
+      return failure;
+    } finally {
+      this.releaseSlot();
+    }
+  }
+
+  private async acquireSlot(): Promise<boolean> {
+    if (this.activeTasks < this.config.concurrency) {
+      this.activeTasks += 1;
+      return true;
+    }
+    return new Promise<boolean>((resolve) => {
+      const taskId = generateId('queue');
+      const release = () => {
+        resolve(true);
+      };
+      this.queue.push(release);
+      this.emit('start', {
+        taskId,
+        macroId: 'queued',
+        payload: {},
+        context: [],
+        guidelines: {
+          environment: [],
+          testing: [],
+          coding: [],
+          logging: [],
+          pullRequests: [],
+        },
+        metadata: {
+          priority: 0,
+          createdAt: nowIso(),
+          source: 'queue',
+          version: '1.0.0',
+        },
+      });
+    });
+  }
+
+  private releaseSlot(): void {
+    if (this.activeTasks > 0) {
+      this.activeTasks -= 1;
+    }
+    const next = this.queue.shift();
+    if (next) {
+      this.activeTasks += 1;
+      next();
+    }
+  }
+}
+
+export class FrontendAgent extends BaseAgent {
+  constructor(config: AgentConfig) {
+    super(config);
+  }
+
+  protected async execute(message: AgentMessage): Promise<AgentResult> {
+    const summary = `Generated UI plan for task ${message.taskId}`;
+    const artifacts: Record<string, JsonValue> = {
+      recommendations: [
+        'Use responsive grid layout with accessible contrast ratios',
+        'Apply motion grammar micro-interactions for state changes',
+      ],
+      guidelines: JSON.parse(JSON.stringify(message.guidelines)) as JsonValue,
+    };
+    return {
+      taskId: message.taskId,
+      status: 'success',
+      summary,
+      artifacts,
+      issues: [],
+      contextUpdates: message.context,
+      durationMs: 50,
+    };
+  }
+}
+
+export class BackendAgent extends BaseAgent {
+  constructor(config: AgentConfig) {
+    super(config);
+  }
+
+  protected async execute(message: AgentMessage): Promise<AgentResult> {
+    const summary = `Produced backend scaffolding for ${message.taskId}`;
+    const artifacts: Record<string, JsonValue> = {
+      apiDesign: JSON.parse(
+        JSON.stringify({
+          endpoints: [
+            {
+              method: 'GET',
+              path: '/health',
+              description: 'Health check endpoint generated by BackendAgent',
+            },
+          ],
+        })
+      ) as JsonValue,
+    };
+    return {
+      taskId: message.taskId,
+      status: 'success',
+      summary,
+      artifacts,
+      issues: [],
+      contextUpdates: message.context,
+      durationMs: 65,
+    };
+  }
+}
+
+export class KnowledgeAgent extends BaseAgent {
+  constructor(config: AgentConfig) {
+    super(config);
+  }
+
+  protected async execute(message: AgentMessage): Promise<AgentResult> {
+    const artifacts: Record<string, JsonValue> = {
+      knowledgeUpdate: message.context.map((packet) => ({
+        packetId: packet.id,
+        summary: packet.summary,
+      })),
+    };
+    return {
+      taskId: message.taskId,
+      status: 'success',
+      summary: 'Knowledge store updated',
+      artifacts,
+      issues: [],
+      contextUpdates: message.context,
+      durationMs: 40,
+    };
+  }
+}
+
+export class QAAgent extends BaseAgent {
+  constructor(config: AgentConfig) {
+    super(config);
+  }
+
+  protected async execute(message: AgentMessage): Promise<AgentResult> {
+    const issues = message.context.length === 0 ? ['No context provided for QA'] : [];
+    return {
+      taskId: message.taskId,
+      status: issues.length ? 'error' : 'success',
+      summary: issues.length ? 'QA issues detected' : 'QA checks passed',
+      artifacts: { executedChecks: message.guidelines.testing },
+      issues,
+      contextUpdates: message.context,
+      durationMs: 30,
+      error: issues.length ? 'Context missing' : undefined,
+    };
+  }
+}
+
+export class RefinementAgent extends BaseAgent {
+  constructor(config: AgentConfig) {
+    super(config);
+  }
+
+  protected async execute(message: AgentMessage): Promise<AgentResult> {
+    const artifacts: Record<string, JsonValue> = {
+      refinements: message.context.map((packet) => ({
+        id: packet.id,
+        improvement: 'Applied styling cognition refinements',
+      })),
+    };
+    return {
+      taskId: message.taskId,
+      status: 'success',
+      summary: 'Applied refinements based on QA feedback',
+      artifacts,
+      issues: [],
+      contextUpdates: message.context,
+      durationMs: 45,
+    };
+  }
+}
+
+export const createAgent = (role: AgentRole, config: Omit<AgentConfig, 'role'>): BaseAgent => {
+  const fullConfig: AgentConfig = { ...config, role };
+  switch (role) {
+    case AgentRole.FRONTEND:
+      return new FrontendAgent(fullConfig);
+    case AgentRole.BACKEND:
+      return new BackendAgent(fullConfig);
+    case AgentRole.KNOWLEDGE:
+      return new KnowledgeAgent(fullConfig);
+    case AgentRole.QA:
+      return new QAAgent(fullConfig);
+    case AgentRole.REFINEMENT:
+      return new RefinementAgent(fullConfig);
+    default:
+      throw new Error(`Unsupported agent role: ${role}`);
+  }
+};

--- a/codex-meta-intelligence/src/agent/reader.ts
+++ b/codex-meta-intelligence/src/agent/reader.ts
@@ -1,0 +1,113 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import merge from 'lodash.merge';
+
+import type { AgentGuidelines } from '../shared/types.js';
+
+const defaultGuidelines: AgentGuidelines = {
+  environment: [],
+  testing: [],
+  coding: [],
+  logging: [],
+  pullRequests: [],
+};
+
+const sectionMatchers: Record<keyof AgentGuidelines, RegExp> = {
+  environment: /##\s+Environment Setup/i,
+  testing: /##\s+Testing[^\n]*/i,
+  coding: /##\s+Coding[^\n]*/i,
+  logging: /##\s+Logging[^\n]*/i,
+  pullRequests: /##\s+Pull Request[^\n]*/i,
+};
+
+export class AgentGuidelineReader {
+  private readonly cache = new Map<string, AgentGuidelines>();
+
+  constructor(private readonly projectRoot: string = process.cwd()) {}
+
+  async mergeGuidelines(source: string): Promise<AgentGuidelines> {
+    const absolute = path.isAbsolute(source) ? source : path.join(this.projectRoot, source);
+    const directories = this.collectDirectories(absolute);
+    let merged: AgentGuidelines = merge({}, defaultGuidelines);
+    for (const directory of directories) {
+      const filePath = await this.resolveAgentsFile(directory);
+      if (!filePath) continue;
+      const cached = this.cache.get(filePath);
+      const parsed = cached ?? (await this.parseFile(filePath));
+      this.cache.set(filePath, parsed);
+      merged = this.mergeGuidelineObjects(merged, parsed);
+    }
+    return merged;
+  }
+
+  private collectDirectories(targetPath: string): string[] {
+    const directories: string[] = [];
+    let current = path.extname(targetPath) ? path.dirname(targetPath) : targetPath;
+    const stopAt = path.resolve(this.projectRoot);
+    while (current && !directories.includes(current)) {
+      directories.unshift(current);
+      if (path.resolve(current) === stopAt) {
+        break;
+      }
+      const parent = path.dirname(current);
+      if (parent === current) {
+        break;
+      }
+      current = parent;
+    }
+    return directories;
+  }
+
+  private async resolveAgentsFile(directory: string): Promise<string | undefined> {
+    const candidates = ['AGENTS.md', 'CODEX.md'];
+    for (const candidate of candidates) {
+      const filePath = path.join(directory, candidate);
+      try {
+        await readFile(filePath);
+        return filePath;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          continue;
+        }
+        throw error;
+      }
+    }
+    return undefined;
+  }
+
+  private async parseFile(filePath: string): Promise<AgentGuidelines> {
+    const content = await readFile(filePath, 'utf8');
+    const result: AgentGuidelines = merge({}, defaultGuidelines);
+    for (const [key, matcher] of Object.entries(sectionMatchers)) {
+      const section = this.extractSection(content, matcher);
+      if (!section) continue;
+      const lines = section
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line.startsWith('-') || line.startsWith('*'))
+        .map((line) => line.replace(/^[-*]\s*/, ''));
+      (result as AgentGuidelines)[key as keyof AgentGuidelines] = lines;
+    }
+    return result;
+  }
+
+  private extractSection(content: string, matcher: RegExp): string | undefined {
+    const headingMatch = content.match(matcher);
+    if (!headingMatch) return undefined;
+    const startIndex = headingMatch.index ?? 0;
+    const remaining = content.slice(startIndex);
+    const nextHeading = remaining.search(/\n##\s+/);
+    if (nextHeading === -1) return remaining;
+    return remaining.slice(0, nextHeading);
+  }
+
+  private mergeGuidelineObjects(base: AgentGuidelines, update: AgentGuidelines): AgentGuidelines {
+    const merged = merge({}, base);
+    for (const key of Object.keys(update) as Array<keyof AgentGuidelines>) {
+      const values = new Set([...(merged[key] ?? []), ...(update[key] ?? [])]);
+      merged[key] = Array.from(values);
+    }
+    return merged;
+  }
+}

--- a/codex-meta-intelligence/src/agent/types.ts
+++ b/codex-meta-intelligence/src/agent/types.ts
@@ -1,0 +1,123 @@
+import Ajv from 'ajv';
+import {
+  AgentRole,
+  type AgentConfig,
+  type AgentGuidelines,
+  type AgentMessage,
+  type AgentResult,
+} from '../shared/types.js';
+import { deepFreeze } from '../shared/utils.js';
+
+const ajv = new Ajv({ allErrors: true, removeAdditional: 'failing', strict: false });
+
+type Schema<T> = { validate: (value: unknown) => T };
+
+const buildValidator = <T>(schema: object): Schema<T> => {
+  const validate = ajv.compile<T>(schema);
+  return {
+    validate(value: unknown): T {
+      if (!validate(value)) {
+        const message = ajv.errorsText(validate.errors, { dataVar: 'payload' });
+        throw new Error(`Validation failed: ${message}`);
+      }
+      return value as T;
+    },
+  };
+};
+
+export const agentConfigSchema = buildValidator<AgentConfig>({
+  type: 'object',
+  required: ['id', 'role', 'concurrency', 'timeoutMs', 'tools'],
+  additionalProperties: false,
+  properties: {
+    id: { type: 'string', minLength: 1 },
+    role: { enum: Object.values(AgentRole) },
+    concurrency: { type: 'integer', minimum: 1 },
+    timeoutMs: { type: 'integer', minimum: 1000 },
+    tools: {
+      type: 'array',
+      items: { type: 'string' },
+      default: [],
+    },
+  },
+});
+
+export const agentGuidelinesSchema = buildValidator<AgentGuidelines>({
+  type: 'object',
+  required: ['environment', 'testing', 'coding', 'logging', 'pullRequests'],
+  properties: {
+    environment: { type: 'array', items: { type: 'string' } },
+    testing: { type: 'array', items: { type: 'string' } },
+    coding: { type: 'array', items: { type: 'string' } },
+    logging: { type: 'array', items: { type: 'string' } },
+    pullRequests: { type: 'array', items: { type: 'string' } },
+  },
+  additionalProperties: false,
+});
+
+export const agentMessageSchema = buildValidator<AgentMessage>({
+  type: 'object',
+  required: ['taskId', 'macroId', 'payload', 'context', 'guidelines', 'metadata'],
+  additionalProperties: false,
+  properties: {
+    taskId: { type: 'string', minLength: 1 },
+    macroId: { type: 'string', minLength: 1 },
+    payload: {},
+    context: {
+      type: 'array',
+      items: { type: 'object' },
+    },
+    guidelines: agentGuidelinesSchema,
+    metadata: {
+      type: 'object',
+      required: ['priority', 'createdAt', 'source', 'version'],
+      additionalProperties: false,
+      properties: {
+        priority: { type: 'integer', minimum: 0 },
+        createdAt: { type: 'string' },
+        source: { type: 'string' },
+        version: { type: 'string' },
+      },
+    },
+  },
+});
+
+export const agentResultSchema = buildValidator<AgentResult>({
+  type: 'object',
+  required: ['taskId', 'status', 'summary', 'artifacts', 'issues', 'contextUpdates', 'durationMs'],
+  additionalProperties: false,
+  properties: {
+    taskId: { type: 'string' },
+    status: { enum: ['success', 'error'] },
+    summary: { type: 'string' },
+    artifacts: {
+      type: 'object',
+      additionalProperties: true,
+    },
+    issues: {
+      type: 'array',
+      items: { type: 'string' },
+    },
+    contextUpdates: {
+      type: 'array',
+      items: { type: 'object' },
+    },
+    durationMs: { type: 'integer', minimum: 0 },
+    error: { type: 'string' },
+  },
+});
+
+deepFreeze(agentConfigSchema);
+deepFreeze(agentMessageSchema);
+deepFreeze(agentResultSchema);
+
+type Validator<T> = (value: unknown) => T;
+
+export const validateAgentConfig: Validator<AgentConfig> = (value) =>
+  agentConfigSchema.validate(value);
+export const validateAgentMessage: Validator<AgentMessage> = (value) =>
+  agentMessageSchema.validate(value);
+export const validateAgentResult: Validator<AgentResult> = (value) =>
+  agentResultSchema.validate(value);
+
+export type { AgentConfig, AgentGuidelines, AgentMessage, AgentResult };

--- a/codex-meta-intelligence/src/analytics/metrics.ts
+++ b/codex-meta-intelligence/src/analytics/metrics.ts
@@ -1,0 +1,13 @@
+import type { MetricRecord } from '../shared/types.js';
+
+export class MetricsRegistry {
+  private readonly metrics: MetricRecord[] = [];
+
+  record(metric: MetricRecord): void {
+    this.metrics.push(metric);
+  }
+
+  getMetrics(): MetricRecord[] {
+    return [...this.metrics];
+  }
+}

--- a/codex-meta-intelligence/src/analytics/tracing.ts
+++ b/codex-meta-intelligence/src/analytics/tracing.ts
@@ -1,0 +1,31 @@
+import crypto from 'node:crypto';
+
+import type { TraceSpan } from '../shared/types.js';
+import type { JsonValue } from '../shared/utils.js';
+
+export class TracingService {
+  private readonly spans = new Map<string, TraceSpan>();
+
+  startSpan(name: string, attributes: Record<string, JsonValue> = {}): TraceSpan {
+    const span: TraceSpan = {
+      id: crypto.randomUUID(),
+      name,
+      startTime: Date.now(),
+      attributes,
+    };
+    this.spans.set(span.id, span);
+    return span;
+  }
+
+  endSpan(id: string, attributes: Record<string, JsonValue> = {}): TraceSpan | undefined {
+    const span = this.spans.get(id);
+    if (!span) return undefined;
+    span.endTime = Date.now();
+    Object.assign(span.attributes, attributes);
+    return span;
+  }
+
+  getSpans(): TraceSpan[] {
+    return Array.from(this.spans.values());
+  }
+}

--- a/codex-meta-intelligence/src/cicd/linters.ts
+++ b/codex-meta-intelligence/src/cicd/linters.ts
@@ -1,0 +1,21 @@
+import { execSync } from 'node:child_process';
+
+interface LintResult {
+  command: string;
+  success: boolean;
+  output: string;
+}
+
+export const runLintCommand = (command: string): LintResult => {
+  try {
+    const output = execSync(command, { encoding: 'utf8', stdio: 'pipe' });
+    return { command, success: true, output };
+  } catch (error) {
+    const err = error as Error & { stdout?: string; stderr?: string };
+    return {
+      command,
+      success: false,
+      output: `${err.stdout ?? ''}${err.stderr ?? err.message}`,
+    };
+  }
+};

--- a/codex-meta-intelligence/src/cicd/pipeline.ts
+++ b/codex-meta-intelligence/src/cicd/pipeline.ts
@@ -1,0 +1,23 @@
+import { runLintCommand } from './linters.js';
+import { runTestCommand } from './tests.js';
+
+interface PipelineOptions {
+  lintCommand?: string;
+  testCommand?: string;
+}
+
+export interface PipelineOutcome {
+  lint?: ReturnType<typeof runLintCommand>;
+  tests?: ReturnType<typeof runTestCommand>;
+}
+
+export const runPipeline = (options: PipelineOptions = {}): PipelineOutcome => {
+  const outcome: PipelineOutcome = {};
+  if (options.lintCommand) {
+    outcome.lint = runLintCommand(options.lintCommand);
+  }
+  if (options.testCommand) {
+    outcome.tests = runTestCommand(options.testCommand);
+  }
+  return outcome;
+};

--- a/codex-meta-intelligence/src/cicd/tests.ts
+++ b/codex-meta-intelligence/src/cicd/tests.ts
@@ -1,0 +1,21 @@
+import { execSync } from 'node:child_process';
+
+interface TestResult {
+  command: string;
+  success: boolean;
+  output: string;
+}
+
+export const runTestCommand = (command: string): TestResult => {
+  try {
+    const output = execSync(command, { encoding: 'utf8', stdio: 'pipe' });
+    return { command, success: true, output };
+  } catch (error) {
+    const err = error as Error & { stdout?: string; stderr?: string };
+    return {
+      command,
+      success: false,
+      output: `${err.stdout ?? ''}${err.stderr ?? err.message}`,
+    };
+  }
+};

--- a/codex-meta-intelligence/src/context/fabric.ts
+++ b/codex-meta-intelligence/src/context/fabric.ts
@@ -1,0 +1,56 @@
+import { cosineSimilarity, generateId, nowIso, type JsonValue } from '../shared/utils.js';
+import type { ContextPacket, ContextRequest, ContextResponse } from '../shared/types.js';
+
+const normaliseText = (text: string): string => text.replace(/\s+/g, ' ').trim();
+
+const embed = (text: string): number[] => {
+  const normalised = normaliseText(text.toLowerCase());
+  const vector = new Array(16).fill(0);
+  for (let i = 0; i < normalised.length; i += 1) {
+    const code = normalised.charCodeAt(i);
+    vector[i % vector.length] += code / 255;
+  }
+  return vector;
+};
+
+export class ContextFabric {
+  private readonly packets = new Map<string, ContextPacket>();
+
+  ingest(source: string, content: string, metadata: Record<string, JsonValue> = {}): ContextPacket {
+    const summary = content.length > 160 ? `${content.slice(0, 157)}...` : content;
+    const packet: ContextPacket = {
+      id: generateId('ctx'),
+      source,
+      content,
+      summary,
+      embedding: embed(content),
+      metadata,
+      createdAt: nowIso(),
+    };
+    this.packets.set(packet.id, packet);
+    return packet;
+  }
+
+  persist(packet: ContextPacket): void {
+    this.packets.set(packet.id, packet);
+  }
+
+  retrieve(request: ContextRequest): ContextResponse {
+    const scored = Array.from(this.packets.values()).map((packet) => ({
+      packet,
+      score: cosineSimilarity(
+        packet.embedding,
+        request.embedding ?? embed(request.keywords.join(' '))
+      ),
+    }));
+    const selected = scored
+      .filter((entry) => entry.score > 0)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, request.limit)
+      .map((entry) => entry.packet);
+    return {
+      packets: selected,
+      rationale: selected.map((packet) => `Selected from ${packet.source}`),
+    };
+  }
+}

--- a/codex-meta-intelligence/src/context/governance.ts
+++ b/codex-meta-intelligence/src/context/governance.ts
@@ -1,0 +1,30 @@
+import type { AgentRole, ContextPacket, GovernancePolicy } from '../shared/types.js';
+
+const defaultPolicies: GovernancePolicy[] = [
+  {
+    id: 'sensitivity-public',
+    description: 'Public packets are accessible to all agents.',
+    appliesTo: [
+      'frontend' as AgentRole,
+      'backend' as AgentRole,
+      'knowledge' as AgentRole,
+      'qa' as AgentRole,
+      'refinement' as AgentRole,
+    ],
+    validator: (packet) => packet.metadata['sensitivity'] !== 'restricted',
+  },
+];
+
+export class Governance {
+  private readonly policies: GovernancePolicy[];
+
+  constructor(policies: GovernancePolicy[] = defaultPolicies) {
+    this.policies = policies;
+  }
+
+  isAllowed(role: AgentRole, packet: ContextPacket): boolean {
+    return this.policies
+      .filter((policy) => policy.appliesTo.includes(role))
+      .every((policy) => policy.validator(packet));
+  }
+}

--- a/codex-meta-intelligence/src/context/orchestrator.ts
+++ b/codex-meta-intelligence/src/context/orchestrator.ts
@@ -1,0 +1,35 @@
+import type { AgentRole, ContextPacket, ContextRequest, ContextResponse } from '../shared/types.js';
+import type { JsonValue } from '../shared/utils.js';
+import { ContextFabric } from './fabric.js';
+import { Governance } from './governance.js';
+
+export class ContextOrchestrator {
+  private readonly fabric: ContextFabric;
+
+  private readonly governance: Governance;
+
+  constructor(fabric = new ContextFabric(), governance = new Governance()) {
+    this.fabric = fabric;
+    this.governance = governance;
+  }
+
+  ingest(source: string, content: string, metadata: Record<string, JsonValue> = {}): ContextPacket {
+    return this.fabric.ingest(source, content, metadata);
+  }
+
+  retrieve(request: ContextRequest): ContextResponse {
+    const response = this.fabric.retrieve(request);
+    const filtered = response.packets.filter((packet) =>
+      this.governance.isAllowed(request.role, packet)
+    );
+    return {
+      packets: filtered,
+      rationale: filtered.map((packet) => `Allowed for ${request.role} from ${packet.source}`),
+    };
+  }
+
+  compose(role: AgentRole, packets: ContextPacket[]): string {
+    const allowed = packets.filter((packet) => this.governance.isAllowed(role, packet));
+    return allowed.map((packet) => packet.summary).join('\n');
+  }
+}

--- a/codex-meta-intelligence/src/cursor/adaptor.ts
+++ b/codex-meta-intelligence/src/cursor/adaptor.ts
@@ -1,0 +1,17 @@
+import type { AgentGuidelines } from '../shared/types.js';
+import merge from 'lodash.merge';
+
+interface CursorRules {
+  environment?: string[];
+  testing?: string[];
+  coding?: string[];
+  logging?: string[];
+  pullRequests?: string[];
+}
+
+export const mergeCursorRules = (
+  guidelines: AgentGuidelines,
+  cursorRules: CursorRules
+): AgentGuidelines => {
+  return merge({}, guidelines, cursorRules);
+};

--- a/codex-meta-intelligence/src/cursor/sync.ts
+++ b/codex-meta-intelligence/src/cursor/sync.ts
@@ -1,0 +1,14 @@
+interface SyncResult {
+  syncedFiles: string[];
+  conflicts: string[];
+}
+
+export const performSync = (localFiles: string[], remoteFiles: string[]): SyncResult => {
+  const conflicts = localFiles.filter((file) => remoteFiles.includes(file));
+  const uniqueLocal = localFiles.filter((file) => !conflicts.includes(file));
+  const uniqueRemote = remoteFiles.filter((file) => !conflicts.includes(file));
+  return {
+    syncedFiles: [...uniqueLocal, ...uniqueRemote],
+    conflicts,
+  };
+};

--- a/codex-meta-intelligence/src/foresight/analytics.ts
+++ b/codex-meta-intelligence/src/foresight/analytics.ts
@@ -1,0 +1,20 @@
+export const movingAverage = (values: number[], window = values.length): number => {
+  if (values.length === 0 || window <= 0) return 0;
+  const slice = values.slice(-window);
+  return slice.reduce((acc, value) => acc + value, 0) / slice.length;
+};
+
+export const weightedScore = (values: number[], weights: number[]): number => {
+  if (values.length !== weights.length || values.length === 0) {
+    return 0;
+  }
+  const totalWeight = weights.reduce((acc, value) => acc + value, 0);
+  if (totalWeight === 0) return 0;
+  let score = 0;
+  for (let i = 0; i < values.length; i += 1) {
+    const value = values[i]!;
+    const weight = weights[i]!;
+    score += value * weight;
+  }
+  return score / totalWeight;
+};

--- a/codex-meta-intelligence/src/foresight/index.ts
+++ b/codex-meta-intelligence/src/foresight/index.ts
@@ -1,0 +1,40 @@
+import { movingAverage, weightedScore } from './analytics.js';
+import { assessRisk as calculateRisk } from './risk.js';
+import type { ForecastResult, RiskAssessment } from '../shared/types.js';
+
+interface ForecastInputs {
+  taskId: string;
+  durations: number[];
+  qaIssues: number[];
+  weights?: number[];
+}
+
+export class ForesightEngine {
+  predict(inputs: ForecastInputs): ForecastResult {
+    const duration = movingAverage(inputs.durations, 5);
+    const qaPenalty = weightedScore(
+      inputs.qaIssues,
+      inputs.weights ?? inputs.qaIssues.map(() => 1)
+    );
+    const predictedDurationMs = duration * (1 + qaPenalty * 0.1);
+    const confidence = Math.max(0.4, 1 - qaPenalty * 0.05);
+    return {
+      taskId: inputs.taskId,
+      predictedDurationMs,
+      confidence,
+      notes: [
+        `Base duration estimate: ${duration.toFixed(2)}ms`,
+        `QA penalty: ${qaPenalty.toFixed(2)}`,
+      ],
+    };
+  }
+
+  assessRisk(
+    taskId: string,
+    recentFailures: number,
+    qaIssues: number,
+    complexity: number
+  ): RiskAssessment {
+    return calculateRisk(taskId, { recentFailures, qaIssues, complexity });
+  }
+}

--- a/codex-meta-intelligence/src/foresight/risk.ts
+++ b/codex-meta-intelligence/src/foresight/risk.ts
@@ -1,0 +1,24 @@
+import type { RiskAssessment } from '../shared/types.js';
+
+interface RiskSignals {
+  recentFailures: number;
+  qaIssues: number;
+  complexity: number;
+}
+
+export const assessRisk = (taskId: string, signals: RiskSignals): RiskAssessment => {
+  const score = signals.recentFailures * 0.4 + signals.qaIssues * 0.4 + signals.complexity * 0.2;
+  let level: RiskAssessment['level'] = 'low';
+  if (score > 6) level = 'high';
+  else if (score > 3) level = 'medium';
+  return {
+    taskId,
+    riskScore: score,
+    level,
+    factors: [
+      `Recent failures: ${signals.recentFailures}`,
+      `QA issues: ${signals.qaIssues}`,
+      `Complexity: ${signals.complexity}`,
+    ],
+  };
+};

--- a/codex-meta-intelligence/src/integration/email.ts
+++ b/codex-meta-intelligence/src/integration/email.ts
@@ -1,0 +1,11 @@
+interface EmailMessage {
+  to: string;
+  subject: string;
+  body: string;
+}
+
+export const composeEmail = (to: string, subject: string, body: string): EmailMessage => ({
+  to,
+  subject,
+  body,
+});

--- a/codex-meta-intelligence/src/integration/github.ts
+++ b/codex-meta-intelligence/src/integration/github.ts
@@ -1,0 +1,15 @@
+interface PullRequestUpdate {
+  repository: string;
+  number: number;
+  body: string;
+}
+
+export const formatPullRequestUpdate = (
+  repository: string,
+  number: number,
+  summary: string
+): PullRequestUpdate => ({
+  repository,
+  number,
+  body: summary,
+});

--- a/codex-meta-intelligence/src/integration/slack.ts
+++ b/codex-meta-intelligence/src/integration/slack.ts
@@ -1,0 +1,9 @@
+interface SlackMessage {
+  channel: string;
+  text: string;
+}
+
+export const createSlackMessage = (channel: string, text: string): SlackMessage => ({
+  channel,
+  text,
+});

--- a/codex-meta-intelligence/src/knowledge/index.ts
+++ b/codex-meta-intelligence/src/knowledge/index.ts
@@ -1,0 +1,24 @@
+import type { KnowledgeBlock, KnowledgeQuery, KnowledgeResponse } from '../shared/types.js';
+import { InMemoryKnowledgeStore } from './storage.js';
+import { validateKnowledgeBlock } from './scaffolds.js';
+
+export class KnowledgeService {
+  constructor(private readonly store = new InMemoryKnowledgeStore()) {}
+
+  storeBlock(block: KnowledgeBlock): KnowledgeBlock {
+    validateKnowledgeBlock(block);
+    return this.store.storeBlock(block);
+  }
+
+  ingestBlocks(blocks: KnowledgeBlock[]): KnowledgeBlock[] {
+    return blocks.map((block) => this.storeBlock(block));
+  }
+
+  fetchBlock(id: string): KnowledgeBlock | undefined {
+    return this.store.getBlock(id);
+  }
+
+  queryKnowledge(query: KnowledgeQuery): KnowledgeResponse {
+    return this.store.search(query);
+  }
+}

--- a/codex-meta-intelligence/src/knowledge/scaffolds.ts
+++ b/codex-meta-intelligence/src/knowledge/scaffolds.ts
@@ -1,0 +1,58 @@
+import Ajv from 'ajv';
+
+import type { KnowledgeBlock } from '../shared/types.js';
+
+const ajv = new Ajv({ allErrors: true, strict: false });
+
+const blockSchema = {
+  type: 'object',
+  required: ['id', 'content', 'metadata'],
+  additionalProperties: false,
+  properties: {
+    id: { type: 'string' },
+    content: { type: 'string' },
+    metadata: {
+      type: 'object',
+      required: ['author', 'timestamp', 'tags', 'citations', 'source', 'reliabilityScore'],
+      additionalProperties: false,
+      properties: {
+        author: { type: 'string' },
+        timestamp: { type: 'string' },
+        tags: { type: 'array', items: { type: 'string' } },
+        citations: { type: 'array', items: { type: 'string' } },
+        source: { type: 'string' },
+        reliabilityScore: { type: 'number', minimum: 0, maximum: 1 },
+      },
+    },
+    links: {
+      type: 'array',
+      items: { type: 'string' },
+      default: [],
+    },
+  },
+};
+
+const validateBlock = ajv.compile<KnowledgeBlock>(blockSchema);
+
+export const parseNdjson = (content: string): KnowledgeBlock[] => {
+  const lines = content
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return lines.map((line, index) => {
+    const parsed = JSON.parse(line);
+    if (!validateBlock(parsed)) {
+      throw new Error(
+        `Invalid knowledge block at line ${index + 1}: ${ajv.errorsText(validateBlock.errors)}`
+      );
+    }
+    return parsed;
+  });
+};
+
+export const validateKnowledgeBlock = (block: KnowledgeBlock): KnowledgeBlock => {
+  if (!validateBlock(block)) {
+    throw new Error(ajv.errorsText(validateBlock.errors));
+  }
+  return block;
+};

--- a/codex-meta-intelligence/src/knowledge/storage.ts
+++ b/codex-meta-intelligence/src/knowledge/storage.ts
@@ -1,0 +1,49 @@
+import type { KnowledgeBlock, KnowledgeQuery, KnowledgeResponse } from '../shared/types.js';
+import { clamp, generateId } from '../shared/utils.js';
+
+export class InMemoryKnowledgeStore {
+  private readonly blocks = new Map<string, KnowledgeBlock>();
+
+  storeBlock(block: KnowledgeBlock): KnowledgeBlock {
+    if (this.blocks.has(block.id)) {
+      throw new Error(`Knowledge block with id ${block.id} already exists`);
+    }
+    this.blocks.set(block.id, block);
+    return block;
+  }
+
+  createBlock(content: string, metadata: KnowledgeBlock['metadata']): KnowledgeBlock {
+    const block: KnowledgeBlock = {
+      id: generateId('kb'),
+      content,
+      metadata,
+    };
+    this.storeBlock(block);
+    return block;
+  }
+
+  getBlock(id: string): KnowledgeBlock | undefined {
+    return this.blocks.get(id);
+  }
+
+  search(query: KnowledgeQuery): KnowledgeResponse {
+    const limit = clamp(query.limit ?? 10, 1, 50);
+    const results = Array.from(this.blocks.values())
+      .map((block) => ({ block, score: this.scoreBlock(block, query) }))
+      .filter((entry) => entry.score > 0)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, limit);
+    return { blocks: results };
+  }
+
+  private scoreBlock(block: KnowledgeBlock, query: KnowledgeQuery): number {
+    const keywordMatches = query.keywords.reduce((acc, keyword) => {
+      const matches = block.content.toLowerCase().includes(keyword.toLowerCase()) ? 1 : 0;
+      return acc + matches;
+    }, 0);
+    const tagMatches = (query.tags ?? []).reduce((acc, tag) => {
+      return acc + (block.metadata.tags.includes(tag) ? 1 : 0);
+    }, 0);
+    return keywordMatches * 2 + tagMatches;
+  }
+}

--- a/codex-meta-intelligence/src/macro/index.ts
+++ b/codex-meta-intelligence/src/macro/index.ts
@@ -1,0 +1,130 @@
+import { createAgent } from '../agent/index.js';
+import { AgentGuidelineReader } from '../agent/reader.js';
+import { DEFAULT_AGENT_TIMEOUT_MS } from '../shared/constants.js';
+import {
+  AgentRole,
+  type AgentResult,
+  type ContextPacket,
+  type MacroContext,
+  type MacroDefinition,
+  type MacroResult,
+  type MacroStage,
+} from '../shared/types.js';
+import { generateId, nowIso } from '../shared/utils.js';
+import { createDefaultMacroRegistry } from './scripts.js';
+import {
+  validateMacroDefinition,
+  type MacroRegistry,
+  type MacroStageExecutionResult,
+} from './types.js';
+
+const toContextPackets = (metadata: Record<string, unknown>): ContextPacket[] => {
+  const value = metadata['contextPackets'];
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is ContextPacket => typeof item === 'object' && item !== null);
+};
+
+export class MacroOrchestrator {
+  private readonly registry: MacroRegistry;
+
+  private readonly guidelineReader: AgentGuidelineReader;
+
+  constructor(registry: MacroRegistry = createDefaultMacroRegistry()) {
+    this.registry = registry;
+    this.guidelineReader = new AgentGuidelineReader();
+    for (const definition of registry.values()) {
+      validateMacroDefinition(definition);
+    }
+  }
+
+  async runMacro(name: string, context: MacroContext): Promise<MacroResult> {
+    const definition = this.registry.get(name);
+    if (!definition) {
+      throw new Error(`Macro '${name}' not found`);
+    }
+
+    const startedAt = nowIso();
+    const stageResults: AgentResult[] = [];
+
+    try {
+      const packets = toContextPackets(context.metadata);
+      for (const stage of definition.stages) {
+        const execution = await this.executeStage(stage, definition, context, packets);
+        stageResults.push(execution.result);
+        if (execution.result.status === 'error' && !stage.continueOnError) {
+          throw new Error(`Stage ${stage.name} failed: ${execution.result.summary}`);
+        }
+      }
+      return {
+        taskId: context.taskId,
+        macroName: definition.name,
+        stageResults,
+        success: true,
+        startedAt,
+        finishedAt: nowIso(),
+      };
+    } catch (error) {
+      if (definition.fallbackMacro) {
+        return this.runMacro(definition.fallbackMacro, context);
+      }
+      const result: MacroResult = {
+        taskId: context.taskId,
+        macroName: definition.name,
+        stageResults,
+        success: false,
+        startedAt,
+        finishedAt: nowIso(),
+      };
+      return result;
+    }
+  }
+
+  private async executeStage(
+    stage: MacroStage,
+    definition: MacroDefinition,
+    context: MacroContext,
+    packets: ContextPacket[]
+  ): Promise<MacroStageExecutionResult> {
+    const agent = createAgent(stage.agentRole as AgentRole, {
+      id: `${stage.id}-${generateId('agent')}`,
+      concurrency: 1,
+      timeoutMs: DEFAULT_AGENT_TIMEOUT_MS,
+      tools: [],
+    });
+    const guidelines = await this.guidelineReader.mergeGuidelines(process.cwd());
+    let attempts = 0;
+    let result: AgentResult | undefined;
+    do {
+      attempts += 1;
+      const message = {
+        taskId: context.taskId,
+        macroId: definition.name,
+        payload: context.input,
+        context: packets,
+        guidelines,
+        metadata: {
+          priority: 0,
+          createdAt: nowIso(),
+          source: 'macro-orchestrator',
+          version: '1.0.0',
+        },
+      };
+      // eslint-disable-next-line no-await-in-loop
+      result = await agent.handleMessage(message);
+      if (result.status === 'success') {
+        break;
+      }
+    } while (attempts <= stage.retryLimit);
+
+    if (!result) {
+      throw new Error(`Stage ${stage.name} did not produce a result`);
+    }
+
+    return { stage, result, attempts };
+  }
+}
+
+export const runMacro = async (macroName: string, context: MacroContext): Promise<MacroResult> => {
+  const orchestrator = new MacroOrchestrator();
+  return orchestrator.runMacro(macroName, context);
+};

--- a/codex-meta-intelligence/src/macro/scripts.ts
+++ b/codex-meta-intelligence/src/macro/scripts.ts
@@ -1,0 +1,78 @@
+import { AgentRole, type MacroDefinition } from '../shared/types.js';
+import type { MacroRegistry } from './types.js';
+
+const defaultMacros: MacroDefinition[] = [
+  {
+    name: 'full-pipeline',
+    description: 'Runs draft, audit and refinement stages to produce deployable artifacts.',
+    qualityThreshold: 0.8,
+    stages: [
+      {
+        id: 'draft-ui',
+        name: 'Draft UI',
+        description: 'Generate initial frontend concept.',
+        agentRole: AgentRole.FRONTEND,
+        retryLimit: 1,
+        continueOnError: false,
+      },
+      {
+        id: 'draft-api',
+        name: 'Draft API',
+        description: 'Craft backend scaffold with health endpoint.',
+        agentRole: AgentRole.BACKEND,
+        retryLimit: 1,
+        continueOnError: true,
+      },
+      {
+        id: 'qa',
+        name: 'Quality Assurance',
+        description: 'Run QA checks to validate the draft.',
+        agentRole: AgentRole.QA,
+        retryLimit: 0,
+        continueOnError: false,
+      },
+      {
+        id: 'refine',
+        name: 'Refinement',
+        description: 'Apply improvements from QA findings.',
+        agentRole: AgentRole.REFINEMENT,
+        retryLimit: 1,
+        continueOnError: true,
+      },
+    ],
+  },
+  {
+    name: 'knowledge-refresh',
+    description: 'Synchronise knowledge blocks and refresh context.',
+    qualityThreshold: 0.6,
+    stages: [
+      {
+        id: 'knowledge-update',
+        name: 'Knowledge Update',
+        description: 'Push context packets into the knowledge store.',
+        agentRole: AgentRole.KNOWLEDGE,
+        retryLimit: 2,
+        continueOnError: false,
+      },
+      {
+        id: 'qa-audit',
+        name: 'QA Audit',
+        description: 'Validate knowledge quality.',
+        agentRole: AgentRole.QA,
+        retryLimit: 1,
+        continueOnError: false,
+      },
+    ],
+    fallbackMacro: 'full-pipeline',
+  },
+];
+
+export const createDefaultMacroRegistry = (): MacroRegistry => {
+  const registry: MacroRegistry = new Map();
+  for (const macro of defaultMacros) {
+    registry.set(macro.name, macro);
+  }
+  return registry;
+};
+
+export const listMacros = (): MacroDefinition[] => [...defaultMacros];

--- a/codex-meta-intelligence/src/macro/types.ts
+++ b/codex-meta-intelligence/src/macro/types.ts
@@ -1,0 +1,69 @@
+import Ajv from 'ajv';
+
+import type {
+  AgentRole,
+  AgentResult,
+  MacroContext,
+  MacroDefinition,
+  MacroResult,
+  MacroStage,
+} from '../shared/types.js';
+import { deepFreeze } from '../shared/utils.js';
+
+const ajv = new Ajv({ allErrors: true, removeAdditional: 'failing' });
+
+const macroStageSchema = {
+  type: 'object',
+  required: ['id', 'name', 'description', 'agentRole', 'retryLimit', 'continueOnError'],
+  additionalProperties: false,
+  properties: {
+    id: { type: 'string' },
+    name: { type: 'string' },
+    description: { type: 'string' },
+    agentRole: { type: 'string' },
+    retryLimit: { type: 'integer', minimum: 0 },
+    continueOnError: { type: 'boolean' },
+  },
+};
+
+const macroDefinitionSchema = {
+  type: 'object',
+  required: ['name', 'description', 'stages', 'qualityThreshold'],
+  additionalProperties: false,
+  properties: {
+    name: { type: 'string' },
+    description: { type: 'string' },
+    stages: { type: 'array', items: macroStageSchema, minItems: 1 },
+    fallbackMacro: { type: 'string' },
+    qualityThreshold: { type: 'number', minimum: 0, maximum: 1 },
+  },
+};
+
+const validate = <T>(schema: object, payload: unknown): T => {
+  const compiled = ajv.compile<T>(schema);
+  if (!compiled(payload)) {
+    throw new Error(ajv.errorsText(compiled.errors, { dataVar: 'macro' }));
+  }
+  return payload as T;
+};
+
+export const validateMacroDefinition = (payload: unknown): MacroDefinition =>
+  validate<MacroDefinition>(macroDefinitionSchema, payload);
+
+export interface MacroExecutionContext {
+  context: MacroContext;
+  definition: MacroDefinition;
+}
+
+export interface MacroStageExecutionResult {
+  stage: MacroStage;
+  result: AgentResult;
+  attempts: number;
+}
+
+export type MacroRegistry = Map<string, MacroDefinition>;
+
+deepFreeze(macroStageSchema);
+deepFreeze(macroDefinitionSchema);
+
+export type { AgentRole, MacroContext, MacroDefinition, MacroResult, MacroStage };

--- a/codex-meta-intelligence/src/memory/cache.ts
+++ b/codex-meta-intelligence/src/memory/cache.ts
@@ -1,0 +1,25 @@
+import { LruCache } from '../shared/utils.js';
+
+export class MemoryCache<T> {
+  private readonly cache: LruCache<string, T>;
+
+  constructor(capacity: number) {
+    this.cache = new LruCache<string, T>(capacity);
+  }
+
+  get(key: string): T | undefined {
+    return this.cache.get(key);
+  }
+
+  set(key: string, value: T, ttlMs?: number): void {
+    this.cache.set(key, value, ttlMs);
+  }
+
+  has(key: string): boolean {
+    return this.cache.has(key);
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+}

--- a/codex-meta-intelligence/src/memory/index.ts
+++ b/codex-meta-intelligence/src/memory/index.ts
@@ -1,0 +1,39 @@
+import type { MemoryRecord } from '../shared/types.js';
+import { LruCache, generateId } from '../shared/utils.js';
+import { DEFAULT_CACHE_CAPACITY } from '../shared/constants.js';
+
+export class MemoryService {
+  private readonly records = new Map<string, MemoryRecord>();
+
+  private readonly indexByAgent = new Map<string, string[]>();
+
+  private readonly cache = new LruCache<string, MemoryRecord>(DEFAULT_CACHE_CAPACITY);
+
+  store(record: Omit<MemoryRecord, 'id'>): MemoryRecord {
+    const entry: MemoryRecord = { ...record, id: generateId('memory') };
+    this.records.set(entry.id, entry);
+    this.cache.set(entry.id, entry);
+    const agentRecords = this.indexByAgent.get(entry.agentId) ?? [];
+    agentRecords.push(entry.id);
+    this.indexByAgent.set(entry.agentId, agentRecords);
+    return entry;
+  }
+
+  retrieve(id: string): MemoryRecord | undefined {
+    return this.cache.get(id) ?? this.records.get(id);
+  }
+
+  queryByAgent(agentId: string): MemoryRecord[] {
+    const ids = this.indexByAgent.get(agentId) ?? [];
+    return ids
+      .map((id) => this.retrieve(id))
+      .filter((record): record is MemoryRecord => record !== undefined);
+  }
+
+  queryRange(start: Date, end: Date): MemoryRecord[] {
+    return Array.from(this.records.values()).filter((record) => {
+      const timestamp = new Date(record.timestamp).getTime();
+      return timestamp >= start.getTime() && timestamp <= end.getTime();
+    });
+  }
+}

--- a/codex-meta-intelligence/src/memory/logs.ts
+++ b/codex-meta-intelligence/src/memory/logs.ts
@@ -1,0 +1,41 @@
+import { createWriteStream, existsSync, mkdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+import type { LogEntry } from '../shared/types.js';
+import { nowIso } from '../shared/utils.js';
+
+const DEFAULT_MAX_SIZE = 512 * 1024;
+
+export class RotatingLogger {
+  private stream: ReturnType<typeof createWriteStream>;
+
+  constructor(
+    private readonly directory: string,
+    private readonly maxSize = DEFAULT_MAX_SIZE
+  ) {
+    if (!existsSync(directory)) {
+      mkdirSync(directory, { recursive: true });
+    }
+    this.stream = this.createStream();
+  }
+
+  log(entry: LogEntry): void {
+    const payload = JSON.stringify({ ...entry, loggedAt: nowIso() });
+    this.stream.write(`${payload}\n`);
+    this.rotateIfNeeded();
+  }
+
+  private rotateIfNeeded(): void {
+    const { size } = statSync(this.stream.path.toString());
+    if (size < this.maxSize) {
+      return;
+    }
+    this.stream.end();
+    this.stream = this.createStream();
+  }
+
+  private createStream(): ReturnType<typeof createWriteStream> {
+    const filePath = path.join(this.directory, `memory-${Date.now()}.log`);
+    return createWriteStream(filePath, { flags: 'a', encoding: 'utf8' });
+  }
+}

--- a/codex-meta-intelligence/src/metaagent/index.ts
+++ b/codex-meta-intelligence/src/metaagent/index.ts
@@ -1,0 +1,88 @@
+import { MacroOrchestrator } from '../macro/index.js';
+import type { MacroContext, MetaStateSnapshot, MetaTask } from '../shared/types.js';
+import { MetaAgentMonitor } from './monitor.js';
+import { MetaAgentScheduler } from './scheduler.js';
+import { MetaAgentState } from './state.js';
+
+export class MetaAgent {
+  private readonly state: MetaAgentState;
+
+  private readonly scheduler: MetaAgentScheduler;
+
+  private readonly monitor: MetaAgentMonitor;
+
+  private readonly contexts = new Map<string, MacroContext>();
+
+  private processing = false;
+
+  constructor(
+    state = new MetaAgentState(),
+    scheduler = new MetaAgentScheduler(new MacroOrchestrator()),
+    monitor = new MetaAgentMonitor()
+  ) {
+    this.state = state;
+    this.scheduler = scheduler;
+    this.monitor = monitor;
+  }
+
+  enqueueTask(task: Omit<MetaTask, 'id' | 'requestedAt'>, context: MacroContext): string {
+    const stored = this.state.enqueueTask(task);
+    this.contexts.set(stored.id, context);
+    this.monitor.recordTaskQueued(stored);
+    void this.processQueue();
+    return stored.id;
+  }
+
+  cancelTask(taskId: string): boolean {
+    const cancelled = this.state.cancelTask(taskId);
+    if (cancelled) {
+      this.contexts.delete(taskId);
+    }
+    return cancelled;
+  }
+
+  getState(): MetaStateSnapshot {
+    return this.state.getSnapshot();
+  }
+
+  private async processQueue(): Promise<void> {
+    if (this.processing) {
+      return;
+    }
+    this.processing = true;
+    try {
+      while (true) {
+        const snapshot = this.state.getSnapshot();
+        const next = this.scheduler.chooseNextTask(snapshot.queued);
+        if (!next) {
+          break;
+        }
+        const task = this.state.pullTask(next.id);
+        if (!task) {
+          break;
+        }
+        const context = this.contexts.get(task.id);
+        if (!context) {
+          this.state.completeTask(task.id, {
+            taskId: task.id,
+            macroName: task.macroName,
+            stageResults: [],
+            success: false,
+            startedAt: task.requestedAt,
+            finishedAt: new Date().toISOString(),
+          });
+          continue;
+        }
+        this.monitor.recordTaskStarted(task);
+        // eslint-disable-next-line no-await-in-loop
+        const result = await this.scheduler.executeTask(task, context);
+        this.state.completeTask(task.id, result);
+        this.monitor.recordTaskCompleted(result);
+        this.contexts.delete(task.id);
+      }
+    } finally {
+      this.processing = false;
+      this.monitor.recordHeartbeat();
+    }
+  }
+}

--- a/codex-meta-intelligence/src/metaagent/monitor.ts
+++ b/codex-meta-intelligence/src/metaagent/monitor.ts
@@ -1,0 +1,53 @@
+import EventEmitter from 'eventemitter3';
+
+import type { MacroResult, MetaTask } from '../shared/types.js';
+import type { MetricRecord } from '../shared/types.js';
+import { nowIso } from '../shared/utils.js';
+
+interface MonitorEvents {
+  taskQueued: [MetaTask];
+  taskStarted: [MetaTask];
+  taskCompleted: [MacroResult];
+  metric: [MetricRecord];
+}
+
+export class MetaAgentMonitor extends EventEmitter<MonitorEvents> {
+  recordTaskQueued(task: MetaTask): void {
+    this.emit('taskQueued', task);
+    this.emit('metric', {
+      name: 'metaagent.tasks.queued',
+      labels: { macro: task.macroName },
+      value: task.priority,
+      timestamp: Date.now(),
+    });
+  }
+
+  recordTaskStarted(task: MetaTask): void {
+    this.emit('taskStarted', task);
+    this.emit('metric', {
+      name: 'metaagent.tasks.started',
+      labels: { macro: task.macroName },
+      value: 1,
+      timestamp: Date.now(),
+    });
+  }
+
+  recordTaskCompleted(result: MacroResult): void {
+    this.emit('taskCompleted', result);
+    this.emit('metric', {
+      name: 'metaagent.tasks.completed',
+      labels: { macro: result.macroName, success: String(result.success) },
+      value: result.success ? 1 : 0,
+      timestamp: Date.now(),
+    });
+  }
+
+  recordHeartbeat(): void {
+    this.emit('metric', {
+      name: 'metaagent.heartbeat',
+      labels: { timestamp: nowIso() },
+      value: 1,
+      timestamp: Date.now(),
+    });
+  }
+}

--- a/codex-meta-intelligence/src/metaagent/scheduler.ts
+++ b/codex-meta-intelligence/src/metaagent/scheduler.ts
@@ -1,0 +1,51 @@
+import type { MacroContext, MetaTask } from '../shared/types.js';
+import { nowIso } from '../shared/utils.js';
+import { MacroOrchestrator } from '../macro/index.js';
+import type { MacroResult } from '../shared/types.js';
+
+export interface SchedulerStrategy {
+  selectTask(queue: MetaTask[]): MetaTask | undefined;
+}
+
+export class PriorityScheduler implements SchedulerStrategy {
+  selectTask(queue: MetaTask[]): MetaTask | undefined {
+    if (queue.length === 0) return undefined;
+    let highest: MetaTask | undefined;
+    for (const task of queue) {
+      if (!highest || task.priority > highest.priority) {
+        highest = task;
+      }
+    }
+    return highest;
+  }
+}
+
+export class MetaAgentScheduler {
+  private readonly orchestrator: MacroOrchestrator;
+
+  private readonly strategy: SchedulerStrategy;
+
+  constructor(
+    orchestrator = new MacroOrchestrator(),
+    strategy: SchedulerStrategy = new PriorityScheduler()
+  ) {
+    this.orchestrator = orchestrator;
+    this.strategy = strategy;
+  }
+
+  async executeTask(task: MetaTask, context: MacroContext): Promise<MacroResult> {
+    const enrichedContext: MacroContext = {
+      ...context,
+      metadata: {
+        ...context.metadata,
+        scheduledAt: nowIso(),
+        priority: task.priority,
+      },
+    };
+    return this.orchestrator.runMacro(task.macroName, enrichedContext);
+  }
+
+  chooseNextTask(queue: MetaTask[]): MetaTask | undefined {
+    return this.strategy.selectTask(queue);
+  }
+}

--- a/codex-meta-intelligence/src/metaagent/state.ts
+++ b/codex-meta-intelligence/src/metaagent/state.ts
@@ -1,0 +1,97 @@
+import { LruCache, generateId, nowIso } from '../shared/utils.js';
+import type { MacroResult, MetaStateSnapshot, MetaTask } from '../shared/types.js';
+
+export class MetaAgentState {
+  private readonly queued: MetaTask[] = [];
+
+  private readonly running: MetaTask[] = [];
+
+  private readonly completed: MacroResult[] = [];
+
+  private readonly metrics = new Map<string, number>();
+
+  private readonly recentTasks = new LruCache<string, MetaTask>(100);
+
+  enqueueTask(task: Omit<MetaTask, 'id' | 'requestedAt'>): MetaTask {
+    const fullTask: MetaTask = {
+      ...task,
+      id: generateId('task'),
+      requestedAt: nowIso(),
+    };
+    this.queued.push(fullTask);
+    this.recentTasks.set(fullTask.id, fullTask);
+    this.incrementMetric('tasks_enqueued');
+    return fullTask;
+  }
+
+  startNextTask(): MetaTask | undefined {
+    const task = this.queued.shift();
+    if (!task) {
+      return undefined;
+    }
+    this.running.push(task);
+    this.incrementMetric('tasks_started');
+    return task;
+  }
+
+  pullTask(taskId: string): MetaTask | undefined {
+    const index = this.queued.findIndex((task) => task.id === taskId);
+    if (index === -1) {
+      return undefined;
+    }
+    const [task] = this.queued.splice(index, 1);
+    if (!task) {
+      return undefined;
+    }
+    this.running.push(task);
+    this.incrementMetric('tasks_started');
+    return task;
+  }
+
+  completeTask(taskId: string, result: MacroResult): void {
+    const index = this.running.findIndex((task) => task.id === taskId);
+    if (index !== -1) {
+      this.running.splice(index, 1);
+    }
+    this.completed.push(result);
+    this.incrementMetric(result.success ? 'tasks_succeeded' : 'tasks_failed');
+  }
+
+  cancelTask(taskId: string): boolean {
+    const inQueue = this.removeTask(this.queued, taskId);
+    const inRunning = this.removeTask(this.running, taskId);
+    if (inQueue || inRunning) {
+      this.incrementMetric('tasks_cancelled');
+    }
+    return inQueue || inRunning;
+  }
+
+  getSnapshot(): MetaStateSnapshot {
+    return {
+      queued: [...this.queued],
+      running: [...this.running],
+      completed: [...this.completed],
+      metrics: Object.fromEntries(this.metrics.entries()),
+    };
+  }
+
+  getTask(taskId: string): MetaTask | undefined {
+    return (
+      this.running.find((task) => task.id === taskId) ||
+      this.queued.find((task) => task.id === taskId) ||
+      this.recentTasks.get(taskId)
+    );
+  }
+
+  private removeTask(tasks: MetaTask[], taskId: string): boolean {
+    const index = tasks.findIndex((task) => task.id === taskId);
+    if (index === -1) return false;
+    tasks.splice(index, 1);
+    return true;
+  }
+
+  private incrementMetric(name: string): void {
+    const current = this.metrics.get(name) ?? 0;
+    this.metrics.set(name, current + 1);
+  }
+}

--- a/codex-meta-intelligence/src/openai-standards/codex.ts
+++ b/codex-meta-intelligence/src/openai-standards/codex.ts
@@ -1,0 +1,28 @@
+import type { AgentMessage, AgentResult } from '../shared/types.js';
+
+interface CodexInvocation {
+  prompt: string;
+  tools: string[];
+}
+
+export class CodexAdaptor {
+  constructor(private readonly apiUrl: string) {}
+
+  prepareInvocation(message: AgentMessage): CodexInvocation {
+    const prompt = `Task ${message.taskId} from ${message.metadata.source}`;
+    return { prompt, tools: message.guidelines.environment };
+  }
+
+  async execute(message: AgentMessage): Promise<AgentResult> {
+    const invocation = this.prepareInvocation(message);
+    return {
+      taskId: message.taskId,
+      status: 'success',
+      summary: `Invoked Codex with prompt: ${invocation.prompt}`,
+      artifacts: { tools: invocation.tools },
+      issues: [],
+      contextUpdates: message.context,
+      durationMs: 10,
+    };
+  }
+}

--- a/codex-meta-intelligence/src/openai-standards/guidelines.ts
+++ b/codex-meta-intelligence/src/openai-standards/guidelines.ts
@@ -1,0 +1,17 @@
+import type { AgentGuidelines } from '../shared/types.js';
+
+export interface ComplianceReport {
+  executedCommands: string[];
+  missingCommands: string[];
+}
+
+export const verifyCompliance = (
+  guidelines: AgentGuidelines,
+  executed: string[]
+): ComplianceReport => {
+  const missingCommands = guidelines.testing.filter((command) => !executed.includes(command));
+  return {
+    executedCommands: executed,
+    missingCommands,
+  };
+};

--- a/codex-meta-intelligence/src/operator/hooks.ts
+++ b/codex-meta-intelligence/src/operator/hooks.ts
@@ -1,0 +1,27 @@
+import EventEmitter from 'eventemitter3';
+
+import type { MetaAgent } from '../metaagent/index.js';
+import type { MacroContext, MetaTask } from '../shared/types.js';
+
+interface OperatorEvents {
+  notification: [string];
+}
+
+export class OperatorHooks extends EventEmitter<OperatorEvents> {
+  constructor(private readonly metaAgent: MetaAgent) {
+    super();
+  }
+
+  enqueueTask(task: Omit<MetaTask, 'id' | 'requestedAt'>, context: MacroContext): string {
+    const id = this.metaAgent.enqueueTask(task, context);
+    this.emit('notification', `Task ${id} enqueued`);
+    return id;
+  }
+
+  cancelTask(taskId: string): boolean {
+    const cancelled = this.metaAgent.cancelTask(taskId);
+    const message = cancelled ? `Task ${taskId} cancelled` : `Task ${taskId} not found`;
+    this.emit('notification', message);
+    return cancelled;
+  }
+}

--- a/codex-meta-intelligence/src/operator/interface.ts
+++ b/codex-meta-intelligence/src/operator/interface.ts
@@ -1,0 +1,76 @@
+import readline from 'node:readline';
+
+import type { MetaAgent } from '../metaagent/index.js';
+import type { MacroContext, MetaTask } from '../shared/types.js';
+import { OperatorHooks } from './hooks.js';
+
+export class OperatorInterface {
+  private readonly hooks: OperatorHooks;
+
+  constructor(private readonly metaAgent: MetaAgent) {
+    this.hooks = new OperatorHooks(metaAgent);
+    this.hooks.on('notification', (message) => {
+      process.stdout.write(`\n[Operator] ${message}\n`);
+    });
+  }
+
+  registerCommandHandlers(): void {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    rl.setPrompt('meta-agent> ');
+    rl.prompt();
+    rl.on('line', (line) => {
+      const [command, ...args] = line.trim().split(/\s+/);
+      switch (command) {
+        case 'enqueue':
+          this.enqueueCommand(args);
+          break;
+        case 'cancel':
+          this.cancelCommand(args);
+          break;
+        case 'exit':
+          rl.close();
+          break;
+        default:
+          process.stdout.write('Unknown command\n');
+      }
+      rl.prompt();
+    });
+  }
+
+  private enqueueCommand(args: string[]): void {
+    const [macroName] = args;
+    if (!macroName) {
+      process.stdout.write('Usage: enqueue <macroName>\n');
+      return;
+    }
+    const task: Omit<MetaTask, 'id' | 'requestedAt'> = {
+      macroName,
+      input: {},
+      priority: 1,
+      owner: 'operator',
+    };
+    const context: MacroContext = {
+      taskId: macroName,
+      operatorId: 'operator',
+      input: {},
+      metadata: {},
+      guidelines: {
+        environment: [],
+        testing: [],
+        coding: [],
+        logging: [],
+        pullRequests: [],
+      },
+    };
+    this.hooks.enqueueTask(task, context);
+  }
+
+  private cancelCommand(args: string[]): void {
+    const [taskId] = args;
+    if (!taskId) {
+      process.stdout.write('Usage: cancel <taskId>\n');
+      return;
+    }
+    this.hooks.cancelTask(taskId);
+  }
+}

--- a/codex-meta-intelligence/src/operator/ui.ts
+++ b/codex-meta-intelligence/src/operator/ui.ts
@@ -1,0 +1,20 @@
+export interface OperatorWidget {
+  id: string;
+  title: string;
+  description: string;
+}
+
+export interface OperatorDashboardState {
+  widgets: OperatorWidget[];
+}
+
+export const createDefaultDashboard = (): OperatorDashboardState => ({
+  widgets: [
+    {
+      id: 'tasks',
+      title: 'Task Overview',
+      description: 'Displays queued, running and completed tasks.',
+    },
+    { id: 'qa', title: 'QA Findings', description: 'Summarises recent QA issues and severities.' },
+  ],
+});

--- a/codex-meta-intelligence/src/protocol/execution.ts
+++ b/codex-meta-intelligence/src/protocol/execution.ts
@@ -1,0 +1,38 @@
+import { PIPELINE_STAGES } from '../shared/constants.js';
+import type { AgentResult } from '../shared/types.js';
+
+export type ExecutionStageName = (typeof PIPELINE_STAGES)[number];
+
+export interface ExecutionStage {
+  name: ExecutionStageName;
+  action: () => Promise<AgentResult>;
+}
+
+export interface ExecutionSummary {
+  stages: Array<{ name: ExecutionStageName; result: AgentResult }>;
+  success: boolean;
+}
+
+export class ExecutionPipeline {
+  async runStage(stage: ExecutionStage): Promise<AgentResult> {
+    return stage.action();
+  }
+
+  async run(stages: ExecutionStage[]): Promise<ExecutionSummary> {
+    const results: Array<{ name: ExecutionStageName; result: AgentResult }> = [];
+    for (const stage of stages) {
+      // eslint-disable-next-line no-await-in-loop
+      const result = await this.runStage(stage);
+      results.push({ name: stage.name, result });
+      if (result.status === 'error') {
+        return { stages: results, success: false };
+      }
+    }
+    return { stages: results, success: true };
+  }
+}
+
+export const runPipeline = async (stages: ExecutionStage[]): Promise<ExecutionSummary> => {
+  const pipeline = new ExecutionPipeline();
+  return pipeline.run(stages);
+};

--- a/codex-meta-intelligence/src/protocol/harmony.ts
+++ b/codex-meta-intelligence/src/protocol/harmony.ts
@@ -1,0 +1,27 @@
+interface Proposal {
+  id: string;
+  priority: number;
+  confidence: number;
+  content: string;
+  timestamp: number;
+}
+
+interface HarmonyResult {
+  accepted: Proposal;
+  rejected: Proposal[];
+}
+
+export const resolveConflict = (proposals: Proposal[]): HarmonyResult => {
+  if (proposals.length === 0) {
+    throw new Error('No proposals provided for harmony resolution');
+  }
+  const sorted = [...proposals].sort((a, b) => {
+    if (a.priority !== b.priority) return b.priority - a.priority;
+    if (a.confidence !== b.confidence) return b.confidence - a.confidence;
+    return b.timestamp - a.timestamp;
+  });
+  const [accepted, ...rest] = sorted as [Proposal, ...Proposal[]];
+  return { accepted, rejected: rest };
+};
+
+export type { Proposal as HarmonyProposal, HarmonyResult };

--- a/codex-meta-intelligence/src/protocol/open-protocols.ts
+++ b/codex-meta-intelligence/src/protocol/open-protocols.ts
@@ -1,0 +1,75 @@
+import crypto from 'node:crypto';
+
+interface McpTool {
+  name: string;
+  description: string;
+  schema: object;
+}
+
+interface AcpEnvelope<T = unknown> {
+  sender: string;
+  recipient: string;
+  protocolVersion: string;
+  conversationId: string;
+  timestamp: string;
+  payload: T;
+  signature?: string;
+}
+
+interface AgentRegistration {
+  id: string;
+  role: string;
+  capabilities: string[];
+  endpoint: string;
+}
+
+const signEnvelope = (envelope: AcpEnvelope, secret: string): string => {
+  const hmac = crypto.createHmac('sha256', secret);
+  hmac.update(JSON.stringify({ ...envelope, signature: undefined }));
+  return hmac.digest('hex');
+};
+
+export const createMcpToolRegistry = (tools: McpTool[]): Map<string, McpTool> => {
+  const registry = new Map<string, McpTool>();
+  for (const tool of tools) {
+    registry.set(tool.name, tool);
+  }
+  return registry;
+};
+
+export const createAcpEnvelope = <T>(
+  payload: T,
+  sender: string,
+  recipient: string,
+  secret?: string
+): AcpEnvelope<T> => {
+  const envelope: AcpEnvelope<T> = {
+    sender,
+    recipient,
+    protocolVersion: '1.0.0',
+    conversationId: crypto.randomUUID(),
+    timestamp: new Date().toISOString(),
+    payload,
+  };
+  if (secret) {
+    envelope.signature = signEnvelope(envelope, secret);
+  }
+  return envelope;
+};
+
+export const verifyAcpEnvelope = (envelope: AcpEnvelope, secret: string): boolean => {
+  if (!envelope.signature) return false;
+  const expected = signEnvelope(envelope, secret);
+  return envelope.signature === expected;
+};
+
+export const registerAgent = (
+  registry: Map<string, AgentRegistration>,
+  registration: AgentRegistration
+): void => {
+  registry.set(registration.id, registration);
+};
+
+export const listAgents = (registry: Map<string, AgentRegistration>): AgentRegistration[] => {
+  return Array.from(registry.values());
+};

--- a/codex-meta-intelligence/src/protocol/styling.ts
+++ b/codex-meta-intelligence/src/protocol/styling.ts
@@ -1,0 +1,41 @@
+interface StylingIssue {
+  rule: string;
+  message: string;
+  severity: 'info' | 'warning' | 'error';
+}
+
+interface StylingDocument {
+  palette: Array<{ name: string; contrastRatio: number }>;
+  typographyScale: number[];
+  motionDensity: number;
+}
+
+export const validateStyling = (document: StylingDocument): StylingIssue[] => {
+  const issues: StylingIssue[] = [];
+  for (const colour of document.palette) {
+    if (colour.contrastRatio < 4.5) {
+      issues.push({
+        rule: 'contrast',
+        message: `${colour.name} contrast ratio below 4.5:1`,
+        severity: 'error',
+      });
+    }
+  }
+  if (document.typographyScale.length < 3) {
+    issues.push({
+      rule: 'typography-scale',
+      message: 'Typography scale should provide at least three steps for hierarchy.',
+      severity: 'warning',
+    });
+  }
+  if (document.motionDensity > 0.6) {
+    issues.push({
+      rule: 'motion-density',
+      message: 'Motion density is high; consider reducing animations for accessibility.',
+      severity: 'warning',
+    });
+  }
+  return issues;
+};
+
+export type { StylingDocument, StylingIssue };

--- a/codex-meta-intelligence/src/qa/aesthetic.ts
+++ b/codex-meta-intelligence/src/qa/aesthetic.ts
@@ -1,0 +1,10 @@
+import type { QAIssue } from '../shared/types.js';
+import { validateStyling, type StylingDocument } from '../protocol/styling.js';
+
+export const runAestheticChecks = (document: StylingDocument): QAIssue[] => {
+  return validateStyling(document).map((issue) => ({
+    engine: 'aesthetic',
+    severity: issue.severity,
+    message: `${issue.rule}: ${issue.message}`,
+  }));
+};

--- a/codex-meta-intelligence/src/qa/index.ts
+++ b/codex-meta-intelligence/src/qa/index.ts
@@ -1,0 +1,21 @@
+import type { QAResult, QAIssue } from '../shared/types.js';
+import { runAestheticChecks } from './aesthetic.js';
+import { runNarrativeChecks } from './narrative.js';
+import { runTechnicalChecks } from './technical.js';
+
+interface QAInputs {
+  aesthetic: Parameters<typeof runAestheticChecks>[0];
+  narrative: Parameters<typeof runNarrativeChecks>[0];
+  technical: Parameters<typeof runTechnicalChecks>[0];
+}
+
+export class QAEngine {
+  runQA(inputs: QAInputs): QAResult {
+    const issues: QAIssue[] = [];
+    issues.push(...runAestheticChecks(inputs.aesthetic));
+    issues.push(...runTechnicalChecks(inputs.technical));
+    issues.push(...runNarrativeChecks(inputs.narrative));
+    const hasError = issues.some((issue) => issue.severity === 'error');
+    return { success: !hasError, issues };
+  }
+}

--- a/codex-meta-intelligence/src/qa/narrative.ts
+++ b/codex-meta-intelligence/src/qa/narrative.ts
@@ -1,0 +1,33 @@
+import type { QAIssue } from '../shared/types.js';
+
+interface NarrativeAnalysis {
+  tone: 'neutral' | 'enthusiastic' | 'formal' | 'empathetic';
+  coherenceScore: number;
+  fairnessScore: number;
+}
+
+export const runNarrativeChecks = (analysis: NarrativeAnalysis): QAIssue[] => {
+  const issues: QAIssue[] = [];
+  if (analysis.coherenceScore < 0.7) {
+    issues.push({
+      engine: 'narrative',
+      severity: 'warning',
+      message: 'Narrative coherence below threshold',
+    });
+  }
+  if (analysis.fairnessScore < 0.8) {
+    issues.push({
+      engine: 'narrative',
+      severity: 'warning',
+      message: 'Fairness score below recommended minimum',
+    });
+  }
+  if (analysis.tone === 'formal') {
+    issues.push({
+      engine: 'narrative',
+      severity: 'info',
+      message: 'Tone is formal; consider adding warmth for user-facing content',
+    });
+  }
+  return issues;
+};

--- a/codex-meta-intelligence/src/qa/technical.ts
+++ b/codex-meta-intelligence/src/qa/technical.ts
@@ -1,0 +1,33 @@
+import type { QAIssue } from '../shared/types.js';
+
+interface TechnicalReport {
+  lintErrors: number;
+  testFailures: number;
+  coverage: number;
+}
+
+export const runTechnicalChecks = (report: TechnicalReport): QAIssue[] => {
+  const issues: QAIssue[] = [];
+  if (report.lintErrors > 0) {
+    issues.push({
+      engine: 'technical',
+      severity: 'error',
+      message: `${report.lintErrors} lint errors detected`,
+    });
+  }
+  if (report.testFailures > 0) {
+    issues.push({
+      engine: 'technical',
+      severity: 'error',
+      message: `${report.testFailures} test failures detected`,
+    });
+  }
+  if (report.coverage < 0.8) {
+    issues.push({
+      engine: 'technical',
+      severity: 'warning',
+      message: `Test coverage below threshold: ${(report.coverage * 100).toFixed(1)}%`,
+    });
+  }
+  return issues;
+};

--- a/codex-meta-intelligence/src/security/auth.ts
+++ b/codex-meta-intelligence/src/security/auth.ts
@@ -1,0 +1,33 @@
+import crypto from 'node:crypto';
+
+interface JwtPayload {
+  sub: string;
+  aud: string;
+  exp: number;
+  [key: string]: unknown;
+}
+
+const base64UrlEncode = (input: Buffer): string => input.toString('base64url');
+
+const sign = (data: string, secret: string): string => {
+  return crypto.createHmac('sha256', secret).update(data).digest('base64url');
+};
+
+export const createJwt = (payload: JwtPayload, secret: string): string => {
+  const header = base64UrlEncode(Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })));
+  const body = base64UrlEncode(Buffer.from(JSON.stringify(payload)));
+  const signature = sign(`${header}.${body}`, secret);
+  return `${header}.${body}.${signature}`;
+};
+
+export const verifyJwt = (token: string, secret: string): JwtPayload | undefined => {
+  const [headerB64, payloadB64, signature] = token.split('.');
+  if (!headerB64 || !payloadB64 || !signature) return undefined;
+  const expectedSignature = sign(`${headerB64}.${payloadB64}`, secret);
+  if (expectedSignature !== signature) return undefined;
+  const payload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString('utf8')) as JwtPayload;
+  if (payload.exp < Math.floor(Date.now() / 1000)) {
+    return undefined;
+  }
+  return payload;
+};

--- a/codex-meta-intelligence/src/security/encryption.ts
+++ b/codex-meta-intelligence/src/security/encryption.ts
@@ -1,0 +1,33 @@
+import crypto from 'node:crypto';
+
+const ALGORITHM = 'aes-256-gcm';
+
+export const encrypt = (
+  plainText: string,
+  secret: string
+): { iv: string; cipherText: string; authTag: string } => {
+  const iv = crypto.randomBytes(12);
+  const key = crypto.createHash('sha256').update(secret).digest();
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+  const cipherText = Buffer.concat([cipher.update(plainText, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return {
+    iv: iv.toString('hex'),
+    cipherText: cipherText.toString('hex'),
+    authTag: authTag.toString('hex'),
+  };
+};
+
+export const decrypt = (
+  payload: { iv: string; cipherText: string; authTag: string },
+  secret: string
+): string => {
+  const key = crypto.createHash('sha256').update(secret).digest();
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, Buffer.from(payload.iv, 'hex'));
+  decipher.setAuthTag(Buffer.from(payload.authTag, 'hex'));
+  const decrypted = Buffer.concat([
+    decipher.update(Buffer.from(payload.cipherText, 'hex')),
+    decipher.final(),
+  ]);
+  return decrypted.toString('utf8');
+};

--- a/codex-meta-intelligence/src/security/scanner.ts
+++ b/codex-meta-intelligence/src/security/scanner.ts
@@ -1,0 +1,18 @@
+import type { SecurityFinding } from '../shared/types.js';
+
+interface Dependency {
+  name: string;
+  version: string;
+  severity?: 'low' | 'medium' | 'high';
+}
+
+export const scanDependencies = (dependencies: Dependency[]): SecurityFinding[] => {
+  return dependencies
+    .filter((dependency) => dependency.severity)
+    .map((dependency) => ({
+      severity: dependency.severity ?? 'low',
+      category: 'dependency',
+      message: `${dependency.name}@${dependency.version} has ${dependency.severity} severity advisories`,
+      recommendation: 'Update to the latest patched version.',
+    }));
+};

--- a/codex-meta-intelligence/src/shared/config.ts
+++ b/codex-meta-intelligence/src/shared/config.ts
@@ -1,0 +1,18 @@
+interface EnvironmentConfig {
+  cursorApiUrl: string;
+  cursorStrictMode: boolean;
+  knowledgeAutoLoad: boolean;
+}
+
+const resolveBoolean = (value: string | undefined, fallback: boolean): boolean => {
+  if (value === undefined) return fallback;
+  return !['0', 'false', 'off'].includes(value.toLowerCase());
+};
+
+export const loadConfiguration = (): EnvironmentConfig => {
+  return {
+    cursorApiUrl: process.env.CURSOR_API_URL ?? 'https://api.cursor.sh',
+    cursorStrictMode: resolveBoolean(process.env.CURSOR_STRICT_MODE, false),
+    knowledgeAutoLoad: resolveBoolean(process.env.KNOWLEDGE_AUTO_LOAD, true),
+  };
+};

--- a/codex-meta-intelligence/src/shared/constants.ts
+++ b/codex-meta-intelligence/src/shared/constants.ts
@@ -1,0 +1,19 @@
+export const DEFAULT_AGENT_TIMEOUT_MS = 5 * 60 * 1000;
+export const DEFAULT_CONCURRENCY = 2;
+export const PIPELINE_STAGES = [
+  'draft',
+  'audit',
+  'refinement',
+  'elevation',
+  'delivery',
+  'deploy',
+] as const;
+
+export const QA_SEVERITY_ORDER: Record<'info' | 'warning' | 'error', number> = {
+  info: 0,
+  warning: 1,
+  error: 2,
+};
+
+export const DEFAULT_CACHE_CAPACITY = 256;
+export const DEFAULT_CACHE_TTL_MS = 10 * 60 * 1000;

--- a/codex-meta-intelligence/src/shared/types.ts
+++ b/codex-meta-intelligence/src/shared/types.ts
@@ -1,0 +1,229 @@
+import type { JsonObject, JsonValue } from './utils.js';
+
+export enum AgentRole {
+  FRONTEND = 'frontend',
+  BACKEND = 'backend',
+  KNOWLEDGE = 'knowledge',
+  QA = 'qa',
+  REFINEMENT = 'refinement',
+  OPERATOR = 'operator',
+}
+
+export interface AgentConfig {
+  id: string;
+  role: AgentRole;
+  concurrency: number;
+  timeoutMs: number;
+  tools: string[];
+}
+
+export interface AgentGuidelines {
+  environment: string[];
+  testing: string[];
+  coding: string[];
+  logging: string[];
+  pullRequests: string[];
+}
+
+export interface AgentMessage {
+  taskId: string;
+  macroId: string;
+  payload: JsonValue;
+  context: ContextPacket[];
+  guidelines: AgentGuidelines;
+  metadata: {
+    priority: number;
+    createdAt: string;
+    source: string;
+    version: string;
+  };
+}
+
+export interface AgentResult {
+  taskId: string;
+  status: 'success' | 'error';
+  summary: string;
+  artifacts: Record<string, JsonValue>;
+  issues: string[];
+  contextUpdates: ContextPacket[];
+  durationMs: number;
+  error?: string;
+}
+
+export interface MacroStage {
+  id: string;
+  name: string;
+  description: string;
+  agentRole: AgentRole;
+  retryLimit: number;
+  continueOnError: boolean;
+}
+
+export interface MacroDefinition {
+  name: string;
+  description: string;
+  stages: MacroStage[];
+  fallbackMacro?: string;
+  qualityThreshold: number;
+}
+
+export interface MacroContext {
+  taskId: string;
+  operatorId: string;
+  input: JsonValue;
+  metadata: Record<string, JsonValue>;
+  guidelines: AgentGuidelines;
+}
+
+export interface MacroResult {
+  taskId: string;
+  macroName: string;
+  stageResults: AgentResult[];
+  success: boolean;
+  startedAt: string;
+  finishedAt: string;
+}
+
+export interface MetaTask {
+  id: string;
+  macroName: string;
+  input: JsonValue;
+  priority: number;
+  owner: string;
+  requestedAt: string;
+}
+
+export interface MetaStateSnapshot {
+  queued: MetaTask[];
+  running: MetaTask[];
+  completed: MacroResult[];
+  metrics: Record<string, number>;
+}
+
+export interface KnowledgeBlock {
+  id: string;
+  content: string;
+  metadata: {
+    author: string;
+    timestamp: string;
+    tags: string[];
+    citations: string[];
+    source: string;
+    reliabilityScore: number;
+  };
+  links?: string[];
+}
+
+export interface KnowledgeQuery {
+  keywords: string[];
+  tags?: string[];
+  limit?: number;
+}
+
+export interface KnowledgeResponse {
+  blocks: Array<{ block: KnowledgeBlock; score: number }>;
+}
+
+export interface MemoryRecord {
+  id: string;
+  agentId: string;
+  timestamp: string;
+  dataType: string;
+  payload: JsonValue;
+  tags: string[];
+  sensitivity?: 'public' | 'confidential' | 'restricted';
+}
+
+export interface LogEntry {
+  taskId: string;
+  actor: string;
+  action: string;
+  result: string;
+  timestamp: string;
+}
+
+export interface CacheEntry<T> {
+  key: string;
+  value: T;
+  expiresAt: number;
+}
+
+export interface QAIssue {
+  engine: 'aesthetic' | 'technical' | 'narrative';
+  severity: 'info' | 'warning' | 'error';
+  message: string;
+  affectedFiles?: string[];
+}
+
+export interface QAResult {
+  success: boolean;
+  issues: QAIssue[];
+}
+
+export interface ForecastResult {
+  taskId: string;
+  predictedDurationMs: number;
+  confidence: number;
+  notes: string[];
+}
+
+export interface RiskAssessment {
+  taskId: string;
+  riskScore: number;
+  level: 'low' | 'medium' | 'high';
+  factors: string[];
+}
+
+export interface ContextPacket {
+  id: string;
+  source: string;
+  content: string;
+  summary: string;
+  embedding: number[];
+  metadata: Record<string, JsonValue>;
+  createdAt: string;
+}
+
+export interface ContextRequest {
+  taskId: string;
+  role: AgentRole;
+  keywords: string[];
+  limit: number;
+  embedding?: number[];
+}
+
+export interface ContextResponse {
+  packets: ContextPacket[];
+  rationale: string[];
+}
+
+export interface GovernancePolicy {
+  id: string;
+  description: string;
+  appliesTo: AgentRole[];
+  validator: (packet: ContextPacket) => boolean;
+}
+
+export interface SecurityFinding {
+  severity: 'low' | 'medium' | 'high';
+  category: string;
+  message: string;
+  recommendation: string;
+}
+
+export interface MetricRecord {
+  name: string;
+  labels: Record<string, string>;
+  value: number;
+  timestamp: number;
+}
+
+export interface TraceSpan {
+  id: string;
+  name: string;
+  startTime: number;
+  endTime?: number;
+  attributes: Record<string, JsonValue>;
+}
+
+export type JsonSchema = JsonObject;

--- a/codex-meta-intelligence/src/shared/utils.ts
+++ b/codex-meta-intelligence/src/shared/utils.ts
@@ -1,0 +1,109 @@
+import crypto from 'node:crypto';
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonObject | JsonArray;
+export interface JsonObject {
+  [key: string]: JsonValue;
+}
+export interface JsonArray extends Array<JsonValue> {}
+
+export const nowIso = (): string => new Date().toISOString();
+
+export const generateId = (prefix = 'id'): string => `${prefix}_${crypto.randomUUID()}`;
+
+export const deepFreeze = <T>(value: T): T => {
+  if (typeof value !== 'object' || value === null) {
+    return value;
+  }
+  Object.freeze(value);
+  for (const key of Object.getOwnPropertyNames(value)) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const property = (value as any)[key];
+    if (property && typeof property === 'object' && !Object.isFrozen(property)) {
+      deepFreeze(property);
+    }
+  }
+  return value;
+};
+
+export const cosineSimilarity = (a: number[], b: number[]): number => {
+  if (a.length !== b.length || a.length === 0) {
+    return 0;
+  }
+  let dot = 0;
+  let magA = 0;
+  let magB = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    const ai = a[i]!;
+    const bi = b[i]!;
+    dot += ai * bi;
+    magA += ai ** 2;
+    magB += bi ** 2;
+  }
+  if (magA === 0 || magB === 0) {
+    return 0;
+  }
+  return dot / (Math.sqrt(magA) * Math.sqrt(magB));
+};
+
+export const clamp = (value: number, min: number, max: number): number => {
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+};
+
+export const normaliseWeights = (weights: number[]): number[] => {
+  const total = weights.reduce((acc, value) => acc + value, 0);
+  if (total === 0) {
+    return weights.map(() => 0);
+  }
+  return weights.map((value) => value / total);
+};
+
+export class LruCache<K, V> {
+  private readonly capacity: number;
+
+  private readonly map = new Map<K, { value: V; expiresAt?: number }>();
+
+  constructor(capacity: number) {
+    if (capacity <= 0) {
+      throw new Error('LRU cache capacity must be positive');
+    }
+    this.capacity = capacity;
+  }
+
+  get(key: K): V | undefined {
+    const entry = this.map.get(key);
+    if (!entry) {
+      return undefined;
+    }
+    if (entry.expiresAt && entry.expiresAt < Date.now()) {
+      this.map.delete(key);
+      return undefined;
+    }
+    this.map.delete(key);
+    this.map.set(key, entry);
+    return entry.value;
+  }
+
+  set(key: K, value: V, ttlMs?: number): void {
+    if (this.map.has(key)) {
+      this.map.delete(key);
+    }
+    if (this.map.size >= this.capacity) {
+      const { value: oldestKey, done } = this.map.keys().next();
+      if (!done && oldestKey !== undefined) {
+        this.map.delete(oldestKey);
+      }
+    }
+    this.map.set(key, { value, expiresAt: ttlMs ? Date.now() + ttlMs : undefined });
+  }
+
+  has(key: K): boolean {
+    return this.get(key) !== undefined;
+  }
+
+  clear(): void {
+    this.map.clear();
+  }
+}

--- a/codex-meta-intelligence/stage.json
+++ b/codex-meta-intelligence/stage.json
@@ -1,0 +1,4 @@
+{
+  "stage": 1,
+  "completed": {}
+}

--- a/codex-meta-intelligence/tests/core.spec.ts
+++ b/codex-meta-intelligence/tests/core.spec.ts
@@ -1,0 +1,116 @@
+import { ContextFabric } from '../src/context/fabric';
+import { MacroOrchestrator } from '../src/macro/index';
+import { KnowledgeService } from '../src/knowledge/index';
+import { QAEngine } from '../src/qa/index';
+import { ForesightEngine } from '../src/foresight/index';
+import { MetaAgent } from '../src/metaagent/index';
+import type { MacroContext } from '../src/shared/types';
+import type { JsonValue } from '../src/shared/utils';
+
+const createSamplePacket = () => {
+  const fabric = new ContextFabric();
+  return fabric.ingest('test', 'Sample context packet for QA checks.', { sensitivity: 'public' });
+};
+
+const toJsonValue = (value: unknown): JsonValue => JSON.parse(JSON.stringify(value)) as JsonValue;
+
+describe('Codex Meta-Intelligence Stage 1', () => {
+  it('stores and queries knowledge blocks', () => {
+    const service = new KnowledgeService();
+    const block = service.storeBlock({
+      id: 'kb-1',
+      content: 'The system executes macros and agents cooperatively.',
+      metadata: {
+        author: 'system',
+        timestamp: new Date().toISOString(),
+        tags: ['architecture'],
+        citations: [],
+        source: 'test',
+        reliabilityScore: 0.9,
+      },
+    });
+    const response = service.queryKnowledge({ keywords: ['macros'], limit: 5 });
+    expect(response.blocks[0]?.block.id).toBe(block.id);
+  });
+
+  it('runs macros through the execution pipeline', async () => {
+    const orchestrator = new MacroOrchestrator();
+    const packet = createSamplePacket();
+    const context: MacroContext = {
+      taskId: 'task-1',
+      operatorId: 'operator',
+      input: {},
+      metadata: { contextPackets: toJsonValue([packet]) },
+      guidelines: {
+        environment: ['pnpm install'],
+        testing: ['pnpm test'],
+        coding: [],
+        logging: [],
+        pullRequests: [],
+      },
+    };
+    const result = await orchestrator.runMacro('full-pipeline', context);
+    expect(result.success).toBe(true);
+    expect(result.stageResults).toHaveLength(4);
+  });
+
+  it('executes QA checks with combined engines', () => {
+    const engine = new QAEngine();
+    const issues = engine.runQA({
+      aesthetic: {
+        palette: [
+          { name: 'Primary', contrastRatio: 4.6 },
+          { name: 'Secondary', contrastRatio: 4.8 },
+        ],
+        typographyScale: [1, 1.25, 1.6],
+        motionDensity: 0.3,
+      },
+      technical: { lintErrors: 0, testFailures: 0, coverage: 0.9 },
+      narrative: { tone: 'empathetic', coherenceScore: 0.9, fairnessScore: 0.95 },
+    });
+    expect(issues.success).toBe(true);
+  });
+
+  it('provides foresight predictions and risk assessments', () => {
+    const engine = new ForesightEngine();
+    const forecast = engine.predict({
+      taskId: 'task-2',
+      durations: [100, 120, 110],
+      qaIssues: [0, 1, 0],
+    });
+    expect(forecast.confidence).toBeGreaterThan(0.4);
+    const risk = engine.assessRisk('task-2', 1, 2, 2);
+    expect(risk.level).toBe('low');
+  });
+
+  it('processes tasks via the meta-agent', async () => {
+    const metaAgent = new MetaAgent();
+    const packet = createSamplePacket();
+    const context: MacroContext = {
+      taskId: 'meta-task',
+      operatorId: 'operator',
+      input: {},
+      metadata: { contextPackets: toJsonValue([packet]) },
+      guidelines: {
+        environment: [],
+        testing: [],
+        coding: [],
+        logging: [],
+        pullRequests: [],
+      },
+    };
+    const taskId = metaAgent.enqueueTask(
+      {
+        macroName: 'full-pipeline',
+        input: {},
+        priority: 5,
+        owner: 'operator',
+      },
+      context
+    );
+    expect(taskId).toBeTruthy();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const state = metaAgent.getState();
+    expect(state.completed.some((result) => result.taskId === context.taskId)).toBe(true);
+  });
+});

--- a/codex-meta-intelligence/tsconfig.json
+++ b/codex-meta-intelligence/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "rootDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": false,
+    "noUncheckedIndexedAccess": true,
+    "resolveJsonModule": true,
+    "types": ["node", "jest"]
+  },
+  "include": ["src", "tests"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,64 @@ importers:
         specifier: '5'
         version: 5.9.2
 
+  codex-meta-intelligence:
+    dependencies:
+      ajv:
+        specifier: ^8.12.0
+        version: 8.17.1
+      eventemitter3:
+        specifier: ^5.0.1
+        version: 5.0.1
+      lodash.merge:
+        specifier: ^4.6.2
+        version: 4.6.2
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.12
+        version: 29.5.14
+      '@types/lodash.merge':
+        specifier: ^4.6.9
+        version: 4.6.9
+      '@types/node':
+        specifier: ^20.11.30
+        version: 20.19.17
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^6.21.0
+        version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)
+      '@typescript-eslint/parser':
+        specifier: ^6.21.0
+        version: 6.21.0(eslint@8.57.1)(typescript@5.9.2)
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.1
+      eslint-config-prettier:
+        specifier: ^9.1.0
+        version: 9.1.2(eslint@8.57.1)
+      eslint-plugin-import:
+        specifier: ^2.29.1
+        version: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1)
+      husky:
+        specifier: ^9.0.11
+        version: 9.1.7
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.19.17)(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2))
+      lint-staged:
+        specifier: ^15.2.2
+        version: 15.5.2
+      prettier:
+        specifier: ^3.2.5
+        version: 3.6.2
+      ts-jest:
+        specifier: ^29.1.2
+        version: 29.4.4(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.17)(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2)))(typescript@5.9.2)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@20.19.17)(typescript@5.9.2)
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.2
+
   rentalos-ai: {}
 
   src/cursor: {}
@@ -335,6 +393,27 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-syntax-async-generators@7.8.4':
+    resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-bigint@7.8.3':
+    resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-class-properties@7.12.13':
+    resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-class-static-block@7.14.5':
+    resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-syntax-import-assertions@7.27.1':
     resolution: {integrity: sha512-UT/Jrhw57xg4ILHLFnzFpPDlMbcdEicaAtjPQpbj9wa8T4r5KVWCimHcL/460g8Ht0DMxDyjsLgiWSkVjnwPFg==}
     engines: {node: '>=6.9.0'}
@@ -347,8 +426,60 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-syntax-import-meta@7.10.4':
+    resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-json-strings@7.8.3':
+    resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-syntax-jsx@7.27.1':
     resolution: {integrity: sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4':
+    resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3':
+    resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-numeric-separator@7.10.4':
+    resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-object-rest-spread@7.8.3':
+    resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3':
+    resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-optional-chaining@7.8.3':
+    resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-private-property-in-object@7.14.5':
+    resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-top-level-await@7.14.5':
+    resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -741,6 +872,9 @@ packages:
   '@babel/types@7.28.4':
     resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@0.2.3':
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
@@ -1279,9 +1413,79 @@ packages:
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
 
+  '@istanbuljs/load-nyc-config@1.1.0':
+    resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
+    engines: {node: '>=8'}
+
   '@istanbuljs/schema@0.1.3':
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
+
+  '@jest/console@29.7.0':
+    resolution: {integrity: sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/core@29.7.0':
+    resolution: {integrity: sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
+  '@jest/environment@29.7.0':
+    resolution: {integrity: sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/expect-utils@29.7.0':
+    resolution: {integrity: sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/expect@29.7.0':
+    resolution: {integrity: sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/fake-timers@29.7.0':
+    resolution: {integrity: sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/globals@29.7.0':
+    resolution: {integrity: sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/reporters@29.7.0':
+    resolution: {integrity: sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/source-map@29.6.3':
+    resolution: {integrity: sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/test-result@29.7.0':
+    resolution: {integrity: sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/test-sequencer@29.7.0':
+    resolution: {integrity: sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/transform@29.7.0':
+    resolution: {integrity: sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/types@29.6.3':
+    resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1483,6 +1687,9 @@ packages:
     peerDependencies:
       semantic-release: '>=20.1.0'
 
+  '@sinclair/typebox@0.27.8':
+    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
@@ -1490,6 +1697,12 @@ packages:
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
+
+  '@sinonjs/commons@3.0.1':
+    resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
+
+  '@sinonjs/fake-timers@10.3.0':
+    resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0':
     resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
@@ -1679,6 +1892,18 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/conventional-commits-parser@5.0.1':
     resolution: {integrity: sha512-7uz5EHdzz2TqoMfV7ee61Egf5y6NkcO4FB/1iCCQnbeiI1F3xzv3vK5dBCXUCLQgGYS+mUeigK1iKQzvED+QnQ==}
 
@@ -1691,8 +1916,20 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/graceful-fs@4.1.9':
+    resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
+
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
+
+  '@types/istanbul-lib-report@3.0.3':
+    resolution: {integrity: sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==}
+
+  '@types/istanbul-reports@3.0.4':
+    resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
+
+  '@types/jest@29.5.14':
+    resolution: {integrity: sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -1702,6 +1939,12 @@ packages:
 
   '@types/katex@0.16.7':
     resolution: {integrity: sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ==}
+
+  '@types/lodash.merge@4.6.9':
+    resolution: {integrity: sha512-23sHDPmzd59kUgWyKGiOMO2Qb9YtqRO/x4IhkgNUiPQ1+5MUVqi6bCZeq9nBJ17msjIMbEIO5u+XW4Kz6aGUhQ==}
+
+  '@types/lodash@4.17.20':
+    resolution: {integrity: sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -1726,8 +1969,31 @@ packages:
   '@types/react@19.1.13':
     resolution: {integrity: sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==}
 
+  '@types/semver@7.7.1':
+    resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
+
+  '@types/stack-utils@2.0.3':
+    resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/yargs-parser@21.0.3':
+    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
+
+  '@types/yargs@17.0.33':
+    resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
+
+  '@typescript-eslint/eslint-plugin@6.21.0':
+    resolution: {integrity: sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^6.0.0 || ^6.0.0-alpha
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@typescript-eslint/eslint-plugin@8.44.1':
     resolution: {integrity: sha512-molgphGqOBT7t4YKCSkbasmu1tb1MgrZ2szGzHbclF7PNmOkSTQVHy+2jXOSnxvR3+Xe1yySHFZoqMpz3TfQsw==}
@@ -1736,6 +2002,16 @@ packages:
       '@typescript-eslint/parser': ^8.44.1
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/parser@6.21.0':
+    resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@typescript-eslint/parser@8.44.1':
     resolution: {integrity: sha512-EHrrEsyhOhxYt8MTg4zTF+DJMuNBzWwgvvOYNj/zm1vnaD/IC5zCXFehZv94Piqa2cRFfXrTFxIvO95L7Qc/cw==}
@@ -1750,6 +2026,10 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/scope-manager@6.21.0':
+    resolution: {integrity: sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+
   '@typescript-eslint/scope-manager@8.44.1':
     resolution: {integrity: sha512-NdhWHgmynpSvyhchGLXh+w12OMT308Gm25JoRIyTZqEbApiBiQHD/8xgb6LqCWCFcxFtWwaVdFsLPQI3jvhywg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1760,6 +2040,16 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/type-utils@6.21.0':
+    resolution: {integrity: sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@typescript-eslint/type-utils@8.44.1':
     resolution: {integrity: sha512-KdEerZqHWXsRNKjF9NYswNISnFzXfXNDfPxoTh7tqohU/PRIbwTmsjGK6V9/RTYWau7NZvfo52lgVk+sJh0K3g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1767,9 +2057,22 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/types@6.21.0':
+    resolution: {integrity: sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+
   '@typescript-eslint/types@8.44.1':
     resolution: {integrity: sha512-Lk7uj7y9uQUOEguiDIDLYLJOrYHQa7oBiURYVFqIpGxclAFQ78f6VUOM8lI2XEuNOKNB7XuvM2+2cMXAoq4ALQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@6.21.0':
+    resolution: {integrity: sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@typescript-eslint/typescript-estree@8.44.1':
     resolution: {integrity: sha512-qnQJ+mVa7szevdEyvfItbO5Vo+GfZ4/GZWWDRRLjrxYPkhM+6zYB2vRYwCsoJLzqFCdZT4mEqyJoyzkunsZ96A==}
@@ -1777,12 +2080,22 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/utils@6.21.0':
+    resolution: {integrity: sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+
   '@typescript-eslint/utils@8.44.1':
     resolution: {integrity: sha512-DpX5Fp6edTlocMCwA+mHY8Mra+pPjRZ0TfHkXI8QFelIKcbADQz1LUPNtzOFUriBB2UYqw4Pi9+xV4w9ZczHFg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/visitor-keys@6.21.0':
+    resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
+    engines: {node: ^16.0.0 || >=18.0.0}
 
   '@typescript-eslint/visitor-keys@8.44.1':
     resolution: {integrity: sha512-576+u0QD+Jp3tZzvfRfxon0EA2lzcDt3lhUbsC6Lgzy9x2VR4E+JUiNyGHi5T8vk0TV+fpJ5GLG1JsJuWCaKhw==}
@@ -1956,6 +2269,10 @@ packages:
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
+  ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
+
   ansi-escapes@7.1.1:
     resolution: {integrity: sha512-Zhl0ErHcSRUaVfGUeUdDuLgpkEo8KIFjB4Y9uAc46ScOpdDiU1Dbyplh7qWJeJ/ZHpbyMSM26+X3BySgnIz40Q==}
     engines: {node: '>=18'}
@@ -1976,6 +2293,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -1983,12 +2304,19 @@ packages:
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
   are-docs-informative@0.0.2:
     resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
     engines: {node: '>=14'}
 
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -2042,6 +2370,20 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
+  babel-jest@29.7.0:
+    resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@babel/core': ^7.8.0
+
+  babel-plugin-istanbul@6.1.1:
+    resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
+    engines: {node: '>=8'}
+
+  babel-plugin-jest-hoist@29.6.3:
+    resolution: {integrity: sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   babel-plugin-polyfill-corejs2@0.4.14:
     resolution: {integrity: sha512-Co2Y9wX854ts6U8gAAPXfn0GmAyctHuK8n0Yhfjd6t30g7yvKjspvvOo9yG+z52PZRgFErt7Ka2pYnXCjLKEpg==}
     peerDependencies:
@@ -2056,6 +2398,17 @@ packages:
     resolution: {integrity: sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+
+  babel-preset-current-node-syntax@1.2.0:
+    resolution: {integrity: sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0 || ^8.0.0-0
+
+  babel-preset-jest@29.6.3:
+    resolution: {integrity: sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@babel/core': ^7.0.0
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -2094,6 +2447,16 @@ packages:
     resolution: {integrity: sha512-ECFzp6uFOSB+dcZ5BK/IBaGWssbSYBHvuMeMt3MMFyhI0Z8SqGgEkBLARgpRH3hutIgPVsALcMwbDrJqPxQ65A==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  bs-logger@0.2.6:
+    resolution: {integrity: sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==}
+    engines: {node: '>= 6'}
+
+  bser@2.1.1:
+    resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
   builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
@@ -2134,6 +2497,10 @@ packages:
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
 
   camelcase@6.3.0:
@@ -2179,9 +2546,16 @@ packages:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
 
+  ci-info@3.9.0:
+    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
+    engines: {node: '>=8'}
+
   ci-info@4.3.0:
     resolution: {integrity: sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==}
     engines: {node: '>=8'}
+
+  cjs-module-lexer@1.4.3:
+    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
   clean-regexp@1.0.0:
     resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
@@ -2208,6 +2582,10 @@ packages:
     resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
     engines: {node: 10.* || >= 12.*}
 
+  cli-truncate@4.0.0:
+    resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
+    engines: {node: '>=18'}
+
   cli-truncate@5.1.0:
     resolution: {integrity: sha512-7JDGG+4Zp0CsknDCedl0DYdaeOhc46QNpXi3NLQblkZpXXgA6LncLDUUyvrjSvZeF3VRQa+KiMGomazQrC1V8g==}
     engines: {node: '>=20'}
@@ -2225,6 +2603,13 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  co@4.6.0:
+    resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
+    engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
+
+  collect-v8-coverage@1.0.2:
+    resolution: {integrity: sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==}
 
   color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
@@ -2367,6 +2752,11 @@ packages:
       typescript:
         optional: true
 
+  create-jest@29.7.0:
+    resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
@@ -2491,6 +2881,14 @@ packages:
   decode-named-character-reference@1.2.0:
     resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
 
+  dedent@1.7.0:
+    resolution: {integrity: sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==}
+    peerDependencies:
+      babel-plugin-macros: ^3.1.0
+    peerDependenciesMeta:
+      babel-plugin-macros:
+        optional: true
+
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -2526,12 +2924,20 @@ packages:
     resolution: {integrity: sha512-ecqj/sy1jcK1uWrwpR67UhYrIFQ+5WlGxth34WquCbamhFA6hkkwiu37o6J5xCHdo1oixJRfVRw+ywV+Hq/0Aw==}
     engines: {node: '>=8'}
 
+  detect-newline@3.1.0:
+    resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
+    engines: {node: '>=8'}
+
   detect-newline@4.0.1:
     resolution: {integrity: sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
@@ -2605,6 +3011,10 @@ packages:
 
   electron-to-chromium@1.5.223:
     resolution: {integrity: sha512-qKm55ic6nbEmagFlTFczML33rF90aU+WtrJ9MdTCThrcvDNdUHN4p6QfVN78U06ZmguqXIyMPyYhw2TrbDUwPQ==}
+
+  emittery@0.13.1:
+    resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
+    engines: {node: '>=12'}
 
   emoji-regex@10.5.0:
     resolution: {integrity: sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==}
@@ -2694,6 +3104,10 @@ packages:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
 
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
+
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
@@ -2710,6 +3124,12 @@ packages:
 
   eslint-config-prettier@10.1.8:
     resolution: {integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
+
+  eslint-config-prettier@9.1.2:
+    resolution: {integrity: sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
@@ -2903,6 +3323,10 @@ packages:
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
@@ -2914,6 +3338,10 @@ packages:
   exit@0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
+
+  expect@29.7.0:
+    resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   express@5.1.0:
     resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
@@ -2951,6 +3379,9 @@ packages:
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
+
+  fb-watchman@2.0.2:
+    resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2991,6 +3422,10 @@ packages:
   find-up@2.1.0:
     resolution: {integrity: sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==}
     engines: {node: '>=4'}
+
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
 
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -3040,6 +3475,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
@@ -3076,6 +3516,10 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-package-type@0.1.0:
+    resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
+    engines: {node: '>=8.0.0'}
 
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
@@ -3264,6 +3708,10 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
+
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
@@ -3300,6 +3748,11 @@ packages:
   import-from-esm@2.0.0:
     resolution: {integrity: sha512-YVt14UZCgsX1vZQ3gKjkWVdBdHQ6eu3MPU1TBgL1H5orXe2+jWD006WCPPtOuwlQm10NuzOW5WawiF1Q9veW8g==}
     engines: {node: '>=18.20'}
+
+  import-local@3.2.0:
+    resolution: {integrity: sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
@@ -3409,9 +3862,17 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-fullwidth-code-point@4.0.0:
+    resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
+    engines: {node: '>=12'}
+
   is-fullwidth-code-point@5.1.0:
     resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
     engines: {node: '>=18'}
+
+  is-generator-fn@2.1.0:
+    resolution: {integrity: sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==}
+    engines: {node: '>=6'}
 
   is-generator-function@1.1.0:
     resolution: {integrity: sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==}
@@ -3470,6 +3931,10 @@ packages:
   is-shared-array-buffer@1.0.4:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
 
   is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
@@ -3531,8 +3996,20 @@ packages:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
 
+  istanbul-lib-instrument@5.2.1:
+    resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-instrument@6.0.3:
+    resolution: {integrity: sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==}
+    engines: {node: '>=10'}
+
   istanbul-lib-report@3.0.1:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@4.0.1:
+    resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
 
   istanbul-reports@3.2.0:
@@ -3550,12 +4027,145 @@ packages:
     resolution: {integrity: sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==}
     engines: {node: '>= 0.6.0'}
 
+  jest-changed-files@29.7.0:
+    resolution: {integrity: sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-circus@29.7.0:
+    resolution: {integrity: sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-cli@29.7.0:
+    resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
+  jest-config@29.7.0:
+    resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@types/node': '*'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      ts-node:
+        optional: true
+
+  jest-diff@29.7.0:
+    resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-docblock@29.7.0:
+    resolution: {integrity: sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-each@29.7.0:
+    resolution: {integrity: sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-environment-node@29.7.0:
+    resolution: {integrity: sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-get-type@29.6.3:
+    resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-haste-map@29.7.0:
+    resolution: {integrity: sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-leak-detector@29.7.0:
+    resolution: {integrity: sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-matcher-utils@29.7.0:
+    resolution: {integrity: sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-message-util@29.7.0:
+    resolution: {integrity: sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-mock@29.7.0:
+    resolution: {integrity: sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-pnp-resolver@1.2.3:
+    resolution: {integrity: sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==}
+    engines: {node: '>=6'}
+    peerDependencies:
+      jest-resolve: '*'
+    peerDependenciesMeta:
+      jest-resolve:
+        optional: true
+
+  jest-regex-util@29.6.3:
+    resolution: {integrity: sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-resolve-dependencies@29.7.0:
+    resolution: {integrity: sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-resolve@29.7.0:
+    resolution: {integrity: sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-runner@29.7.0:
+    resolution: {integrity: sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-runtime@29.7.0:
+    resolution: {integrity: sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-snapshot@29.7.0:
+    resolution: {integrity: sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-util@29.7.0:
+    resolution: {integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-validate@29.7.0:
+    resolution: {integrity: sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-watcher@29.7.0:
+    resolution: {integrity: sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-worker@29.7.0:
+    resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest@29.7.0:
+    resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
   jiti@2.6.0:
     resolution: {integrity: sha512-VXe6RjJkBPj0ohtqaO8vSWP3ZhAKo66fKrFNCll4BTcwljPLz03pCbaNKfzGP5MbrCYcbJ7v0nOYYwUzTEIdXQ==}
     hasBin: true
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@3.14.1:
+    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
+    hasBin: true
 
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -3642,8 +4252,16 @@ packages:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
 
+  kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
+
   known-css-properties@0.37.0:
     resolution: {integrity: sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==}
+
+  leven@3.1.0:
+    resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
+    engines: {node: '>=6'}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -3713,16 +4331,29 @@ packages:
     resolution: {integrity: sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==}
     engines: {node: '>= 12.0.0'}
 
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
 
+  lint-staged@15.5.2:
+    resolution: {integrity: sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w==}
+    engines: {node: '>=18.12.0'}
+    hasBin: true
+
   lint-staged@16.2.0:
     resolution: {integrity: sha512-spdYSOCQ2MdZ9CM1/bu/kDmaYGsrpNOeu1InFFV8uhv14x6YIubGxbCpSmGILFoxkiheNQPDXSg5Sbb5ZuVnug==}
     engines: {node: '>=20.17'}
     hasBin: true
+
+  listr2@8.3.3:
+    resolution: {integrity: sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==}
+    engines: {node: '>=18.0.0'}
 
   listr2@9.0.4:
     resolution: {integrity: sha512-1wd/kpAdKRLwv7/3OKC8zZ5U8e/fajCfWMxacUvB79S5nLrYGPtUI/8chMQhn3LQjsRVErTb9i1ECAwW0ZIHnQ==}
@@ -3735,6 +4366,10 @@ packages:
   locate-path@2.0.0:
     resolution: {integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==}
     engines: {node: '>=4'}
+
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -3767,6 +4402,9 @@ packages:
 
   lodash.kebabcase@4.1.1:
     resolution: {integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==}
+
+  lodash.memoize@4.1.2:
+    resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -3821,6 +4459,9 @@ packages:
 
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
+  makeerror@1.0.12:
+    resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
   markdown-it@14.1.0:
     resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
@@ -3980,6 +4621,10 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
   mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
@@ -3997,6 +4642,10 @@ packages:
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+
+  minimatch@9.0.3:
+    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
@@ -4074,6 +4723,9 @@ packages:
     resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
     engines: {node: '>=18'}
 
+  node-int64@0.4.0:
+    resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
+
   node-releases@2.0.21:
     resolution: {integrity: sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==}
 
@@ -4088,6 +4740,10 @@ packages:
   normalize-url@8.1.0:
     resolution: {integrity: sha512-X06Mfd/5aKsRHc0O0J5CUedwnPmnDtLF2+nq+KN9KSDlJHkPuh0JUviWjEWMe0SW/9TDdSLVPuk7L5gGTIA1/w==}
     engines: {node: '>=14.16'}
+
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
 
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
@@ -4212,6 +4868,10 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
@@ -4256,6 +4916,10 @@ packages:
     resolution: {integrity: sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==}
     engines: {node: '>=4'}
 
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -4267,6 +4931,10 @@ packages:
   p-locate@2.0.0:
     resolution: {integrity: sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==}
     engines: {node: '>=4'}
+
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
 
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
@@ -4287,6 +4955,10 @@ packages:
   p-try@1.0.0:
     resolution: {integrity: sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==}
     engines: {node: '>=4'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -4402,9 +5074,17 @@ packages:
     resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
     engines: {node: '>=4'}
 
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
   pkg-conf@2.1.0:
     resolution: {integrity: sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==}
     engines: {node: '>=4'}
+
+  pkg-dir@4.2.0:
+    resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
+    engines: {node: '>=8'}
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -4451,12 +5131,20 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
 
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
 
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
@@ -4472,6 +5160,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   qs@6.14.0:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
@@ -4496,6 +5187,9 @@ packages:
     resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
     peerDependencies:
       react: ^19.1.0
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
@@ -4573,6 +5267,10 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  resolve-cwd@3.0.0:
+    resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
+    engines: {node: '>=8'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -4583,6 +5281,10 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  resolve.exports@2.0.3:
+    resolution: {integrity: sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==}
+    engines: {node: '>=10'}
 
   resolve@1.22.10:
     resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
@@ -4725,6 +5427,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -4732,6 +5437,9 @@ packages:
   signale@1.4.0:
     resolution: {integrity: sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==}
     engines: {node: '>=6'}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
   skin-tone@2.0.0:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
@@ -4744,6 +5452,10 @@ packages:
   slice-ansi@4.0.0:
     resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
     engines: {node: '>=10'}
+
+  slice-ansi@5.0.0:
+    resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
+    engines: {node: '>=12'}
 
   slice-ansi@7.1.2:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
@@ -4771,6 +5483,9 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  source-map-support@0.5.13:
+    resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
 
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
@@ -4801,9 +5516,16 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
   stable-hash-x@0.2.0:
     resolution: {integrity: sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==}
     engines: {node: '>=12.0.0'}
+
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
 
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
@@ -4823,6 +5545,10 @@ packages:
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
+
+  string-length@4.0.2:
+    resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
+    engines: {node: '>=10'}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -4869,6 +5595,14 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  strip-bom@4.0.0:
+    resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
+    engines: {node: '>=8'}
+
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
 
   strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
@@ -4944,6 +5678,10 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
   supports-hyperlinks@3.2.0:
     resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==}
     engines: {node: '>=14.18'}
@@ -4990,6 +5728,10 @@ packages:
     resolution: {integrity: sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==}
     engines: {node: '>=14.16'}
 
+  test-exclude@6.0.0:
+    resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
+    engines: {node: '>=8'}
+
   test-exclude@7.0.1:
     resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
     engines: {node: '>=18'}
@@ -5025,6 +5767,9 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tmpl@1.0.5:
+    resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -5037,11 +5782,44 @@ packages:
     resolution: {integrity: sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA==}
     engines: {node: '>= 0.4'}
 
+  ts-api-utils@1.4.3:
+    resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      typescript: '>=4.2.0'
+
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-jest@29.4.4:
+    resolution: {integrity: sha512-ccVcRABct5ZELCT5U0+DZwkXMCcOCLi2doHRrKy1nK/s7J7bch6TzJMsrY09WxgUUIP/ITfmcDS8D2yl63rnXw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/transform': ^29.0.0 || ^30.0.0
+      '@jest/types': ^29.0.0 || ^30.0.0
+      babel-jest: ^29.0.0 || ^30.0.0
+      esbuild: '*'
+      jest: ^29.0.0 || ^30.0.0
+      jest-util: ^29.0.0 || ^30.0.0
+      typescript: '>=4.3 <6'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@jest/transform':
+        optional: true
+      '@jest/types':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+      jest-util:
+        optional: true
 
   ts-node@10.9.2:
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
@@ -5067,8 +5845,16 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-detect@4.0.8:
+    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
+    engines: {node: '>=4'}
+
   type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
+    engines: {node: '>=10'}
+
+  type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
 
   type-fest@1.4.0:
@@ -5224,6 +6010,9 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  walker@1.0.8:
+    resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -5270,6 +6059,10 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  write-file-atomic@4.0.2:
+    resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
   write-file-atomic@5.0.1:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
@@ -5541,6 +6334,26 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.4
 
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-syntax-import-assertions@7.27.1(@babel/core@7.28.4)':
     dependencies:
       '@babel/core': 7.28.4
@@ -5551,7 +6364,57 @@ snapshots:
       '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.4)':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
@@ -6073,6 +6936,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
+
+  '@bcoe/v8-coverage@0.2.3': {}
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -6627,7 +7492,177 @@ snapshots:
     dependencies:
       minipass: 7.1.2
 
+  '@istanbuljs/load-nyc-config@1.1.0':
+    dependencies:
+      camelcase: 5.3.1
+      find-up: 4.1.0
+      get-package-type: 0.1.0
+      js-yaml: 3.14.1
+      resolve-from: 5.0.0
+
   '@istanbuljs/schema@0.1.3': {}
+
+  '@jest/console@29.7.0':
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.17
+      chalk: 4.1.2
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      slash: 3.0.0
+
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2))':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.17
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@20.19.17)(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2))
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  '@jest/environment@29.7.0':
+    dependencies:
+      '@jest/fake-timers': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.17
+      jest-mock: 29.7.0
+
+  '@jest/expect-utils@29.7.0':
+    dependencies:
+      jest-get-type: 29.6.3
+
+  '@jest/expect@29.7.0':
+    dependencies:
+      expect: 29.7.0
+      jest-snapshot: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jest/fake-timers@29.7.0':
+    dependencies:
+      '@jest/types': 29.6.3
+      '@sinonjs/fake-timers': 10.3.0
+      '@types/node': 20.19.17
+      jest-message-util: 29.7.0
+      jest-mock: 29.7.0
+      jest-util: 29.7.0
+
+  '@jest/globals@29.7.0':
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/expect': 29.7.0
+      '@jest/types': 29.6.3
+      jest-mock: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jest/reporters@29.7.0':
+    dependencies:
+      '@bcoe/v8-coverage': 0.2.3
+      '@jest/console': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/node': 20.19.17
+      chalk: 4.1.2
+      collect-v8-coverage: 1.0.2
+      exit: 0.1.2
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-instrument: 6.0.3
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 4.0.1
+      istanbul-reports: 3.2.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      jest-worker: 29.7.0
+      slash: 3.0.0
+      string-length: 4.0.2
+      strip-ansi: 6.0.1
+      v8-to-istanbul: 9.3.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.8
+
+  '@jest/source-map@29.6.3':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      callsites: 3.1.0
+      graceful-fs: 4.2.11
+
+  '@jest/test-result@29.7.0':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/istanbul-lib-coverage': 2.0.6
+      collect-v8-coverage: 1.0.2
+
+  '@jest/test-sequencer@29.7.0':
+    dependencies:
+      '@jest/test-result': 29.7.0
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      slash: 3.0.0
+
+  '@jest/transform@29.7.0':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@jest/types': 29.6.3
+      '@jridgewell/trace-mapping': 0.3.31
+      babel-plugin-istanbul: 6.1.1
+      chalk: 4.1.2
+      convert-source-map: 2.0.0
+      fast-json-stable-stringify: 2.1.0
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-util: 29.7.0
+      micromatch: 4.0.8
+      pirates: 4.0.7
+      slash: 3.0.0
+      write-file-atomic: 4.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jest/types@29.6.3':
+    dependencies:
+      '@jest/schemas': 29.6.3
+      '@types/istanbul-lib-coverage': 2.0.6
+      '@types/istanbul-reports': 3.0.4
+      '@types/node': 20.19.17
+      '@types/yargs': 17.0.33
+      chalk: 4.1.2
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -6861,9 +7896,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@sinclair/typebox@0.27.8': {}
+
   '@sindresorhus/is@4.6.0': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@sinonjs/commons@3.0.1':
+    dependencies:
+      type-detect: 4.0.8
+
+  '@sinonjs/fake-timers@10.3.0':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.28.4)':
     dependencies:
@@ -7049,9 +8094,30 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.28.4
+      '@babel/types': 7.28.4
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.28.4
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.28.4
+      '@babel/types': 7.28.4
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.28.4
+
   '@types/conventional-commits-parser@5.0.1':
     dependencies:
-      '@types/node': 24.5.2
+      '@types/node': 20.19.17
 
   '@types/debug@4.1.12':
     dependencies:
@@ -7061,13 +8127,36 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/graceful-fs@4.1.9':
+    dependencies:
+      '@types/node': 20.19.17
+
   '@types/istanbul-lib-coverage@2.0.6': {}
+
+  '@types/istanbul-lib-report@3.0.3':
+    dependencies:
+      '@types/istanbul-lib-coverage': 2.0.6
+
+  '@types/istanbul-reports@3.0.4':
+    dependencies:
+      '@types/istanbul-lib-report': 3.0.3
+
+  '@types/jest@29.5.14':
+    dependencies:
+      expect: 29.7.0
+      pretty-format: 29.7.0
 
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
 
   '@types/katex@0.16.7': {}
+
+  '@types/lodash.merge@4.6.9':
+    dependencies:
+      '@types/lodash': 4.17.20
+
+  '@types/lodash@4.17.20': {}
 
   '@types/ms@2.1.0': {}
 
@@ -7093,7 +8182,37 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
+  '@types/semver@7.7.1': {}
+
+  '@types/stack-utils@2.0.3': {}
+
   '@types/unist@2.0.11': {}
+
+  '@types/yargs-parser@21.0.3': {}
+
+  '@types/yargs@17.0.33':
+    dependencies:
+      '@types/yargs-parser': 21.0.3
+
+  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.9.2)
+      '@typescript-eslint/scope-manager': 6.21.0
+      '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.1)(typescript@5.9.2)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.9.2)
+      '@typescript-eslint/visitor-keys': 6.21.0
+      debug: 4.4.3
+      eslint: 8.57.1
+      graphemer: 1.4.0
+      ignore: 5.3.2
+      natural-compare: 1.4.0
+      semver: 7.7.2
+      ts-api-utils: 1.4.3(typescript@5.9.2)
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
 
   '@typescript-eslint/eslint-plugin@8.44.1(@typescript-eslint/parser@8.44.1(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
@@ -7108,6 +8227,19 @@ snapshots:
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.1.0(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 6.21.0
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.2)
+      '@typescript-eslint/visitor-keys': 6.21.0
+      debug: 4.4.3
+      eslint: 8.57.1
+    optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
@@ -7133,6 +8265,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/scope-manager@6.21.0':
+    dependencies:
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/visitor-keys': 6.21.0
+
   '@typescript-eslint/scope-manager@8.44.1':
     dependencies:
       '@typescript-eslint/types': 8.44.1
@@ -7141,6 +8278,18 @@ snapshots:
   '@typescript-eslint/tsconfig-utils@8.44.1(typescript@5.9.2)':
     dependencies:
       typescript: 5.9.2
+
+  '@typescript-eslint/type-utils@6.21.0(eslint@8.57.1)(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.2)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.9.2)
+      debug: 4.4.3
+      eslint: 8.57.1
+      ts-api-utils: 1.4.3(typescript@5.9.2)
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
 
   '@typescript-eslint/type-utils@8.44.1(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
@@ -7154,7 +8303,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/types@6.21.0': {}
+
   '@typescript-eslint/types@8.44.1': {}
+
+  '@typescript-eslint/typescript-estree@6.21.0(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/visitor-keys': 6.21.0
+      debug: 4.4.3
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.3
+      semver: 7.7.2
+      ts-api-utils: 1.4.3(typescript@5.9.2)
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
 
   '@typescript-eslint/typescript-estree@8.44.1(typescript@5.9.2)':
     dependencies:
@@ -7172,6 +8338,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@6.21.0(eslint@8.57.1)(typescript@5.9.2)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@8.57.1)
+      '@types/json-schema': 7.0.15
+      '@types/semver': 7.7.1
+      '@typescript-eslint/scope-manager': 6.21.0
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.2)
+      eslint: 8.57.1
+      semver: 7.7.2
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@typescript-eslint/utils@8.44.1(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@8.57.1)
@@ -7182,6 +8362,11 @@ snapshots:
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
+
+  '@typescript-eslint/visitor-keys@6.21.0':
+    dependencies:
+      '@typescript-eslint/types': 6.21.0
+      eslint-visitor-keys: 3.4.3
 
   '@typescript-eslint/visitor-keys@8.44.1':
     dependencies:
@@ -7299,6 +8484,10 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  ansi-escapes@4.3.2:
+    dependencies:
+      type-fest: 0.21.3
+
   ansi-escapes@7.1.1:
     dependencies:
       environment: 1.1.0
@@ -7315,13 +8504,24 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   any-promise@1.3.0: {}
 
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.1
+
   are-docs-informative@0.0.2: {}
 
   arg@4.1.3: {}
+
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
 
@@ -7391,6 +8591,36 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
+  babel-jest@29.7.0(@babel/core@7.28.4):
+    dependencies:
+      '@babel/core': 7.28.4
+      '@jest/transform': 29.7.0
+      '@types/babel__core': 7.20.5
+      babel-plugin-istanbul: 6.1.1
+      babel-preset-jest: 29.6.3(@babel/core@7.28.4)
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-istanbul@6.1.1:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+      '@istanbuljs/load-nyc-config': 1.1.0
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-instrument: 5.2.1
+      test-exclude: 6.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-jest-hoist@29.6.3:
+    dependencies:
+      '@babel/template': 7.27.2
+      '@babel/types': 7.28.4
+      '@types/babel__core': 7.20.5
+      '@types/babel__traverse': 7.28.0
+
   babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.28.4):
     dependencies:
       '@babel/compat-data': 7.28.4
@@ -7414,6 +8644,31 @@ snapshots:
       '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.4)
     transitivePeerDependencies:
       - supports-color
+
+  babel-preset-current-node-syntax@1.2.0(@babel/core@7.28.4):
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.4)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.28.4)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.28.4)
+      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.4)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.4)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.4)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.4)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.4)
+
+  babel-preset-jest@29.6.3(@babel/core@7.28.4):
+    dependencies:
+      '@babel/core': 7.28.4
+      babel-plugin-jest-hoist: 29.6.3
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.4)
 
   balanced-match@1.0.2: {}
 
@@ -7462,6 +8717,16 @@ snapshots:
       node-releases: 2.0.21
       update-browserslist-db: 1.1.3(browserslist@4.26.2)
 
+  bs-logger@0.2.6:
+    dependencies:
+      fast-json-stable-stringify: 2.1.0
+
+  bser@2.1.1:
+    dependencies:
+      node-int64: 0.4.0
+
+  buffer-from@1.1.2: {}
+
   builtin-modules@3.3.0: {}
 
   builtin-modules@5.0.0: {}
@@ -7509,6 +8774,8 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  camelcase@5.3.1: {}
+
   camelcase@6.3.0: {}
 
   caniuse-lite@1.0.30001743: {}
@@ -7542,7 +8809,11 @@ snapshots:
 
   chownr@3.0.0: {}
 
+  ci-info@3.9.0: {}
+
   ci-info@4.3.0: {}
+
+  cjs-module-lexer@1.4.3: {}
 
   clean-regexp@1.0.0:
     dependencies:
@@ -7576,6 +8847,11 @@ snapshots:
     optionalDependencies:
       '@colors/colors': 1.5.0
 
+  cli-truncate@4.0.0:
+    dependencies:
+      slice-ansi: 5.0.0
+      string-width: 7.2.0
+
   cli-truncate@5.1.0:
     dependencies:
       slice-ansi: 7.1.2
@@ -7599,6 +8875,10 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  co@4.6.0: {}
+
+  collect-v8-coverage@1.0.2: {}
 
   color-convert@1.9.3:
     dependencies:
@@ -7726,6 +9006,21 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.2
+
+  create-jest@29.7.0(@types/node@20.19.17)(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2)):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@20.19.17)(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2))
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
 
   create-require@1.1.1: {}
 
@@ -7897,6 +9192,8 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  dedent@1.7.0: {}
+
   deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
@@ -7923,11 +9220,15 @@ snapshots:
 
   detect-libc@2.1.1: {}
 
+  detect-newline@3.1.0: {}
+
   detect-newline@4.0.1: {}
 
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  diff-sequences@29.6.3: {}
 
   diff@4.0.2: {}
 
@@ -8005,6 +9306,8 @@ snapshots:
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.223: {}
+
+  emittery@0.13.1: {}
 
   emoji-regex@10.5.0: {}
 
@@ -8130,6 +9433,8 @@ snapshots:
 
   escape-string-regexp@1.0.5: {}
 
+  escape-string-regexp@2.0.0: {}
+
   escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
@@ -8140,6 +9445,10 @@ snapshots:
       semver: 7.7.2
 
   eslint-config-prettier@10.1.8(eslint@8.57.1):
+    dependencies:
+      eslint: 8.57.1
+
+  eslint-config-prettier@9.1.2(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
 
@@ -8179,6 +9488,17 @@ snapshots:
       esquery: 1.6.0
       jsonc-eslint-parser: 2.4.1
 
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.9.2)
+      eslint: 8.57.1
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-module-utils@2.12.1(@typescript-eslint/parser@8.44.1(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
@@ -8188,6 +9508,35 @@ snapshots:
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 8.57.1
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1)
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.9.2)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
       - supports-color
 
   eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.1(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1):
@@ -8408,6 +9757,18 @@ snapshots:
 
   eventemitter3@5.0.1: {}
 
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
   execa@8.0.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -8436,6 +9797,14 @@ snapshots:
       yoctocolors: 2.1.2
 
   exit@0.1.2: {}
+
+  expect@29.7.0:
+    dependencies:
+      '@jest/expect-utils': 29.7.0
+      jest-get-type: 29.6.3
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
 
   express@5.1.0:
     dependencies:
@@ -8497,6 +9866,10 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  fb-watchman@2.0.2:
+    dependencies:
+      bser: 2.1.1
+
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
@@ -8537,6 +9910,11 @@ snapshots:
   find-up@2.1.0:
     dependencies:
       locate-path: 2.0.0
+
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
 
   find-up@5.0.0:
     dependencies:
@@ -8594,6 +9972,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.3:
+    optional: true
+
   function-bind@1.1.2: {}
 
   function-timeout@1.0.2: {}
@@ -8631,6 +10012,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
+
+  get-package-type@0.1.0: {}
 
   get-proto@1.0.1:
     dependencies:
@@ -8839,6 +10222,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  human-signals@2.1.0: {}
+
   human-signals@5.0.0: {}
 
   human-signals@8.0.1: {}
@@ -8868,6 +10253,11 @@ snapshots:
       import-meta-resolve: 4.2.0
     transitivePeerDependencies:
       - supports-color
+
+  import-local@3.2.0:
+    dependencies:
+      pkg-dir: 4.2.0
+      resolve-cwd: 3.0.0
 
   import-meta-resolve@4.2.0: {}
 
@@ -8970,9 +10360,13 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
+  is-fullwidth-code-point@4.0.0: {}
+
   is-fullwidth-code-point@5.1.0:
     dependencies:
       get-east-asian-width: 1.4.0
+
+  is-generator-fn@2.1.0: {}
 
   is-generator-function@1.1.0:
     dependencies:
@@ -9020,6 +10414,8 @@ snapshots:
   is-shared-array-buffer@1.0.4:
     dependencies:
       call-bound: 1.0.4
+
+  is-stream@2.0.1: {}
 
   is-stream@3.0.0: {}
 
@@ -9075,11 +10471,39 @@ snapshots:
 
   istanbul-lib-coverage@3.2.2: {}
 
+  istanbul-lib-instrument@5.2.1:
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/parser': 7.28.4
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-coverage: 3.2.2
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-lib-instrument@6.0.3:
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/parser': 7.28.4
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-coverage: 3.2.2
+      semver: 7.7.2
+    transitivePeerDependencies:
+      - supports-color
+
   istanbul-lib-report@3.0.1:
     dependencies:
       istanbul-lib-coverage: 3.2.2
       make-dir: 4.0.0
       supports-color: 7.2.0
+
+  istanbul-lib-source-maps@4.0.1:
+    dependencies:
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      source-map: 0.6.1
+    transitivePeerDependencies:
+      - supports-color
 
   istanbul-reports@3.2.0:
     dependencies:
@@ -9098,9 +10522,323 @@ snapshots:
 
   java-properties@1.0.2: {}
 
+  jest-changed-files@29.7.0:
+    dependencies:
+      execa: 5.1.1
+      jest-util: 29.7.0
+      p-limit: 3.1.0
+
+  jest-circus@29.7.0:
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/expect': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.17
+      chalk: 4.1.2
+      co: 4.6.0
+      dedent: 1.7.0
+      is-generator-fn: 2.1.0
+      jest-each: 29.7.0
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      p-limit: 3.1.0
+      pretty-format: 29.7.0
+      pure-rand: 6.1.0
+      slash: 3.0.0
+      stack-utils: 2.0.6
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-cli@29.7.0(@types/node@20.19.17)(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2)):
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2))
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@20.19.17)(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2))
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@20.19.17)(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2))
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  jest-config@29.7.0(@types/node@20.19.17)(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2)):
+    dependencies:
+      '@babel/core': 7.28.4
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.28.4)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.19.17
+      ts-node: 10.9.2(@types/node@20.19.17)(typescript@5.9.2)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-diff@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.6.3
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-docblock@29.7.0:
+    dependencies:
+      detect-newline: 3.1.0
+
+  jest-each@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      jest-get-type: 29.6.3
+      jest-util: 29.7.0
+      pretty-format: 29.7.0
+
+  jest-environment-node@29.7.0:
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/fake-timers': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.17
+      jest-mock: 29.7.0
+      jest-util: 29.7.0
+
+  jest-get-type@29.6.3: {}
+
+  jest-haste-map@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/graceful-fs': 4.1.9
+      '@types/node': 20.19.17
+      anymatch: 3.1.3
+      fb-watchman: 2.0.2
+      graceful-fs: 4.2.11
+      jest-regex-util: 29.6.3
+      jest-util: 29.7.0
+      jest-worker: 29.7.0
+      micromatch: 4.0.8
+      walker: 1.0.8
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  jest-leak-detector@29.7.0:
+    dependencies:
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-matcher-utils@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-message-util@29.7.0:
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@jest/types': 29.6.3
+      '@types/stack-utils': 2.0.3
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      stack-utils: 2.0.6
+
+  jest-mock@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.17
+      jest-util: 29.7.0
+
+  jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
+    optionalDependencies:
+      jest-resolve: 29.7.0
+
+  jest-regex-util@29.6.3: {}
+
+  jest-resolve-dependencies@29.7.0:
+    dependencies:
+      jest-regex-util: 29.6.3
+      jest-snapshot: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-resolve@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      jest-pnp-resolver: 1.2.3(jest-resolve@29.7.0)
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      resolve: 1.22.10
+      resolve.exports: 2.0.3
+      slash: 3.0.0
+
+  jest-runner@29.7.0:
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/environment': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.17
+      chalk: 4.1.2
+      emittery: 0.13.1
+      graceful-fs: 4.2.11
+      jest-docblock: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-haste-map: 29.7.0
+      jest-leak-detector: 29.7.0
+      jest-message-util: 29.7.0
+      jest-resolve: 29.7.0
+      jest-runtime: 29.7.0
+      jest-util: 29.7.0
+      jest-watcher: 29.7.0
+      jest-worker: 29.7.0
+      p-limit: 3.1.0
+      source-map-support: 0.5.13
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-runtime@29.7.0:
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/fake-timers': 29.7.0
+      '@jest/globals': 29.7.0
+      '@jest/source-map': 29.6.3
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.17
+      chalk: 4.1.2
+      cjs-module-lexer: 1.4.3
+      collect-v8-coverage: 1.0.2
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-mock: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      slash: 3.0.0
+      strip-bom: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-snapshot@29.7.0:
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/generator': 7.28.3
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.4)
+      '@babel/types': 7.28.4
+      '@jest/expect-utils': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.4)
+      chalk: 4.1.2
+      expect: 29.7.0
+      graceful-fs: 4.2.11
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      natural-compare: 1.4.0
+      pretty-format: 29.7.0
+      semver: 7.7.2
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-util@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.17
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      graceful-fs: 4.2.11
+      picomatch: 2.3.1
+
+  jest-validate@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      camelcase: 6.3.0
+      chalk: 4.1.2
+      jest-get-type: 29.6.3
+      leven: 3.1.0
+      pretty-format: 29.7.0
+
+  jest-watcher@29.7.0:
+    dependencies:
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.17
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      emittery: 0.13.1
+      jest-util: 29.7.0
+      string-length: 4.0.2
+
+  jest-worker@29.7.0:
+    dependencies:
+      '@types/node': 20.19.17
+      jest-util: 29.7.0
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
+
+  jest@29.7.0(@types/node@20.19.17)(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2)):
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2))
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@20.19.17)(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2))
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   jiti@2.6.0: {}
 
   js-tokens@4.0.0: {}
+
+  js-yaml@3.14.1:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
 
   js-yaml@4.1.0:
     dependencies:
@@ -9175,7 +10913,11 @@ snapshots:
 
   kind-of@6.0.3: {}
 
+  kleur@3.0.3: {}
+
   known-css-properties@0.37.0: {}
+
+  leven@3.1.0: {}
 
   levn@0.4.1:
     dependencies:
@@ -9227,11 +10969,28 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.30.1
       lightningcss-win32-x64-msvc: 1.30.1
 
+  lilconfig@3.1.3: {}
+
   lines-and-columns@1.2.4: {}
 
   linkify-it@5.0.0:
     dependencies:
       uc.micro: 2.1.0
+
+  lint-staged@15.5.2:
+    dependencies:
+      chalk: 5.6.2
+      commander: 13.1.0
+      debug: 4.4.3
+      execa: 8.0.1
+      lilconfig: 3.1.3
+      listr2: 8.3.3
+      micromatch: 4.0.8
+      pidtree: 0.6.0
+      string-argv: 0.3.2
+      yaml: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
 
   lint-staged@16.2.0:
     dependencies:
@@ -9242,6 +11001,15 @@ snapshots:
       pidtree: 0.6.0
       string-argv: 0.3.2
       yaml: 2.8.1
+
+  listr2@8.3.3:
+    dependencies:
+      cli-truncate: 4.0.0
+      colorette: 2.0.20
+      eventemitter3: 5.0.1
+      log-update: 6.1.0
+      rfdc: 1.4.1
+      wrap-ansi: 9.0.2
 
   listr2@9.0.4:
     dependencies:
@@ -9263,6 +11031,10 @@ snapshots:
     dependencies:
       p-locate: 2.0.0
       path-exists: 3.0.0
+
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
 
   locate-path@6.0.0:
     dependencies:
@@ -9287,6 +11059,8 @@ snapshots:
   lodash.isstring@4.0.1: {}
 
   lodash.kebabcase@4.1.1: {}
+
+  lodash.memoize@4.1.2: {}
 
   lodash.merge@4.6.2: {}
 
@@ -9335,6 +11109,10 @@ snapshots:
       semver: 7.7.2
 
   make-error@1.3.6: {}
+
+  makeerror@1.0.12:
+    dependencies:
+      tmpl: 1.0.5
 
   markdown-it@14.1.0:
     dependencies:
@@ -9596,6 +11374,8 @@ snapshots:
 
   mime@4.1.0: {}
 
+  mimic-fn@2.1.0: {}
+
   mimic-fn@4.0.0: {}
 
   mimic-function@5.0.1: {}
@@ -9611,6 +11391,10 @@ snapshots:
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
+
+  minimatch@9.0.3:
+    dependencies:
+      brace-expansion: 2.0.2
 
   minimatch@9.0.5:
     dependencies:
@@ -9681,6 +11465,8 @@ snapshots:
       emojilib: 2.4.0
       skin-tone: 2.0.0
 
+  node-int64@0.4.0: {}
+
   node-releases@2.0.21: {}
 
   normalize-package-data@6.0.2:
@@ -9692,6 +11478,10 @@ snapshots:
   normalize-path@3.0.0: {}
 
   normalize-url@8.1.0: {}
+
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
 
   npm-run-path@5.3.0:
     dependencies:
@@ -9755,6 +11545,10 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
   onetime@6.0.0:
     dependencies:
       mimic-fn: 4.0.0
@@ -9792,6 +11586,10 @@ snapshots:
     dependencies:
       p-try: 1.0.0
 
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -9803,6 +11601,10 @@ snapshots:
   p-locate@2.0.0:
     dependencies:
       p-limit: 1.3.0
+
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
 
   p-locate@5.0.0:
     dependencies:
@@ -9817,6 +11619,8 @@ snapshots:
   p-reduce@3.0.0: {}
 
   p-try@1.0.0: {}
+
+  p-try@2.2.0: {}
 
   package-json-from-dist@1.0.1: {}
 
@@ -9914,10 +11718,16 @@ snapshots:
 
   pify@3.0.0: {}
 
+  pirates@4.0.7: {}
+
   pkg-conf@2.1.0:
     dependencies:
       find-up: 2.1.0
       load-json-file: 4.0.0
+
+  pkg-dir@4.2.0:
+    dependencies:
+      find-up: 4.1.0
 
   pluralize@8.0.0: {}
 
@@ -9956,11 +11766,22 @@ snapshots:
 
   prettier@3.6.2: {}
 
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
   pretty-ms@9.3.0:
     dependencies:
       parse-ms: 4.0.0
 
   process-nextick-args@2.0.1: {}
+
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
 
   proto-list@1.2.4: {}
 
@@ -9972,6 +11793,8 @@ snapshots:
   punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
+
+  pure-rand@6.1.0: {}
 
   qs@6.14.0:
     dependencies:
@@ -9999,6 +11822,8 @@ snapshots:
     dependencies:
       react: 19.1.0
       scheduler: 0.26.0
+
+  react-is@18.3.1: {}
 
   react@19.1.0: {}
 
@@ -10099,11 +11924,17 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  resolve-cwd@3.0.0:
+    dependencies:
+      resolve-from: 5.0.0
+
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  resolve.exports@2.0.3: {}
 
   resolve@1.22.10:
     dependencies:
@@ -10342,6 +12173,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  signal-exit@3.0.7: {}
+
   signal-exit@4.1.0: {}
 
   signale@1.4.0:
@@ -10349,6 +12182,8 @@ snapshots:
       chalk: 2.4.2
       figures: 2.0.0
       pkg-conf: 2.1.0
+
+  sisteransi@1.0.5: {}
 
   skin-tone@2.0.0:
     dependencies:
@@ -10361,6 +12196,11 @@ snapshots:
       ansi-styles: 4.3.0
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
+
+  slice-ansi@5.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 4.0.0
 
   slice-ansi@7.1.2:
     dependencies:
@@ -10389,6 +12229,11 @@ snapshots:
       tinyglobby: 0.2.15
 
   source-map-js@1.2.1: {}
+
+  source-map-support@0.5.13:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
 
   source-map@0.6.1: {}
 
@@ -10419,7 +12264,13 @@ snapshots:
 
   split2@4.2.0: {}
 
+  sprintf-js@1.0.3: {}
+
   stable-hash-x@0.2.0: {}
+
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
 
   statuses@2.0.1: {}
 
@@ -10436,6 +12287,11 @@ snapshots:
       readable-stream: 2.3.8
 
   string-argv@0.3.2: {}
+
+  string-length@4.0.2:
+    dependencies:
+      char-regex: 1.0.2
+      strip-ansi: 6.0.1
 
   string-width@4.2.3:
     dependencies:
@@ -10498,6 +12354,10 @@ snapshots:
       ansi-regex: 6.2.2
 
   strip-bom@3.0.0: {}
+
+  strip-bom@4.0.0: {}
+
+  strip-final-newline@2.0.0: {}
 
   strip-final-newline@3.0.0: {}
 
@@ -10590,6 +12450,10 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
   supports-hyperlinks@3.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -10644,6 +12508,12 @@ snapshots:
       type-fest: 2.19.0
       unique-string: 3.0.0
 
+  test-exclude@6.0.0:
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 7.2.3
+      minimatch: 3.1.2
+
   test-exclude@7.0.1:
     dependencies:
       '@istanbuljs/schema': 0.1.3
@@ -10680,6 +12550,8 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tmpl@1.0.5: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -10688,9 +12560,33 @@ snapshots:
 
   traverse@0.6.8: {}
 
+  ts-api-utils@1.4.3(typescript@5.9.2):
+    dependencies:
+      typescript: 5.9.2
+
   ts-api-utils@2.1.0(typescript@5.9.2):
     dependencies:
       typescript: 5.9.2
+
+  ts-jest@29.4.4(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.17)(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2)))(typescript@5.9.2):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.8
+      jest: 29.7.0(@types/node@20.19.17)(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2))
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.7.2
+      type-fest: 4.41.0
+      typescript: 5.9.2
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.28.4
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.28.4)
+      jest-util: 29.7.0
 
   ts-node@10.9.2(@types/node@18.19.127)(typescript@5.5.4):
     dependencies:
@@ -10710,6 +12606,24 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
+  ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.19.17
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.9.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+
   tsconfig-paths@3.15.0:
     dependencies:
       '@types/json5': 0.0.29
@@ -10723,7 +12637,11 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-detect@4.0.8: {}
+
   type-fest@0.20.2: {}
+
+  type-fest@0.21.3: {}
 
   type-fest@1.4.0: {}
 
@@ -10892,6 +12810,10 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
+  walker@1.0.8:
+    dependencies:
+      makeerror: 1.0.12
+
   which-boxed-primitive@1.1.1:
     dependencies:
       is-bigint: 1.1.0
@@ -10964,6 +12886,11 @@ snapshots:
       strip-ansi: 7.1.2
 
   wrappy@1.0.2: {}
+
+  write-file-atomic@4.0.2:
+    dependencies:
+      imurmurhash: 0.1.4
+      signal-exit: 3.0.7
 
   write-file-atomic@5.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,4 @@ packages:
   - 'src/cursor'
   - 'src/knowledge'
   - 'src/mobile'
+  - 'codex-meta-intelligence'


### PR DESCRIPTION
## Summary
- scaffold the codex-meta-intelligence workspace with stage tracking, build orchestration, and project-specific agent guidelines
- implement the stage 1 TypeScript architecture spanning agents, macros, meta-agent control plane, context fabric, knowledge, QA, CI/CD, security, and integration utilities
- add comprehensive documentation and Jest coverage describing agent responsibilities, protocols, foresight, and operator workflows

## Testing
- pnpm lint (from `codex-meta-intelligence`)
- pnpm test (from `codex-meta-intelligence`)
- pnpm typecheck (from `codex-meta-intelligence`)


------
https://chatgpt.com/codex/tasks/task_e_68d49bb9659c83219079cd02e620f1a0