### PR TITLE
feat: add Cursor compliance runtime and tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,7 @@ repos:
           - tomli
         args:
           - --skip=**/package-lock.json
+          - --ignore-words-list=afterAll,afterEach
   - repo: local
     hooks:
       - id: markdownlint

--- a/codex-meta-intelligence/README.md
+++ b/codex-meta-intelligence/README.md
@@ -9,6 +9,7 @@ Codex Meta-Intelligence is a multi-agent operating system for software developme
 - Agent framework with context-aware execution, AGENTS.md parsing and message bus hooks.
 - Knowledge, memory, protocol and context services providing deterministic behaviour and documentation.
 - QA, CI/CD, foresight, security, analytics and integration modules prepared for Stage 2 enhancements.
+- Cursor integration runtime with automated compliance checks, knowledge auto-loading and mobile goal orchestration.
 
 ## Getting Started
 
@@ -22,11 +23,14 @@ pnpm build
 
 1. Modify or extend modules under `src/`.
 2. Update relevant specification markdown files when behaviour changes.
-3. Run quality gates:
+3. If working through Cursor, start the integration runtime:
+   - `pnpm ts-node src/cursor/index.ts` (for scripted automation)
+   - or invoke `startCursorAutoInvocation` from custom tooling.
+4. Run quality gates:
    - `pnpm lint`
    - `pnpm test`
    - `pnpm typecheck`
-4. Execute `./build.sh` to run stage tasks and optionally promote to the next stage.
+5. Execute `./build.sh` to run stage tasks and optionally promote to the next stage.
 
 ## Testing
 

--- a/codex-meta-intelligence/cursor.md
+++ b/codex-meta-intelligence/cursor.md
@@ -24,3 +24,19 @@ All outbound data is scrubbed using governance policies. Sensitive files may be 
 ## Roadmap
 
 Stage 2 adds full API support and cursor automation, while Stage 3 integrates UI feedback loops and plugin synchronisation.
+
+## Runtime Integration Utilities
+
+Stage 1 now includes a Cursor integration runtime (`src/cursor/index.ts`) that satisfies the enforcement workflow described in the blueprint:
+
+- `startCursorAutoInvocation(paths)` wires file watchers for every monitored workspace path using glob patterns from `CURSOR_FILE_PATTERNS`. Duplicate events are throttled using the monitor interval to keep downstream cost predictable.
+- `requireCursorAgent(agentType)` returns a higher-order wrapper that asserts Cursor auto-invocation is active before allowing domain handlers to run, ensuring every code path is executed with an explicit agent role.
+- `validateCursorCompliance()` and `enforceCursorIntegration()` orchestrate environment validation. They verify API credentials, knowledge ingestion, brain blocks activation, mobile goal management and agent selection before returning a compliance score.
+
+Supporting modules located under `src/knowledge` and `src/mobile` provide the contextual data required by Cursor:
+
+- `auto-loader.ts` ingests NDJSON files listed in `KNOWLEDGE_NDJSON_PATHS`, normalises metadata and refreshes entries on a configurable interval.
+- `brain-blocks-integration.ts` exposes semantic queries, derived sections and tag taxonomies for the loaded knowledge blocks.
+- `mobile-app.ts` offers an in-memory goal manager so operators can create, approve and complete tasks from mobile channels.
+
+These utilities are idempotent, safe to start multiple times and automatically awaken dormant subsystems when compliance checks demand them. Agents can therefore execute Cursor-enforced workflows without bespoke bootstrapping scripts.

--- a/codex-meta-intelligence/src/cursor/index.ts
+++ b/codex-meta-intelligence/src/cursor/index.ts
@@ -1,0 +1,347 @@
+import { EventEmitter } from 'node:events';
+import { watch, type FSWatcher } from 'node:fs';
+import { readdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+
+import type {
+  CursorAgentType,
+  CursorComplianceCheck,
+  CursorComplianceReport,
+} from '../shared/types.js';
+import { DEFAULT_CURSOR_MONITOR_INTERVAL_MS } from '../shared/constants.js';
+import {
+  getKnowledgeEntries,
+  isKnowledgeAutoLoaderActive,
+  startKnowledgeAutoLoading,
+} from '../knowledge/auto-loader.js';
+import {
+  getSections,
+  getTags,
+  isBrainBlocksActive,
+  startBrainBlocksIntegration,
+} from '../knowledge/brain-blocks-integration.js';
+import { getGoals, isMobileControlActive, startMobileApp } from '../mobile/mobile-app.js';
+import { clamp } from '../shared/utils.js';
+
+interface CursorInvocationEvent {
+  filePath: string;
+  timestamp: number;
+}
+
+interface CursorAutoInvokerEvents {
+  invocation: [CursorInvocationEvent];
+  error: [Error];
+}
+
+const normalisePath = (target: string): string => path.resolve(target);
+
+const globToRegExp = (pattern: string): RegExp => {
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*\*/g, '::DOUBLE_STAR::')
+    .replace(/\*/g, '[^/]*')
+    .replace(/::DOUBLE_STAR::/g, '.*');
+  return new RegExp(`^${escaped}$`);
+};
+
+const parsePatterns = (raw: string | undefined): RegExp[] => {
+  if (!raw) {
+    return [globToRegExp('**/*.ts')];
+  }
+  return raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((pattern) => globToRegExp(pattern));
+};
+
+const patterns = parsePatterns(process.env.CURSOR_FILE_PATTERNS);
+
+class CursorAutoInvoker extends EventEmitter<CursorAutoInvokerEvents> {
+  private readonly watchers = new Map<string, FSWatcher>();
+
+  private readonly triggeredFiles = new Map<string, number>();
+
+  private running = false;
+
+  constructor(private readonly monitorIntervalMs: number) {
+    super();
+  }
+
+  async start(paths: Iterable<string>): Promise<void> {
+    if (this.running) {
+      return;
+    }
+    for (const pathEntry of paths) {
+      // eslint-disable-next-line no-await-in-loop
+      await this.watchPath(normalisePath(pathEntry));
+    }
+    this.running = true;
+  }
+
+  stop(): void {
+    for (const watcher of this.watchers.values()) {
+      watcher.close();
+    }
+    this.watchers.clear();
+    this.running = false;
+    this.triggeredFiles.clear();
+  }
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  getWatchedPaths(): string[] {
+    return Array.from(this.watchers.keys());
+  }
+
+  getTriggeredFiles(): string[] {
+    return Array.from(this.triggeredFiles.keys());
+  }
+
+  getLastInvocation(): number | undefined {
+    const timestamps = Array.from(this.triggeredFiles.values());
+    return timestamps.length > 0 ? Math.max(...timestamps) : undefined;
+  }
+
+  private async watchPath(target: string): Promise<void> {
+    try {
+      const stats = await stat(target);
+      if (stats.isDirectory()) {
+        this.registerWatcher(target);
+        const entries = await readdir(target, { withFileTypes: true });
+        for (const entry of entries) {
+          const entryPath = path.join(target, entry.name);
+          if (entry.isDirectory()) {
+            // eslint-disable-next-line no-await-in-loop
+            await this.watchPath(entryPath);
+          }
+        }
+      } else {
+        const parent = path.dirname(target);
+        this.registerWatcher(parent);
+      }
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      this.emit('error', err);
+    }
+  }
+
+  private registerWatcher(directory: string): void {
+    if (this.watchers.has(directory)) {
+      return;
+    }
+    const watcher = watch(directory, { persistent: false }, (eventType, fileName) => {
+      if (!fileName) {
+        return;
+      }
+      const absolutePath = normalisePath(path.join(directory, fileName.toString()));
+      if (eventType === 'rename') {
+        // Ensure new directories are watched.
+        stat(absolutePath)
+          .then((stats) => {
+            if (stats.isDirectory()) {
+              return this.watchPath(absolutePath);
+            }
+            return undefined;
+          })
+          .catch(() => undefined);
+      }
+      if (this.matchesPatterns(absolutePath)) {
+        const now = Date.now();
+        const last = this.triggeredFiles.get(absolutePath);
+        if (!last || now - last >= this.monitorIntervalMs) {
+          this.triggeredFiles.set(absolutePath, now);
+          this.emit('invocation', { filePath: absolutePath, timestamp: now });
+        }
+      }
+    });
+    watcher.on('error', (error) => {
+      const err = error instanceof Error ? error : new Error(String(error));
+      this.emit('error', err);
+    });
+    this.watchers.set(directory, watcher);
+  }
+
+  private matchesPatterns(filePath: string): boolean {
+    const relative = path.relative(process.cwd(), filePath);
+    return patterns.some((pattern) => pattern.test(relative));
+  }
+}
+
+let autoInvoker: CursorAutoInvoker | undefined;
+
+const getMonitorInterval = (): number => {
+  const env = process.env.CURSOR_MONITOR_INTERVAL;
+  if (!env) {
+    return DEFAULT_CURSOR_MONITOR_INTERVAL_MS;
+  }
+  const parsed = Number.parseInt(env, 10);
+  if (Number.isNaN(parsed)) {
+    return DEFAULT_CURSOR_MONITOR_INTERVAL_MS;
+  }
+  return clamp(parsed * 1000, 1000, 60 * 60 * 1000);
+};
+
+export const startCursorAutoInvocation = async (
+  paths: Iterable<string>
+): Promise<CursorAutoInvoker> => {
+  if (!autoInvoker) {
+    autoInvoker = new CursorAutoInvoker(getMonitorInterval());
+  }
+  await autoInvoker.start(paths);
+  return autoInvoker;
+};
+
+export const stopCursorAutoInvocation = (): void => {
+  autoInvoker?.stop();
+  autoInvoker = undefined;
+};
+
+export const getAutoInvoker = (): CursorAutoInvoker | undefined => autoInvoker;
+
+let activeAgentType: CursorAgentType | undefined;
+
+const ensureAgentSelection = (type: CursorAgentType): void => {
+  activeAgentType = type;
+};
+
+export const requireCursorAgent = (agentType: CursorAgentType) => {
+  return <T extends (...args: unknown[]) => unknown>(handler: T): T => {
+    const wrapped = ((...args: Parameters<T>) => {
+      ensureAgentSelection(agentType);
+      if (!autoInvoker || !autoInvoker.isRunning()) {
+        throw new Error('Cursor auto-invocation is not active');
+      }
+      return handler(...args);
+    }) as T;
+    return wrapped;
+  };
+};
+
+const evaluateCheck = (name: string, passed: boolean, message: string): CursorComplianceCheck => ({
+  name,
+  passed,
+  message,
+});
+
+const REQUIRED_ENV_VARS = ['CURSOR_API_URL', 'CURSOR_API_KEY'];
+
+const computeEnvChecks = (): CursorComplianceCheck[] => {
+  return REQUIRED_ENV_VARS.map((name) => {
+    const exists = Boolean(process.env[name]);
+    const message = exists
+      ? `${name} configured`
+      : `${name} missing – set this variable to enable Cursor connectivity.`;
+    return evaluateCheck(`env:${name.toLowerCase()}`, exists, message);
+  });
+};
+
+const ensureSupportingServices = async (): Promise<void> => {
+  if (!isMobileControlActive()) {
+    await startMobileApp();
+  }
+  if (!isKnowledgeAutoLoaderActive()) {
+    await startKnowledgeAutoLoading();
+  }
+  if (!isBrainBlocksActive()) {
+    await startBrainBlocksIntegration();
+  }
+};
+
+export const validateCursorCompliance = async (): Promise<CursorComplianceReport> => {
+  await ensureSupportingServices();
+  const checks: CursorComplianceCheck[] = [];
+  const invokerActive = Boolean(autoInvoker && autoInvoker.isRunning());
+  checks.push(
+    evaluateCheck(
+      'cursor:auto_invocation',
+      invokerActive,
+      invokerActive ? 'Auto invocation running' : 'Call startCursorAutoInvocation first.'
+    )
+  );
+
+  const knowledgeActive = isKnowledgeAutoLoaderActive();
+  checks.push(
+    evaluateCheck(
+      'knowledge:auto_loader',
+      knowledgeActive,
+      knowledgeActive ? 'Knowledge auto loader active' : 'Enable KNOWLEDGE_AUTO_LOAD=true.'
+    )
+  );
+
+  const brainBlocks = isBrainBlocksActive();
+  checks.push(
+    evaluateCheck(
+      'knowledge:brain_blocks',
+      brainBlocks,
+      brainBlocks ? 'Brain blocks integration active' : 'Start brain blocks integration.'
+    )
+  );
+
+  const mobileActive = isMobileControlActive();
+  checks.push(
+    evaluateCheck(
+      'mobile:control',
+      mobileActive,
+      mobileActive ? 'Mobile control active' : 'Start the mobile control service.'
+    )
+  );
+
+  const agentSelected = Boolean(activeAgentType);
+  checks.push(
+    evaluateCheck(
+      'cursor:agent_selected',
+      agentSelected,
+      agentSelected ? `Agent ${activeAgentType} selected` : 'Call requireCursorAgent in workflows.'
+    )
+  );
+
+  checks.push(...computeEnvChecks());
+
+  const passedChecks = checks.filter((check) => check.passed).length;
+  const compliance = checks.length === 0 ? 1 : passedChecks / checks.length;
+
+  const details = {
+    agentType: activeAgentType ?? 'unassigned',
+    watchedFiles: autoInvoker?.getTriggeredFiles().length ?? 0,
+    knowledgeEntries: (await getKnowledgeEntries()).length,
+    brainSections: (await getSections()).length,
+    brainTags: (await getTags()).length,
+    goals: (await getGoals()).length,
+  };
+
+  return {
+    compliance,
+    checks,
+    details,
+  };
+};
+
+export const enforceCursorIntegration = async (): Promise<void> => {
+  const report = await validateCursorCompliance();
+  const strict = (process.env.CURSOR_STRICT_MODE ?? 'true').toLowerCase() === 'true';
+  if (strict && report.compliance < 1) {
+    const failed = report.checks.filter((check) => !check.passed).map((check) => check.message);
+    throw new Error(
+      `Cursor compliance ${Math.round(report.compliance * 100)}% – ${failed.join('; ')}`
+    );
+  }
+};
+
+export const getAutoInvokerEvents = (): CursorInvocationEvent[] => {
+  const invoker = autoInvoker;
+  if (!invoker) {
+    return [];
+  }
+  const lastInvocation = invoker.getLastInvocation();
+  return invoker.getTriggeredFiles().map((filePath) => ({
+    filePath,
+    timestamp: lastInvocation ?? Date.now(),
+  }));
+};
+
+export const getCursorAgentType = (): CursorAgentType | undefined => activeAgentType;
+
+export type { CursorAutoInvoker, CursorInvocationEvent };

--- a/codex-meta-intelligence/src/knowledge/auto-loader.ts
+++ b/codex-meta-intelligence/src/knowledge/auto-loader.ts
@@ -1,0 +1,151 @@
+import { EventEmitter } from 'node:events';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import type { KnowledgeBlock } from '../shared/types.js';
+import { generateId, nowIso } from '../shared/utils.js';
+import { parseNdjson } from './scaffolds.js';
+
+interface KnowledgeAutoLoaderEvents {
+  reload: [KnowledgeBlock[]];
+  error: [Error];
+}
+
+const DEFAULT_INTERVAL_MS =
+  Number.parseInt(process.env.KNOWLEDGE_WATCH_INTERVAL ?? '30', 10) * 1000;
+
+const getPathsFromEnv = (): string[] => {
+  const env = process.env.KNOWLEDGE_NDJSON_PATHS ?? '';
+  return env
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => path.resolve(entry));
+};
+
+const normaliseBlocks = (blocks: KnowledgeBlock[]): KnowledgeBlock[] => {
+  return blocks.map((block) => ({
+    ...block,
+    id: block.id || generateId('kb'),
+    metadata: {
+      ...block.metadata,
+      timestamp: block.metadata.timestamp || nowIso(),
+      tags: block.metadata.tags ?? [],
+      citations: block.metadata.citations ?? [],
+    },
+    links: block.links ?? [],
+  }));
+};
+
+class KnowledgeAutoLoader extends EventEmitter<KnowledgeAutoLoaderEvents> {
+  private readonly entries = new Map<string, KnowledgeBlock>();
+
+  private readonly intervalMs: number;
+
+  private readonly paths: string[];
+
+  private timer?: NodeJS.Timeout;
+
+  private active = false;
+
+  constructor(paths: string[], intervalMs: number) {
+    super();
+    this.paths = paths;
+    this.intervalMs = intervalMs;
+  }
+
+  async start(): Promise<void> {
+    if (this.active) {
+      return;
+    }
+    await this.reload();
+    if (this.paths.length > 0) {
+      this.timer = setInterval(() => {
+        void this.reload();
+      }, this.intervalMs).unref();
+    }
+    this.active = true;
+  }
+
+  async stop(): Promise<void> {
+    if (this.timer) {
+      clearInterval(this.timer);
+    }
+    this.timer = undefined;
+    this.active = false;
+  }
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  getEntries(): KnowledgeBlock[] {
+    return Array.from(this.entries.values());
+  }
+
+  private async reload(): Promise<void> {
+    try {
+      const loaded: KnowledgeBlock[] = [];
+      for (const file of this.paths) {
+        try {
+          const raw = await readFile(file, 'utf8');
+          const blocks = normaliseBlocks(parseNdjson(raw));
+          for (const block of blocks) {
+            this.entries.set(block.id, block);
+            loaded.push(block);
+          }
+        } catch (error) {
+          const err = error instanceof Error ? error : new Error(String(error));
+          this.emit('error', err);
+        }
+      }
+      this.emit('reload', loaded);
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      this.emit('error', err);
+    }
+  }
+}
+
+let loader: KnowledgeAutoLoader | undefined;
+
+const shouldAutoLoad = (): boolean => {
+  const env = process.env.KNOWLEDGE_AUTO_LOAD ?? 'false';
+  return env.toLowerCase() === 'true';
+};
+
+export const startKnowledgeAutoLoading = async (
+  paths: string[] = getPathsFromEnv(),
+  intervalMs = DEFAULT_INTERVAL_MS
+): Promise<KnowledgeAutoLoader> => {
+  if (!loader) {
+    loader = new KnowledgeAutoLoader(paths, intervalMs);
+  }
+  if (shouldAutoLoad()) {
+    await loader.start();
+  }
+  return loader;
+};
+
+export const stopKnowledgeAutoLoading = async (): Promise<void> => {
+  if (loader) {
+    await loader.stop();
+  }
+  loader = undefined;
+};
+
+export const getKnowledgeEntries = async (): Promise<KnowledgeBlock[]> => {
+  if (!loader) {
+    return [];
+  }
+  if (!loader.isActive()) {
+    await loader.start();
+  }
+  return loader.getEntries();
+};
+
+export const isKnowledgeAutoLoaderActive = (): boolean => {
+  return loader?.isActive() ?? false;
+};
+
+export type { KnowledgeAutoLoader };

--- a/codex-meta-intelligence/src/knowledge/brain-blocks-integration.ts
+++ b/codex-meta-intelligence/src/knowledge/brain-blocks-integration.ts
@@ -1,0 +1,130 @@
+import { EventEmitter } from 'node:events';
+
+import type { BrainBlock, BrainBlockQuery, KnowledgeBlock } from '../shared/types.js';
+import { generateId } from '../shared/utils.js';
+import {
+  getKnowledgeEntries,
+  isKnowledgeAutoLoaderActive,
+  startKnowledgeAutoLoading,
+} from './auto-loader.js';
+
+interface BrainBlocksEvents {
+  refresh: [BrainBlock[]];
+}
+
+const unique = <T>(values: Iterable<T>): T[] => Array.from(new Set(values));
+
+const deriveSections = (block: KnowledgeBlock | BrainBlock): string[] => {
+  const fromMetadata = block.metadata.tags
+    .map((tag) => (tag.startsWith('section:') ? tag.slice('section:'.length) : undefined))
+    .filter((section): section is string => Boolean(section));
+  if (fromMetadata.length > 0) {
+    return fromMetadata;
+  }
+  const headings = Array.from(block.content.matchAll(/^#+\s*(.+)$/gm)).map((match) => match[1]!);
+  return headings.length > 0 ? headings : ['general'];
+};
+
+const createBrainBlock = (block: BrainBlock | KnowledgeBlock): BrainBlock => {
+  return {
+    ...block,
+    id: block.id || generateId('brain'),
+    sections:
+      'sections' in block && block.sections?.length ? block.sections : deriveSections(block),
+    tags: 'tags' in block && block.tags ? block.tags : unique([...block.metadata.tags]),
+  };
+};
+
+class BrainBlocksIntegration extends EventEmitter<BrainBlocksEvents> {
+  private blocks: BrainBlock[] = [];
+
+  private active = false;
+
+  async start(): Promise<void> {
+    if (!isKnowledgeAutoLoaderActive()) {
+      await startKnowledgeAutoLoading();
+    }
+    await this.refresh();
+    this.active = true;
+  }
+
+  async refresh(): Promise<void> {
+    const entries = await getKnowledgeEntries();
+    this.blocks = entries.map((block) =>
+      createBrainBlock({
+        ...block,
+        sections: block.links && block.links.length > 0 ? block.links : undefined,
+      })
+    );
+    this.emit('refresh', this.blocks);
+  }
+
+  stop(): void {
+    this.blocks = [];
+    this.active = false;
+  }
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  query(query: BrainBlockQuery = {}): BrainBlock[] {
+    return this.blocks.filter((block) => {
+      const matchesSearch = query.search
+        ? block.content.toLowerCase().includes(query.search.toLowerCase())
+        : true;
+      const matchesTags = query.tags?.length
+        ? query.tags.every((tag) => block.tags.includes(tag))
+        : true;
+      return matchesSearch && matchesTags;
+    });
+  }
+
+  listSections(): string[] {
+    return unique(this.blocks.flatMap((block) => block.sections));
+  }
+
+  listTags(): string[] {
+    return unique(this.blocks.flatMap((block) => block.tags));
+  }
+}
+
+let integration: BrainBlocksIntegration | undefined;
+
+export const startBrainBlocksIntegration = async (): Promise<BrainBlocksIntegration> => {
+  if (!integration) {
+    integration = new BrainBlocksIntegration();
+  }
+  await integration.start();
+  return integration;
+};
+
+export const stopBrainBlocksIntegration = (): void => {
+  integration?.stop();
+  integration = undefined;
+};
+
+export const queryBrainBlocks = async (query?: BrainBlockQuery): Promise<BrainBlock[]> => {
+  if (!integration) {
+    await startBrainBlocksIntegration();
+  }
+  return integration!.query(query);
+};
+
+export const getSections = async (): Promise<string[]> => {
+  if (!integration) {
+    await startBrainBlocksIntegration();
+  }
+  return integration!.listSections();
+};
+
+export const getTags = async (): Promise<string[]> => {
+  if (!integration) {
+    await startBrainBlocksIntegration();
+  }
+  return integration!.listTags();
+};
+
+export const isBrainBlocksActive = (): boolean => integration?.isActive() ?? false;
+
+export type { BrainBlocksIntegration };

--- a/codex-meta-intelligence/src/mobile/mobile-app.ts
+++ b/codex-meta-intelligence/src/mobile/mobile-app.ts
@@ -1,0 +1,124 @@
+import { EventEmitter } from 'node:events';
+
+import type { MobileGoal, MobileGoalInput } from '../shared/types.js';
+import { generateId, nowIso } from '../shared/utils.js';
+
+interface MobileAppEvents {
+  created: [MobileGoal];
+  updated: [MobileGoal];
+}
+
+class MobileControl extends EventEmitter<MobileAppEvents> {
+  private readonly goals = new Map<string, MobileGoal>();
+
+  private active = false;
+
+  start(): void {
+    if (this.active) {
+      return;
+    }
+    this.active = true;
+  }
+
+  stop(): void {
+    this.goals.clear();
+    this.active = false;
+  }
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  createGoal(input: MobileGoalInput): MobileGoal {
+    if (!this.active) {
+      throw new Error('Mobile control is not active');
+    }
+    const goal: MobileGoal = {
+      id: generateId('goal'),
+      title: input.title,
+      description: input.description,
+      priority: input.priority ?? 'medium',
+      status: 'pending',
+      createdAt: nowIso(),
+      updatedAt: nowIso(),
+    };
+    this.goals.set(goal.id, goal);
+    this.emit('created', goal);
+    return goal;
+  }
+
+  listGoals(): MobileGoal[] {
+    return Array.from(this.goals.values());
+  }
+
+  updateGoal(id: string, status: MobileGoal['status']): MobileGoal {
+    const goal = this.goals.get(id);
+    if (!goal) {
+      throw new Error(`Goal ${id} not found`);
+    }
+    const updated: MobileGoal = {
+      ...goal,
+      status,
+      updatedAt: nowIso(),
+    };
+    this.goals.set(id, updated);
+    this.emit('updated', updated);
+    return updated;
+  }
+}
+
+let controller: MobileControl | undefined;
+
+const ensureController = (): MobileControl => {
+  if (!controller) {
+    controller = new MobileControl();
+  }
+  return controller;
+};
+
+export const startMobileApp = async (): Promise<MobileControl> => {
+  const instance = ensureController();
+  instance.start();
+  return instance;
+};
+
+export const stopMobileApp = (): void => {
+  controller?.stop();
+  controller = undefined;
+};
+
+export const isMobileControlActive = (): boolean => controller?.isActive() ?? false;
+
+export const createGoal = async (input: MobileGoalInput): Promise<MobileGoal> => {
+  const instance = ensureController();
+  if (!instance.isActive()) {
+    instance.start();
+  }
+  return instance.createGoal(input);
+};
+
+export const getGoals = async (): Promise<MobileGoal[]> => {
+  const instance = ensureController();
+  if (!instance.isActive()) {
+    instance.start();
+  }
+  return instance.listGoals();
+};
+
+export const approveGoal = async (goalId: string): Promise<MobileGoal> => {
+  const instance = ensureController();
+  if (!instance.isActive()) {
+    instance.start();
+  }
+  return instance.updateGoal(goalId, 'approved');
+};
+
+export const completeGoal = async (goalId: string): Promise<MobileGoal> => {
+  const instance = ensureController();
+  if (!instance.isActive()) {
+    instance.start();
+  }
+  return instance.updateGoal(goalId, 'completed');
+};
+
+export type { MobileControl };

--- a/codex-meta-intelligence/src/shared/constants.ts
+++ b/codex-meta-intelligence/src/shared/constants.ts
@@ -17,3 +17,4 @@ export const QA_SEVERITY_ORDER: Record<'info' | 'warning' | 'error', number> = {
 
 export const DEFAULT_CACHE_CAPACITY = 256;
 export const DEFAULT_CACHE_TTL_MS = 10 * 60 * 1000;
+export const DEFAULT_CURSOR_MONITOR_INTERVAL_MS = 5 * 1000;

--- a/codex-meta-intelligence/src/shared/types.ts
+++ b/codex-meta-intelligence/src/shared/types.ts
@@ -9,6 +9,8 @@ export enum AgentRole {
   OPERATOR = 'operator',
 }
 
+export type CursorAgentType = 'FRONTEND' | 'BACKEND' | 'KNOWLEDGE' | 'QA' | 'CICD' | 'ARCHITECT';
+
 export interface AgentConfig {
   id: string;
   role: AgentRole;
@@ -124,6 +126,16 @@ export interface KnowledgeResponse {
   blocks: Array<{ block: KnowledgeBlock; score: number }>;
 }
 
+export interface BrainBlock extends KnowledgeBlock {
+  sections: string[];
+  tags: string[];
+}
+
+export interface BrainBlockQuery {
+  search?: string;
+  tags?: string[];
+}
+
 export interface MemoryRecord {
   id: string;
   agentId: string;
@@ -224,6 +236,34 @@ export interface TraceSpan {
   startTime: number;
   endTime?: number;
   attributes: Record<string, JsonValue>;
+}
+
+export interface CursorComplianceCheck {
+  name: string;
+  passed: boolean;
+  message: string;
+}
+
+export interface CursorComplianceReport {
+  compliance: number;
+  checks: CursorComplianceCheck[];
+  details: Record<string, JsonValue>;
+}
+
+export interface MobileGoalInput {
+  title: string;
+  description: string;
+  priority?: 'low' | 'medium' | 'high';
+}
+
+export interface MobileGoal {
+  id: string;
+  title: string;
+  description: string;
+  priority: 'low' | 'medium' | 'high';
+  status: 'pending' | 'approved' | 'completed';
+  createdAt: string;
+  updatedAt: string;
 }
 
 export type JsonSchema = JsonObject;

--- a/codex-meta-intelligence/tests/cursor.integration.spec.ts
+++ b/codex-meta-intelligence/tests/cursor.integration.spec.ts
@@ -1,0 +1,108 @@
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+
+import {
+  enforceCursorIntegration,
+  getAutoInvoker,
+  requireCursorAgent,
+  startCursorAutoInvocation,
+  stopCursorAutoInvocation,
+  validateCursorCompliance,
+} from '../src/cursor/index';
+import {
+  getKnowledgeEntries,
+  startKnowledgeAutoLoading,
+  stopKnowledgeAutoLoading,
+} from '../src/knowledge/auto-loader';
+import {
+  startBrainBlocksIntegration,
+  stopBrainBlocksIntegration,
+} from '../src/knowledge/brain-blocks-integration';
+import { startMobileApp, stopMobileApp } from '../src/mobile/mobile-app';
+
+const createKnowledgeFile = async (): Promise<string> => {
+  const directory = await mkdtemp(path.join(tmpdir(), 'cmi-knowledge-'));
+  const filePath = path.join(directory, 'blocks.ndjson');
+  const content = [
+    JSON.stringify({
+      id: 'brain-1',
+      content: '# Section\nCursor integration knowledge entry',
+      metadata: {
+        author: 'test',
+        timestamp: new Date().toISOString(),
+        tags: ['section:runtime', 'cursor'],
+        citations: [],
+        source: 'test-suite',
+        reliabilityScore: 0.9,
+      },
+    }),
+  ].join('\n');
+  await writeFile(filePath, content, 'utf8');
+  return filePath;
+};
+
+describe('Cursor integration runtime', () => {
+  const originalEnv = {
+    CURSOR_API_URL: process.env.CURSOR_API_URL,
+    CURSOR_API_KEY: process.env.CURSOR_API_KEY,
+    CURSOR_STRICT_MODE: process.env.CURSOR_STRICT_MODE,
+    KNOWLEDGE_AUTO_LOAD: process.env.KNOWLEDGE_AUTO_LOAD,
+    KNOWLEDGE_NDJSON_PATHS: process.env.KNOWLEDGE_NDJSON_PATHS,
+  };
+
+  beforeAll(() => {
+    process.env.CURSOR_API_URL = process.env.CURSOR_API_URL ?? 'https://api.cursor.sh';
+    process.env.CURSOR_API_KEY = process.env.CURSOR_API_KEY ?? 'test-key';
+    process.env.CURSOR_STRICT_MODE = 'false';
+    process.env.KNOWLEDGE_AUTO_LOAD = 'true';
+  });
+
+  // codespell:ignore afterEach
+  afterEach(async () => {
+    stopCursorAutoInvocation();
+    await stopKnowledgeAutoLoading();
+    stopBrainBlocksIntegration();
+    stopMobileApp();
+  });
+
+  // codespell:ignore afterAll
+  afterAll(() => {
+    process.env.CURSOR_API_URL = originalEnv.CURSOR_API_URL;
+    process.env.CURSOR_API_KEY = originalEnv.CURSOR_API_KEY;
+    process.env.CURSOR_STRICT_MODE = originalEnv.CURSOR_STRICT_MODE;
+    process.env.KNOWLEDGE_AUTO_LOAD = originalEnv.KNOWLEDGE_AUTO_LOAD;
+    process.env.KNOWLEDGE_NDJSON_PATHS = originalEnv.KNOWLEDGE_NDJSON_PATHS;
+  });
+
+  it('maintains full Cursor compliance after startup', async () => {
+    const knowledgeFile = await createKnowledgeFile();
+    process.env.KNOWLEDGE_NDJSON_PATHS = knowledgeFile;
+
+    await startKnowledgeAutoLoading([knowledgeFile], 50);
+    await startBrainBlocksIntegration();
+    await startMobileApp();
+
+    const workspace = await mkdtemp(path.join(tmpdir(), 'cmi-workspace-'));
+    await startCursorAutoInvocation([workspace]);
+
+    const wrapped = requireCursorAgent('FRONTEND')(() => 'ready');
+    expect(wrapped()).toBe('ready');
+
+    const targetFile = path.join(workspace, 'example.ts');
+    await writeFile(targetFile, 'export const example = 1;');
+    await delay(100);
+
+    const invoker = getAutoInvoker();
+    expect(invoker).toBeDefined();
+    expect(invoker?.getTriggeredFiles()).toContain(targetFile);
+
+    const entries = await getKnowledgeEntries();
+    expect(entries.length).toBeGreaterThan(0);
+
+    const report = await validateCursorCompliance();
+    expect(report.compliance).toBeCloseTo(1, 5);
+    await expect(enforceCursorIntegration()).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add a Cursor auto-invocation runtime with compliance reporting plus supporting knowledge and mobile modules
- document the runtime workflow and extend shared typings/constants for Cursor-aware agents
- add integration coverage for Cursor startup and relax codespell rules for camelCase lifecycle hooks

## Testing
- pnpm lint
- pnpm test
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d4a148198883218085fac487286519