### PR TITLE
fix: correct Cursor auto-setup import path

### DIFF
--- a/scripts/auto_setup_cursor.py
+++ b/scripts/auto_setup_cursor.py
@@ -10,8 +10,10 @@ import os
 import sys
 from pathlib import Path
 
-# Add src to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+# Add repository root to path so `src` package can be imported
+repo_root = Path(__file__).parent.parent
+if str(repo_root) not in sys.path:
+    sys.path.insert(0, str(repo_root))
 
 
 def _is_feature_enabled(value: str | None, default: bool = True) -> bool:


### PR DESCRIPTION
## Summary
- ensure the Cursor auto-setup script adds the repository root to `sys.path`
- keep the `src` package importable during automated setup routines

## Testing
- python -m ruff check scripts/auto_setup_cursor.py

------
https://chatgpt.com/codex/tasks/task_e_68d545f323a08321adb95a5eba0517e1