### PR TITLE
Add environment schema validation and tighten CI security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   PNPM_STORE_PATH: ${{ runner.temp }}/pnpm-store
 
 jobs:
-  node-quality:
+  js-and-docs-quality:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -40,6 +40,9 @@ jobs:
       - name: Node quality suite
         run: python -m src.performance.cli node-quality --output-dir results/performance/node
 
+      - name: Documentation quality suite
+        run: python -m src.performance.cli docs-quality --output-dir results/performance/docs
+
       - name: Commitlint history
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -54,36 +57,6 @@ jobs:
         with:
           name: node-quality-metrics
           path: results/performance/node
-
-  docs-quality:
-    runs-on: ubuntu-latest
-    needs: node-quality
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-          run_install: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'pnpm'
-
-      - name: Configure pnpm store
-        run: |
-          mkdir -p "$PNPM_STORE_PATH"
-          pnpm config set store-dir "$PNPM_STORE_PATH"
-
-      - name: Install Node.js dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Documentation quality suite
-        run: python -m src.performance.cli docs-quality --output-dir results/performance/docs
 
       - name: Upload documentation metrics
         if: always()
@@ -108,6 +81,9 @@ jobs:
       - name: Install Python tooling
         run: pip install -r requirements-dev.txt
 
+      - name: Validate environment configurations
+        run: python -m src.common.config_loader --env .env.example --env config/environments/ci.env --env config/environments/development.env --json
+
       - name: Python quality suite
         run: python -m src.performance.cli python-quality --output-dir results/performance/python
 
@@ -120,7 +96,7 @@ jobs:
 
   codex-status:
     runs-on: ubuntu-latest
-    needs: [node-quality, docs-quality, python-quality]
+    needs: [js-and-docs-quality, python-quality]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+---
+name: Semantic Release
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ['main']
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  release:
+    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    env:
+      PNPM_STORE_PATH: ${{ runner.temp }}/pnpm-store
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Configure pnpm store
+        run: |
+          mkdir -p "$PNPM_STORE_PATH"
+          pnpm config set store-dir "$PNPM_STORE_PATH"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm release

--- a/.github/workflows/security-pr.yml
+++ b/.github/workflows/security-pr.yml
@@ -1,0 +1,38 @@
+---
+name: PR Security Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+  security-events: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dependency review
+        uses: actions/dependency-review-action@v4
+        with:
+          deny-licenses: 'GPL-1.0,GPL-2.0,GPL-3.0,AGPL-1.0,AGPL-3.0'
+          fail-on-severity: high
+
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: TruffleHog scan
+        uses: trufflesecurity/trufflehog@v3.81.7
+        with:
+          extra_args: >-
+            filesystem
+            --only-verified
+            --fail
+            .

--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@ documentation, automation, and templates aligned. Curated profiles now live unde
 minimal setup and the Cursor-heavy automation stack. Review `docs/setup.md` for a complete option
 reference and avoid committing secrets.
 
+The repository now publishes a machine-readable schema at `config/env.schema.json`. Use the shared
+validator to confirm that all required values (and their defaults) are present before committing:
+
+```bash
+python -m src.common.config_loader --env .env --env config/environments/ci.env --json
+```
+
+When schema changes are required, regenerate the artifact with:
+
+```bash
+python scripts/generate_env_schema.py
+```
+
 Knowledge ingestion watchers are now opt-in: leave `KNOWLEDGE_WATCH_INTERVAL` blank to skip polling
 and set it to a positive number to enable background reloads.
 
@@ -109,6 +122,7 @@ make test-python   # execute pytest suites
 make security      # run npm and pip security audits
 make cursor-status # emit Cursor automation health as JSON (non-zero exit on failure)
 python -m src.common.config_loader --json  # validate pipeline/governance/metrics bundles
+python -m src.performance.cli node-quality --skip "pnpm audit" --max-workers 2  # targeted quality run
 ```
 
 Each command is idempotent and suitable for CI usage; the aggregated `make quality` target mirrors

--- a/config/env.schema.json
+++ b/config/env.schema.json
@@ -1,0 +1,190 @@
+{
+  "additionalProperties": true,
+  "description": "Schema describing required environment variables for CodexHUB.",
+  "properties": {
+    "PORT": {
+      "default": 4000,
+      "exclusiveMinimum": 0,
+      "title": "Port",
+      "type": "integer"
+    },
+    "NODE_ENV": {
+      "default": "development",
+      "enum": ["development", "production", "test"],
+      "title": "Node Env",
+      "type": "string"
+    },
+    "SESSION_SECRET": {
+      "default": "replace-with-strong-secret",
+      "title": "Session Secret",
+      "type": "string"
+    },
+    "OPENAI_API_KEY": {
+      "default": "changeme",
+      "title": "Openai Api Key",
+      "type": "string"
+    },
+    "CURSOR_API_KEY": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Cursor Api Key"
+    },
+    "CURSOR_API_URL": {
+      "default": "https://api.cursor.sh",
+      "title": "Cursor Api Url",
+      "type": "string"
+    },
+    "MLFLOW_TRACKING_URI": {
+      "default": "./results/mlruns",
+      "title": "Mlflow Tracking Uri",
+      "type": "string"
+    },
+    "MLFLOW_REGISTRY_URI": {
+      "default": "./results/mlruns",
+      "title": "Mlflow Registry Uri",
+      "type": "string"
+    },
+    "MLFLOW_EXPERIMENT_NAME": {
+      "default": "CodexHUB-Baseline",
+      "title": "Mlflow Experiment Name",
+      "type": "string"
+    },
+    "PIPELINE_CONFIG_PATH": {
+      "default": "config/default.yaml",
+      "format": "path",
+      "title": "Pipeline Config Path",
+      "type": "string"
+    },
+    "GOVERNANCE_CONFIG_PATH": {
+      "default": "config/governance.yaml",
+      "format": "path",
+      "title": "Governance Config Path",
+      "type": "string"
+    },
+    "METRICS_CONFIG_PATH": {
+      "default": "config/metrics.yaml",
+      "format": "path",
+      "title": "Metrics Config Path",
+      "type": "string"
+    },
+    "PERFORMANCE_RESULTS_DIR": {
+      "default": "results/performance",
+      "format": "path",
+      "title": "Performance Results Dir",
+      "type": "string"
+    },
+    "AUDIT_LOG_DIR": {
+      "default": "results/audit",
+      "format": "path",
+      "title": "Audit Log Dir",
+      "type": "string"
+    },
+    "MODEL_CARD_DIR": {
+      "default": "docs/model_cards",
+      "format": "path",
+      "title": "Model Card Dir",
+      "type": "string"
+    },
+    "CURSOR_AUTO_INVOCATION_ENABLED": {
+      "default": false,
+      "title": "Cursor Auto Invocation Enabled",
+      "type": "boolean"
+    },
+    "CURSOR_MONITOR_INTERVAL": {
+      "default": 5,
+      "exclusiveMinimum": 0,
+      "title": "Cursor Monitor Interval",
+      "type": "integer"
+    },
+    "CURSOR_FILE_PATTERNS": {
+      "default": "**/*.tsx,**/*.py,**/*.md,**/*.js,**/*.ts",
+      "title": "Cursor File Patterns",
+      "type": "string"
+    },
+    "KNOWLEDGE_AUTO_LOAD": {
+      "default": false,
+      "title": "Knowledge Auto Load",
+      "type": "boolean"
+    },
+    "KNOWLEDGE_NDJSON_PATHS": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": "Brain docs cleansed .ndjson,Bundle cleansed .ndjson",
+      "title": "Knowledge Ndjson Paths"
+    },
+    "KNOWLEDGE_WATCH_INTERVAL": {
+      "anyOf": [
+        {
+          "exclusiveMinimum": 0,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Knowledge Watch Interval"
+    },
+    "MOBILE_CONTROL_ENABLED": {
+      "default": false,
+      "title": "Mobile Control Enabled",
+      "type": "boolean"
+    },
+    "MOBILE_NOTIFICATIONS_ENABLED": {
+      "default": false,
+      "title": "Mobile Notifications Enabled",
+      "type": "boolean"
+    },
+    "MOBILE_APP_PORT": {
+      "default": 3001,
+      "exclusiveMinimum": 0,
+      "title": "Mobile App Port",
+      "type": "integer"
+    },
+    "BRAIN_BLOCKS_AUTO_LOAD": {
+      "default": false,
+      "title": "Brain Blocks Auto Load",
+      "type": "boolean"
+    },
+    "BRAIN_BLOCKS_DATA_SOURCE": {
+      "default": "Brain docs cleansed .ndjson",
+      "title": "Brain Blocks Data Source",
+      "type": "string"
+    },
+    "BRAIN_BLOCKS_QUERY_DEPTH": {
+      "default": "summary",
+      "title": "Brain Blocks Query Depth",
+      "type": "string"
+    },
+    "CURSOR_PERFORMANCE_MONITORING": {
+      "default": false,
+      "title": "Cursor Performance Monitoring",
+      "type": "boolean"
+    },
+    "CURSOR_USAGE_TRACKING": {
+      "default": false,
+      "title": "Cursor Usage Tracking",
+      "type": "boolean"
+    },
+    "CURSOR_COMPLIANCE_REPORTING": {
+      "default": false,
+      "title": "Cursor Compliance Reporting",
+      "type": "boolean"
+    }
+  },
+  "title": "EnvironmentSettings",
+  "type": "object"
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,7 +16,7 @@ CodexHUB combines an Express entry point, a governance-aware Python pipeline, an
 
 ## Data & Control Flow
 
-1. **Configuration Loading** – YAML and environment variables are parsed via `src/common.config_loader`, yielding validated settings for downstream modules.
+1. **Configuration Loading** – YAML and environment variables are parsed via `src/common.config_loader`, yielding validated settings for downstream modules. Environment bundles are checked against the generated JSON Schema (`config/env.schema.json`) so CI and local runs share the same contract.
 2. **Training & Evaluation** – `src/training` loads datasets, produces reproducible splits, and emits metrics. `src/governance` enforces fairness/privacy rules using thresholds defined in `config/`.
 3. **Registry Management** – `src/registry.registry.MLflowRegistry` standardises run creation, metric logging, and model promotion inside MLflow.
 4. **Inference Delivery** – `src/inference.inference.InferenceService` hydrates the latest registry version, guards concurrency limits, and caches predictions.
@@ -30,8 +30,10 @@ CodexHUB combines an Express entry point, a governance-aware Python pipeline, an
 
 ## Operational Notes
 
-- Environment defaults now live in [`.env.example`](../.env.example), covering Cursor, knowledge ingestion, mobile control, and MLflow destinations.
+- Environment defaults now live in [`.env.example`](../.env.example), covering Cursor, knowledge ingestion, mobile control, and MLflow destinations. Regenerate the schema and validator outputs with `python scripts/generate_env_schema.py` whenever the variable set evolves.
 - Container builds install both Node and Python dependencies and expose port `4000` to align with the Express default. Use `docker run -p 4000:4000 codexhub` after `docker build` to mirror local behaviour.
 - The Makefile centralises commands (`make lint`, `make test-python`, `make status`) to coordinate the mixed-language toolchain.
+- `src/performance.cli` now supports selective skips and configurable concurrency, allowing developers to parallelise fast checks while deferring heavier audits when iterating quickly.
+- GitHub Actions enforces dependency review and secret scanning on every pull request via the `PR Security Gate` workflow, supplementing the scheduled weekly audits.
 
 Refer to [`SECURITY.md`](../SECURITY.md) for hardening guidance and the top-level [`README`](../README.md) for onboarding workflows.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -80,12 +80,16 @@ The watchers run in the background on the active event loop, so startup scripts 
 - `make quality` – Runs Node, documentation, and Python suites in one command while saving
   performance metrics to `results/performance/`.
 - `python -m src.performance.cli node-quality` – Execute only the Node.js commands (typecheck, lint,
-  tests, audit) with timing capture.
+  tests, audit) with timing capture. Pass `--skip <substring>` to omit expensive commands (for
+  example `--skip "pnpm audit"`) and `--max-workers <n>` to run independent steps in parallel when you
+  need a faster feedback loop.
 - `python -m src.performance.cli docs-quality` – Run Markdown/YAML/editorconfig linting with timing
   capture.
 - `python -m src.performance.cli python-quality` – Validate configuration bundles, execute pytest
   with coverage, run Bandit, and audit Python dependencies.
 - `python -m src.common.config_loader --json` – Emit a machine-readable report verifying pipeline,
   metrics, and governance configuration files.
+- `python -m src.common.config_loader --env .env --env config/environments/ci.env --json` – Validate
+  environment variable bundles against the shared schema and confirm defaults are applied.
 
 Always run the relevant checks before committing to maintain the mixed-language toolchain.

--- a/scripts/generate_env_schema.py
+++ b/scripts/generate_env_schema.py
@@ -1,0 +1,61 @@
+"""Generate a JSON Schema representing required CodexHUB environment variables."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Type
+
+ROOT = Path(__file__).resolve().parent.parent
+
+if TYPE_CHECKING:  # pragma: no cover - imported only for typing
+    from src.common.config_loader import EnvironmentSettings as _EnvironmentSettings
+
+
+def _load_environment_model() -> "Type[_EnvironmentSettings]":
+    if str(ROOT) not in sys.path:
+        sys.path.insert(0, str(ROOT))
+    from src.common.config_loader import EnvironmentSettings as _EnvironmentSettings
+
+    return _EnvironmentSettings
+
+
+DEFAULT_OUTPUT = Path("config/env.schema.json")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="Path where the generated schema should be written.",
+    )
+    parser.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="Number of spaces to use when pretty-printing JSON.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    EnvironmentSettings = _load_environment_model()
+    schema = EnvironmentSettings.model_json_schema(ref_template="#/$defs/{model}")
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8") as handle:
+        json.dump(schema, handle, indent=args.indent)
+        handle.write("\n")
+
+    print(f"Environment schema written to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/smoke/test_cursor_stack.py
+++ b/tests/smoke/test_cursor_stack.py
@@ -1,0 +1,80 @@
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+try:  # pragma: no cover - the real dependency exists in production
+    import aiohttp  # type: ignore  # noqa: F401
+except ImportError:  # pragma: no cover - provide a minimal stub for tests
+    sys.modules.setdefault("aiohttp", SimpleNamespace(ClientSession=object))
+
+from src.cursor import cli as cursor_cli
+
+
+@pytest.mark.asyncio()
+async def test_cursor_start_invokes_selected_subsystems(monkeypatch):
+    calls = SimpleNamespace(auto=0, knowledge=0, mobile=0, brain=0)
+
+    async def fake_auto(paths):
+        calls.auto += 1
+        assert paths == [Path(".")]
+
+    async def fake_knowledge():
+        calls.knowledge += 1
+
+    async def fake_mobile():
+        calls.mobile += 1
+
+    async def fake_brain():
+        calls.brain += 1
+
+    monkeypatch.setattr(cursor_cli, "start_cursor_auto_invocation", fake_auto)
+    monkeypatch.setattr(cursor_cli, "start_knowledge_auto_loading", fake_knowledge)
+    monkeypatch.setattr(cursor_cli, "start_mobile_app", fake_mobile)
+    monkeypatch.setattr(cursor_cli, "start_brain_blocks_integration", fake_brain)
+
+    exit_code = await cursor_cli._run_start(
+        watch=[Path(".")],
+        include_knowledge=True,
+        include_mobile=True,
+        include_brain_blocks=True,
+        stay_alive=False,
+    )
+
+    assert exit_code == 0
+    assert calls.auto == 1
+    assert calls.knowledge == 1
+    assert calls.mobile == 1
+    assert calls.brain == 1
+
+
+def test_cursor_validate_and_status(monkeypatch, capsys):
+    monkeypatch.setattr(cursor_cli, "validate_cursor_compliance", lambda: True)
+    monkeypatch.setattr(
+        cursor_cli,
+        "get_cursor_usage_report",
+        lambda: {"compliance_status": "COMPLIANT", "summary": "ok"},
+    )
+
+    assert cursor_cli._run_validate() == 0
+    assert cursor_cli._run_status() == 0
+
+    captured = capsys.readouterr().out
+    assert "COMPLIANT" in captured
+
+
+@pytest.mark.asyncio()
+async def test_cursor_rules_command(monkeypatch, capsys):
+    class DummyInvoker:
+        def get_rule_stats(self):
+            return {"rules": 2}
+
+    monkeypatch.setattr(cursor_cli, "get_auto_invoker", lambda: DummyInvoker())
+
+    assert await cursor_cli._run_rules() == 0
+    captured = capsys.readouterr().out
+    assert "rules" in captured
+
+    await asyncio.sleep(0)

--- a/tests/smoke/test_knowledge_auto_loader.py
+++ b/tests/smoke/test_knowledge_auto_loader.py
@@ -1,0 +1,48 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from src.knowledge import auto_loader
+
+
+@pytest.mark.asyncio()
+async def test_start_knowledge_auto_loading_respects_toggle(monkeypatch):
+    monkeypatch.setenv("KNOWLEDGE_AUTO_LOAD", "false")
+
+    called = False
+
+    async def fail_start():  # pragma: no cover - should not run
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(
+        auto_loader,
+        "get_auto_loader",
+        lambda: SimpleNamespace(start_auto_loading=fail_start),
+    )
+
+    await auto_loader.start_knowledge_auto_loading()
+    assert called is False
+
+
+@pytest.mark.asyncio()
+async def test_start_knowledge_auto_loading_executes_when_enabled(monkeypatch):
+    monkeypatch.delenv("KNOWLEDGE_AUTO_LOAD", raising=False)
+
+    called = False
+
+    async def start():
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(
+        auto_loader,
+        "get_auto_loader",
+        lambda: SimpleNamespace(start_auto_loading=start),
+    )
+
+    await auto_loader.start_knowledge_auto_loading()
+    assert called is True
+
+    await asyncio.sleep(0)

--- a/tests/smoke/test_mobile_app.py
+++ b/tests/smoke/test_mobile_app.py
@@ -1,0 +1,53 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from src.mobile import mobile_app
+
+
+@pytest.mark.asyncio()
+async def test_start_mobile_app_invokes_initialize(monkeypatch):
+    called = False
+
+    class DummyApp:
+        async def initialize(self):
+            nonlocal called
+            called = True
+
+    dummy = DummyApp()
+    monkeypatch.setattr(mobile_app, "get_mobile_app", lambda: dummy)
+
+    await mobile_app.start_mobile_app()
+    assert called is True
+
+
+@pytest.mark.asyncio()
+async def test_mobile_goal_roundtrip(monkeypatch):
+    class DummyGoal:
+        def __init__(self):
+            self.goal_id = "123"
+            self.title = "Demo"
+            self.description = "Desc"
+            self.priority = SimpleNamespace(value="medium")
+            self.approval_status = SimpleNamespace(value="pending")
+            self.created_at = mobile_app.datetime.now()
+
+    class DummyApp:
+        async def create_goal(self, **_: str):
+            return DummyGoal()
+
+        async def get_goals(self, *_):
+            return [DummyGoal()]
+
+    dummy = DummyApp()
+    monkeypatch.setattr(mobile_app, "get_mobile_app", lambda: dummy)
+
+    created = await mobile_app.create_goal("Demo", "Desc")
+    assert created["id"] == "123"
+    assert created["status"] == "pending"
+
+    goals = await mobile_app.get_goals()
+    assert goals[0]["title"] == "Demo"
+
+    await asyncio.sleep(0)

--- a/tests/unit/test_environment_settings.py
+++ b/tests/unit/test_environment_settings.py
@@ -1,0 +1,37 @@
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from src.common.config_loader import ConfigValidationError, load_environment
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "NODE_ENV=test\nCURSOR_AUTO_INVOCATION_ENABLED=false\n",
+        "# comment\n\nNODE_ENV=production\nCURSOR_AUTO_INVOCATION_ENABLED=true\n",
+    ],
+)
+def test_load_environment_accepts_minimal_profiles(tmp_path: Path, content: str) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text(content, encoding="utf-8")
+
+    settings = load_environment(env_file)
+
+    assert settings.node_env in {"test", "production"}
+    assert settings.cursor_auto_invocation_enabled in {True, False}
+    # Defaults should hydrate missing values so CI profiles validate.
+    assert settings.session_secret
+    assert settings.pipeline_config_path.name == "default.yaml"
+
+
+@pytest.mark.asyncio()
+async def test_load_environment_rejects_invalid_boolean(tmp_path: Path) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text("KNOWLEDGE_AUTO_LOAD=not-a-bool\n", encoding="utf-8")
+
+    with pytest.raises(ConfigValidationError):
+        load_environment(env_file)
+
+    await asyncio.sleep(0)

--- a/tests/unit/test_performance_cli.py
+++ b/tests/unit/test_performance_cli.py
@@ -15,18 +15,39 @@ def test_run_suite_records_metrics(tmp_path: Path, monkeypatch: pytest.MonkeyPat
         calls.append(command)
 
     monkeypatch.setattr(cli.subprocess, "run", _fake_run)
-    output_path = cli.run_suite("python-quality", output_dir=tmp_path)
+    output_path = cli.run_suite(
+        "python-quality",
+        output_dir=tmp_path,
+        skip=["pip_audit"],
+        max_workers=2,
+    )
     assert output_path.parent == tmp_path
     payload = json.loads(output_path.read_text(encoding="utf-8"))
     assert payload["summary"]["total_metrics"] >= 1
     assert calls, "expected commands to be executed"
+    assert all("pip_audit" not in " ".join(cmd) for cmd in calls)
+    total_metric = next(
+        metric for metric in payload["metrics"] if metric["name"].endswith("::total")
+    )
+    assert total_metric["metadata"]["skipped"] >= 1
+    assert total_metric["metadata"]["max_workers"] == 2.0
 
 
 def test_main_entrypoint(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setattr(cli.subprocess, "run", lambda command, check: None)
-    exit_code = cli.main(["docs-quality", "--output-dir", str(tmp_path)])
+    exit_code = cli.main(
+        [
+            "docs-quality",
+            "--output-dir",
+            str(tmp_path),
+            "--skip",
+            "spellcheck",
+            "--max-workers",
+            "3",
+        ]
+    )
     captured = capsys.readouterr()
     assert exit_code == 0
     assert "Performance metrics stored" in captured.out


### PR DESCRIPTION
## Summary
- add explicit environment schema validation to the shared config loader, surface a generator script, and publish the generated `config/env.schema.json`
- streamline the QA workflow by combining JavaScript checks, validating env files during Python quality, and introducing dedicated release and PR security workflows
- extend the performance CLI with skip/concurrency switches, add smoke tests for cursor/knowledge/mobile stacks, and document the new ergonomics

## Testing
- `pytest`
- `python -m ruff check src/common/config_loader.py src/performance/cli.py scripts/generate_env_schema.py tests/smoke/test_cursor_stack.py tests/smoke/test_knowledge_auto_loader.py tests/smoke/test_mobile_app.py tests/unit/test_environment_settings.py`
- `python scripts/generate_env_schema.py`


------
https://chatgpt.com/codex/tasks/task_e_68d50d97a5b883219665d53915328d13