### PR TITLE
chore: tidy cursor automation scripts

### DIFF
--- a/scripts/bootstrap_knowledge.py
+++ b/scripts/bootstrap_knowledge.py
@@ -4,15 +4,13 @@ Knowledge Agent Bootstrap Script
 Auto-loads NDJSON knowledge sources into the Knowledge agent for immediate use.
 """
 
-import json
 import sys
 from pathlib import Path
-from typing import List, Dict, Any
 
 # Add src to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-from agents.specialist_agents import KnowledgeAgent, KnowledgeDocument
+from agents.specialist_agents import KnowledgeAgent
 from qa.qa_engine import QAEngine
 from qa.qa_event_bus import QAEventBus
 

--- a/scripts/check_cursor_environment.py
+++ b/scripts/check_cursor_environment.py
@@ -107,7 +107,7 @@ def test_cursor_connection():
             api_key=os.getenv("CURSOR_API_KEY", ""),
         )
 
-        client = CursorClient(config)
+        _client = CursorClient(config)
 
         # Test connection
         print("✅ Cursor client created successfully")

--- a/scripts/codex_cursor_startup.py
+++ b/scripts/codex_cursor_startup.py
@@ -7,9 +7,7 @@ Automatically runs when Codex starts a new task to ensure Cursor IDE is used.
 import asyncio
 import os
 import sys
-import time
 from pathlib import Path
-from typing import Dict, Any, List
 
 # Add src to path for imports
 current_dir = Path(__file__).parent.parent
@@ -60,8 +58,6 @@ async def start_cursor_integration():
             start_cursor_auto_invocation,
             get_auto_invoker,
             validate_cursor_compliance,
-            enforce_cursor_integration,
-            require_cursor_agent,
         )
         from knowledge.auto_loader import start_knowledge_auto_loading
         from mobile.mobile_app import start_mobile_app
@@ -224,11 +220,10 @@ async def main():
 
     # Setup mobile control
     try:
-        goal = await setup_mobile_control()
+        _goal = await setup_mobile_control()
         print("✅ Mobile control setup completed")
     except Exception as e:
         print(f"⚠️ Mobile control error: {e}")
-        goal = None
 
     # Enforce Cursor usage
     try:

--- a/scripts/test_cursor_integration.py
+++ b/scripts/test_cursor_integration.py
@@ -8,7 +8,6 @@ import asyncio
 import json
 import sys
 from pathlib import Path
-from typing import Dict, Any, List
 
 # Add src to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
@@ -16,13 +15,10 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 # Import all Cursor components
 from src.cursor import (
     CursorClient,
-    CursorConfig,
     AgentType,
-    CursorAutoInvoker,
     AutoInvocationRule,
     get_auto_invoker,
     start_cursor_auto_invocation,
-    enforce_cursor_integration,
     require_cursor_agent,
     validate_cursor_compliance,
     get_cursor_usage_report,
@@ -63,7 +59,7 @@ async def test_cursor_client():
         ]
 
         for agent_type in agent_types:
-            agent = client.get_agent(agent_type)
+            client.get_agent(agent_type)
             print(f"✅ {agent_type.value} agent accessible")
 
         return True
@@ -147,7 +143,7 @@ async def test_knowledge_integration():
 
         # Test brain blocks integration
         brain_blocks = get_brain_blocks_integration()
-        print("✅ Brain blocks integration accessible")
+        print(f"✅ Brain blocks integration accessible ({len(brain_blocks)} blocks)")
 
         return True
 
@@ -300,7 +296,7 @@ async def main():
     test_results["full_integration"] = await test_full_integration()
 
     # Generate report
-    report = await generate_integration_report()
+    await generate_integration_report()
 
     # Summary
     print("\n📊 INTEGRATION TEST RESULTS:")

--- a/scripts/validate_cursor_integration.py
+++ b/scripts/validate_cursor_integration.py
@@ -55,7 +55,7 @@ async def validate_integration():
         # Validate brain blocks integration
         print("6. Validating brain blocks integration...")
         brain_blocks = get_brain_blocks_integration()
-        print("✅ Brain blocks integration accessible")
+        print(f"✅ Brain blocks integration accessible ({len(brain_blocks)} blocks)")
 
         print("🎉 All Cursor integration components validated successfully!")
         return True

--- a/src/cursor/enforcement.py
+++ b/src/cursor/enforcement.py
@@ -281,7 +281,7 @@ async def _execute_with_cursor_agent(
         _global_enforcement.log_cursor_usage(
             agent_type, "execute_function", _get_file_path_from_context(), False
         )
-        raise CursorEnforcementError(f"Cursor agent execution failed: {e}")
+        raise CursorEnforcementError(f"Cursor agent execution failed: {e}") from e
 
 
 def _execute_with_cursor_agent_sync(
@@ -321,7 +321,7 @@ def _execute_with_cursor_agent_sync(
         _global_enforcement.log_cursor_usage(
             agent_type, "execute_function", _get_file_path_from_context(), False
         )
-        raise CursorEnforcementError(f"Cursor agent execution failed: {e}")
+        raise CursorEnforcementError(f"Cursor agent execution failed: {e}") from e
 
 
 def validate_cursor_compliance() -> bool:

--- a/src/governance/privacy.py
+++ b/src/governance/privacy.py
@@ -37,7 +37,7 @@ def scrub_text(text: str, config: PrivacyConfig) -> str:
 
     patterns = _compile_patterns(config)
     scrubbed = text
-    for name, pattern in patterns.items():
+    for _name, pattern in patterns.items():
         scrubbed = pattern.sub(REDACTION_TOKEN, scrubbed)
     return scrubbed
 

--- a/tests/unit/test_cursor_cli.py
+++ b/tests/unit/test_cursor_cli.py
@@ -32,7 +32,7 @@ aiohttp_stub.ClientSession = _DummySession
 aiohttp_stub.ClientTimeout = _DummyTimeout
 sys.modules.setdefault("aiohttp", aiohttp_stub)
 
-from src.cursor import cli
+from src.cursor import cli  # noqa: E402
 
 
 def test_validate_exit_codes(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- drop unused imports across cursor bootstrap and validation scripts to eliminate Ruff F401 warnings
- tighten integration diagnostics by logging brain block counts and using unused-variable conventions where necessary
- chain enforcement errors in Cursor to preserve root exceptions and quiet loop-variable lint feedback

## Testing
- python -m ruff check scripts/bootstrap_knowledge.py scripts/check_cursor_environment.py scripts/codex_cursor_startup.py scripts/test_cursor_integration.py scripts/validate_cursor_integration.py src/cursor/enforcement.py src/governance/privacy.py tests/unit/test_cursor_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68d5347a09288321ba4aca76ec0f0c8e