### PR TITLE
chore: add env templates and broaden config validation

### DIFF
--- a/.env.cursor-first.example
+++ b/.env.cursor-first.example
@@ -24,27 +24,27 @@ AUDIT_LOG_DIR=results/audit
 MODEL_CARD_DIR=docs/model_cards
 
 # Automation toggles (set to "true" to enable locally)
-CURSOR_AUTO_INVOCATION_ENABLED=false
+CURSOR_AUTO_INVOCATION_ENABLED=true
 CURSOR_MONITOR_INTERVAL=5
 CURSOR_FILE_PATTERNS=**/*.tsx,**/*.py,**/*.md,**/*.js,**/*.ts
 
 # Knowledge ingestion
-KNOWLEDGE_AUTO_LOAD=false
+KNOWLEDGE_AUTO_LOAD=true
 KNOWLEDGE_NDJSON_PATHS=Brain docs cleansed .ndjson,Bundle cleansed .ndjson
 # Leave blank (or set to a positive number) to enable filesystem watching.
-KNOWLEDGE_WATCH_INTERVAL=
+KNOWLEDGE_WATCH_INTERVAL=10
 
 # Mobile controls
-MOBILE_CONTROL_ENABLED=false
-MOBILE_NOTIFICATIONS_ENABLED=false
+MOBILE_CONTROL_ENABLED=true
+MOBILE_NOTIFICATIONS_ENABLED=true
 MOBILE_APP_PORT=3001
 
 # Brain blocks integration
-BRAIN_BLOCKS_AUTO_LOAD=false
+BRAIN_BLOCKS_AUTO_LOAD=true
 BRAIN_BLOCKS_DATA_SOURCE=Brain docs cleansed .ndjson
-BRAIN_BLOCKS_QUERY_DEPTH=summary
+BRAIN_BLOCKS_QUERY_DEPTH=comprehensive
 
 # Performance monitoring
-CURSOR_PERFORMANCE_MONITORING=false
-CURSOR_USAGE_TRACKING=false
-CURSOR_COMPLIANCE_REPORTING=false
+CURSOR_PERFORMANCE_MONITORING=true
+CURSOR_USAGE_TRACKING=true
+CURSOR_COMPLIANCE_REPORTING=true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,11 @@ repos:
       - id: ruff
         args: ['--line-length=100', '--target-version=py311']
       - id: ruff-format
+  - repo: https://github.com/zricethezav/gitleaks
+    rev: v8.18.4
+    hooks:
+      - id: gitleaks
+        args: ['protect', '--staged', '--no-banner']
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.1.0
     hooks:
@@ -37,3 +42,8 @@ repos:
         entry: pnpm commitlint --edit "$1"
         language: system
         stages: [commit-msg]
+      - id: validate-configs
+        name: validate configuration schemas
+        entry: python scripts/validate_configs.py
+        language: system
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -42,18 +42,26 @@ subset of the toolchain. If you want to hydrate additional pnpm workspaces (for 
 
 ### 2. Configure environment variables
 
-Copy `.env.example` into `.env` and adjust the values to match your environment. Regenerate the
-example file with `pnpm run env:example` whenever environment variables change to keep
-documentation, automation, and templates aligned. Curated profiles now live under
+Copy the environment example that best matches your workflow and adjust the values to fit your
+machine:
+
+- `.env.example` – Minimal profile with all automation toggles disabled.
+- `.env.cursor-first.example` – Power profile with Cursor automation, knowledge syncing, mobile
+  controls, and telemetry enabled.
+
+Regenerate both templates with `pnpm run env:example` whenever environment variables change to keep
+documentation, automation, and templates aligned. Curated profiles also live under
 `config/environments/` (`development.env`, `cursor.env`, `ci.env`) so you can quickly swap between a
 minimal setup and the Cursor-heavy automation stack. Review `docs/setup.md` for a complete option
 reference and avoid committing secrets.
 
 The repository now publishes a machine-readable schema at `config/env.schema.json`. Use the shared
-validator to confirm that all required values (and their defaults) are present before committing:
+validator to confirm that all required values (and their defaults) are present before committing.
+The validator now also checks YAML overlays and curated `.env` bundles:
 
 ```bash
 python -m src.common.config_loader --env .env --env config/environments/ci.env --json
+python scripts/validate_configs.py
 ```
 
 When schema changes are required, regenerate the artifact with:

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -22,7 +22,8 @@ It covers both the structure and process for maintaining governance configuratio
 ### Editing Workflow
 
 1. Propose changes via Pull Request with context on the motivation and impact.
-2. Run `python scripts/validate_configs.py` locally to verify schema compliance.
+2. Run `python scripts/validate_configs.py` locally to verify JSON governance files, YAML overlays, and
+   environment bundles stay within the published schemas.
 3. Tag the Meta Agent and QA reviewers for approval.
 4. Update `CHANGELOG.md` and relevant ADRs describing governance shifts.
 

--- a/docs/QA_ENGINE.md
+++ b/docs/QA_ENGINE.md
@@ -51,7 +51,8 @@ dashboard_report = confidence_report(
 
 ## CLI & Automation
 
-- Run `python scripts/validate_configs.py` before commits to ensure probabilistic policies align with schemas (`qa_policies.json`).
+- Run `python scripts/validate_configs.py` before commits to ensure probabilistic policies align with schemas (`qa_policies.json`),
+  YAML overlays load correctly, and environment bundles remain valid.
 - CI executes `tests/test_probabilistic_qa.py` and `tests/test_statistics_helpers.py` to verify statistical helpers, calibration logic, and governance alignment.
 
 ## Extension Ideas

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -35,7 +35,14 @@ If you want to hydrate optional pnpm workspaces (for example the Next.js editor)
 
 ## 5. Configure environment variables
 
-Create a `.env` file (or export variables in your shell) with the following keys:
+Start from the example that matches your workflow:
+
+- `.env.example` – minimal defaults with all automation disabled.
+- `.env.cursor-first.example` – enables Cursor integrations, knowledge ingestion, and telemetry.
+
+Regenerate both files with `pnpm run env:example` after introducing new variables so the templates
+and documentation stay in sync. Create a `.env` file (or export variables in your shell) with the
+following keys:
 
 | Variable                         | Description                                                                                                     |
 | -------------------------------- | --------------------------------------------------------------------------------------------------------------- |

--- a/scripts/validate_configs.py
+++ b/scripts/validate_configs.py
@@ -1,31 +1,108 @@
 #!/usr/bin/env python3
-"""Validate governance configuration files against their JSON Schemas."""
+"""Validate configuration assets (JSON, YAML, env files) against their schemas."""
 
 from __future__ import annotations
 
 import argparse
 import json
+from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict
+from typing import Any
 
-from jsonschema import ValidationError, validate
-
-CONFIG_SCHEMA_MAP: Dict[str, str] = {
-    "governance.json": "governance.schema.json",
-    "agents.json": "agents.schema.json",
-    "qa_policies.json": "qa_policies.schema.json",
-    "qa_rules.json": "qa_rules.schema.json",
-}
+import yaml
+from jsonschema import Draft7Validator, FormatChecker, ValidationError
 
 
-def validate_file(config_dir: Path, file_name: str, schema_name: str) -> None:
-    """Validate a configuration file against its schema."""
+@dataclass(frozen=True)
+class JsonSchemaTarget:
+    """Pairs a JSON payload with the schema used to validate it."""
 
-    config_path = config_dir / file_name
-    schema_path = config_dir / schema_name
-    payload = json.loads(config_path.read_text(encoding="utf-8"))
-    schema = json.loads(schema_path.read_text(encoding="utf-8"))
-    validate(payload, schema)
+    payload: Path
+    schema: Path
+
+
+JSON_SCHEMA_TARGETS: tuple[JsonSchemaTarget, ...] = (
+    JsonSchemaTarget(Path("governance.json"), Path("governance.schema.json")),
+    JsonSchemaTarget(Path("agents.json"), Path("agents.schema.json")),
+    JsonSchemaTarget(Path("qa_policies.json"), Path("qa_policies.schema.json")),
+    JsonSchemaTarget(Path("qa_rules.json"), Path("qa_rules.schema.json")),
+)
+
+YAML_TARGETS: tuple[str, ...] = (
+    "default.yaml",
+    "governance.yaml",
+    "metrics.yaml",
+)
+
+ENV_FILES: tuple[str, ...] = ("cursor.env",)
+
+ENV_DIRS: tuple[str, ...] = ("environments",)
+
+PATH_FORMAT_CHECKER = FormatChecker()
+
+
+@PATH_FORMAT_CHECKER.checks("path")
+def _validate_path_format(value: str) -> bool:
+    """Ensure path-like strings are not empty."""
+
+    return isinstance(value, str) and value.strip() != ""
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_yaml(path: Path) -> Any:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if data is None:
+        raise ValueError("YAML file is empty")
+    return data
+
+
+def _strip_quotes(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+        return value[1:-1]
+    return value
+
+
+def _coerce_env_value(value: str) -> Any:
+    cleaned = _strip_quotes(value.strip())
+    if cleaned == "":
+        return None
+    lowered = cleaned.lower()
+    if lowered in {"true", "false"}:
+        return lowered == "true"
+    try:
+        return int(cleaned)
+    except ValueError:
+        pass
+    try:
+        return float(cleaned)
+    except ValueError:
+        pass
+    return cleaned
+
+
+def load_env(path: Path) -> dict[str, Any]:
+    values: dict[str, Any] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            raise ValueError(f"Invalid line (missing '='): {raw_line}")
+        key, raw_value = line.split("=", 1)
+        values[key.strip()] = _coerce_env_value(raw_value)
+    return values
+
+
+def iter_env_files(config_dir: Path) -> Iterable[Path]:
+    for filename in ENV_FILES:
+        yield config_dir / filename
+    for directory in ENV_DIRS:
+        for candidate in sorted((config_dir / directory).glob("*.env")):
+            yield candidate
 
 
 def main() -> int:
@@ -33,18 +110,52 @@ def main() -> int:
     parser.add_argument(
         "--config-dir", default="config", help="Directory containing configuration files"
     )
+    parser.add_argument(
+        "--env-schema", default="env.schema.json", help="Schema used to validate .env files"
+    )
     args = parser.parse_args()
+
     config_dir = Path(args.config_dir)
-    errors: Dict[str, str] = {}
-    for file_name, schema_name in CONFIG_SCHEMA_MAP.items():
+    errors: dict[str, str] = {}
+
+    for target in JSON_SCHEMA_TARGETS:
+        payload_path = config_dir / target.payload
+        schema_path = config_dir / target.schema
         try:
-            validate_file(config_dir, file_name, schema_name)
-        except (OSError, json.JSONDecodeError, ValidationError) as exc:  # type: ignore[arg-type]
-            errors[file_name] = str(exc)
+            payload = load_json(payload_path)
+            schema = load_json(schema_path)
+            Draft7Validator(schema, format_checker=PATH_FORMAT_CHECKER).validate(payload)
+        except (OSError, json.JSONDecodeError, ValidationError) as exc:
+            errors[payload_path.name] = str(exc)
+
+    for yaml_name in YAML_TARGETS:
+        yaml_path = config_dir / yaml_name
+        try:
+            load_yaml(yaml_path)
+        except (OSError, yaml.YAMLError, ValueError) as exc:
+            errors[yaml_path.name] = str(exc)
+
+    env_schema_path = config_dir / args.env_schema
+    try:
+        env_schema = load_json(env_schema_path)
+        env_validator = Draft7Validator(env_schema, format_checker=PATH_FORMAT_CHECKER)
+    except (OSError, json.JSONDecodeError, ValidationError) as exc:
+        errors[env_schema_path.name] = f"Failed to load environment schema: {exc}"
+        env_validator = None
+
+    if env_validator is not None:
+        for env_path in iter_env_files(config_dir):
+            try:
+                values = load_env(env_path)
+                env_validator.validate(values)
+            except (OSError, ValidationError, ValueError) as exc:
+                errors[env_path.name] = str(exc)
+
     if errors:
         for file_name, message in errors.items():
             print(f"Validation failed for {file_name}: {message}")
         return 1
+
     print("All configuration files validated successfully.")
     return 0
 


### PR DESCRIPTION
## Summary
- generate both minimal and cursor-first environment examples from a single source of truth
- extend configuration validation to cover YAML overlays and environment bundles
- wire secret scanning plus config validation into pre-commit and document the new workflows

## Testing
- python scripts/generate_env_example.py
- python scripts/validate_configs.py
- python -m ruff check scripts/generate_env_example.py scripts/validate_configs.py

------
https://chatgpt.com/codex/tasks/task_e_68d52d8e58048321a089618b89933d42