### PR TITLE
feat: add context hub docs and tighten security automation

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
   schedule:
     - cron: '0 5 * * 0'
   workflow_dispatch:

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,3 @@
 #!/bin/sh
 
-pnpm lint-staged
-python -m pre_commit run --hook-stage commit --show-diff-on-failure
+pnpm run precommit:run

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,24 @@ repos:
         args:
           - --skip=**/package-lock.json
           - --ignore-words-list=afterAll,afterEach
+  - repo: https://github.com/zricethezav/gitleaks
+    rev: v8.18.4
+    hooks:
+      - id: gitleaks
+        name: gitleaks (staged diff)
+        args:
+          - --log-opts=--unified=0
+        stages: [pre-commit]
+  - repo: https://github.com/semgrep/semgrep
+    rev: v1.80.0
+    hooks:
+      - id: semgrep
+        name: semgrep security audit
+        args:
+          - --config
+          - p/security-audit
+        stages: [pre-commit]
+        pass_filenames: false
   - repo: local
     hooks:
       - id: markdownlint
@@ -32,6 +50,18 @@ repos:
         entry: pnpm exec markdownlint --config .markdownlint.json
         language: system
         files: '\\.(md|mdx)$'
+      - id: pnpm-test
+        name: pnpm test suite
+        entry: pnpm test
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+      - id: secret-scan
+        name: gitleaks full scan
+        entry: pnpm run scan:secrets -- --report-format json
+        language: system
+        pass_filenames: false
+        stages: [manual]
       - id: commitlint
         name: commitlint
         entry: pnpm commitlint --edit "$1"

--- a/README.md
+++ b/README.md
@@ -129,6 +129,20 @@ Each command is idempotent and suitable for CI usage; the aggregated `make quali
 the GitHub Actions matrix and persists timing data under `results/performance/` for use with
 `scripts/codex_status.py`. See `docs/usage.md` for additional workflow-specific helpers.
 
+### 7. Fetch repository context
+
+Use the Context Hub to gather a curated snapshot of architecture and governance docs for humans or
+automated agents. The fetch script copies the latest guidance into a portable bundle:
+
+```bash
+./scripts/fetch-context.sh .context-bundle
+ls .context-bundle
+cat .context-bundle/context-manifest.json
+```
+
+Update the documents under `docs/context/` whenever new architecture patterns or runbooks are
+introduced so the exported bundle remains authoritative.
+
 ## Documentation
 
 - [Setup Guide](docs/setup.md) – System requirements, environment bootstrapping, and dependency
@@ -138,6 +152,31 @@ the GitHub Actions matrix and persists timing data under `results/performance/` 
 - [API Reference](docs/api.md) – Available endpoints and CLI commands.
 - [Architecture](docs/architecture.md) – High-level diagrams and module responsibilities.
 - [Governance](docs/GOVERNANCE.md) – Fairness, privacy, and compliance controls.
+
+## Automated Quality Gates
+
+Husky manages the local Git hooks and delegates linting, formatting, unit tests, and security scans through `pnpm run precommit:run`. The hook executes `lint-staged`, the Python pre-commit suite, Semgrep (SAST), Gitleaks (secret scanning), and the Node.js test runner before every commit. Commit message validation is enforced via the `commit-msg` hook.
+
+To refresh the hooks after cloning or when tooling changes:
+
+```bash
+pnpm install
+pnpm run prepare
+```
+
+To run the same checks manually (for example, on CI agents without Husky), invoke:
+
+```bash
+pnpm run precommit:run
+```
+
+Secret scanning can be executed on demand across the entire Git history with:
+
+```bash
+pnpm run scan:secrets            # writes SARIF to results/security/gitleaks-report.sarif
+```
+
+Set `GITLEAKS_TOKEN` or configure Docker if you prefer running the official container image. Semgrep rules come from the `p/security-audit` policy; customise via `.semgrep.yml` if the default set is too noisy.
 
 ## Security Notes
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,12 +7,13 @@ manageable for the engineering team.
 
 ## Scanner Coverage
 
-| Scanner                                  | When It Runs                                                | Scope                                                            | Output Location                                             |
-| ---------------------------------------- | ----------------------------------------------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------- |
-| **CodeQL**                               | Scheduled weekly on `main`, on-demand via workflow dispatch | Full repository analysis for JavaScript/TypeScript and Python    | GitHub Security → Code Scanning Alerts                      |
-| **Semgrep (incremental)**                | Every pull request                                          | Only files changed in the PR compared against the base branch    | GitHub Security → Code Scanning Alerts + PR summary comment |
-| **Snyk Code**                            | Weekly schedule when `SNYK_TOKEN` secret is configured      | Full repository scan with proprietary rules                      | GitHub Security → Code Scanning Alerts                      |
-| **Dependency, secret, and audit checks** | Every pull request + weekly schedule                        | `pnpm audit`, `pip audit`, Bandit, TruffleHog, dependency review | GitHub Actions log + PR annotations                         |
+| Scanner                                  | When It Runs                                                              | Scope                                                            | Output Location                                             |
+| ---------------------------------------- | ------------------------------------------------------------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------- |
+| **CodeQL**                               | Weekly on `main`, every pull request, and on-demand via workflow dispatch | Full repository analysis for JavaScript/TypeScript and Python    | GitHub Security → Code Scanning Alerts                      |
+| **Semgrep (incremental)**                | Every pull request                                                        | Only files changed in the PR compared against the base branch    | GitHub Security → Code Scanning Alerts + PR summary comment |
+| **Snyk Code**                            | Weekly schedule when `SNYK_TOKEN` secret is configured                    | Full repository scan with proprietary rules                      | GitHub Security → Code Scanning Alerts                      |
+| **Dependency, secret, and audit checks** | Every pull request + weekly schedule                                      | `pnpm audit`, `pip audit`, Bandit, TruffleHog, dependency review | GitHub Actions log + PR annotations                         |
+| **Gitleaks**                             | Manual (`pnpm run scan:secrets`) + optional CI invocation                 | Full Git history using `scripts/scan-secrets.sh`                 | `results/security/gitleaks-report.*`                        |
 
 ### Scheduling Strategy
 
@@ -33,7 +34,8 @@ Developers should stay alert for the following issues when working in this codeb
 - **Insecure deserialization:** Avoid `eval`, `exec`, or `pickle` on untrusted data. Prefer
   safe parsers (e.g., `json.loads`) with schema validation.
 - **Improper secrets handling:** Do not commit credentials or tokens. Use environment
-  variables or secret managers. Automated secret scanning runs on each PR.
+  variables or secret managers. Automated secret scanning runs on each PR and you can perform
+  manual sweeps with `pnpm run scan:secrets` before sharing high-risk branches.
 - **Insecure defaults in configuration:** New configuration files should set secure defaults,
   enforce timeouts, and document how to override safely.
 
@@ -105,3 +107,7 @@ If you discover a vulnerability, please follow the responsible disclosure practi
 `SECURITY_CONTACT.md` (or contact the security team at security@example.com if running in an
 enterprise environment). Do not open public issues that describe exploitable flaws until a fix
 is available.
+
+### Secret Scanning Playbook
+
+Use `scripts/scan-secrets.sh [output_dir] [extra gitleaks args...]` to run ad-hoc scans. The script automatically selects a local gitleaks binary when available or falls back to the official Docker image. Provide `--redact` for reports that omit secret contents when sharing outside the security team.

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -1,0 +1,26 @@
+# Context Hub
+
+The Context Hub centralises the architectural knowledge required for automated and human
+contributors to operate effectively inside CodexHUB. It aggregates domain guidelines,
+reusable component catalogs, and operational runbooks in a predictable directory so that
+context can be fetched programmatically via `scripts/fetch-context.sh` or browsed manually by
+engineers. Every document in this folder should remain concise, link back to authoritative
+sources when available, and highlight how to apply the guidance in day-to-day development.
+
+## Directory Map
+
+| File                 | Description                                                               |
+| -------------------- | ------------------------------------------------------------------------- |
+| `design-patterns.md` | Canonical implementation patterns and anti-patterns for the codebase.     |
+| `best-practices.md`  | Consolidated coding, testing, security, and operational practices.        |
+| `api-schemas.md`     | High-level view of public APIs, shared data models, and validation flows. |
+| `getting-started.md` | Quick-start instructions for local setup, builds, and deployments.        |
+| `knowledge-graph.md` | Machine-readable summary of major subsystems and their dependencies.      |
+
+### Maintenance Rules
+
+- Update this index whenever a new context document is added.
+- Keep cross-links to existing docs (`ARCHITECTURE.md`, `SECURITY.md`, etc.) accurate so the
+  fetch script can package canonical references.
+- Note the version or date of last revision at the top of long-lived documents to help agents
+  decide when to refresh their cached knowledge.

--- a/docs/context/api-schemas.md
+++ b/docs/context/api-schemas.md
@@ -1,0 +1,34 @@
+# API Schemas & Data Models
+
+_Last updated: 2024-11-23_
+
+## HTTP Services
+
+| Service           | Path         | Description                                                | Schema Source                              |
+| ----------------- | ------------ | ---------------------------------------------------------- | ------------------------------------------ |
+| Codex CLI backend | `/healthz`   | Liveness check used by orchestrators.                      | `backend/src/middleware/health-check.ts`   |
+| Codex bridge      | `/api/plans` | Validates and stores plan definitions submitted by agents. | `codexbridge/src/schemas/plan.schema.json` |
+| Editor service    | `/api/auth`  | Issues ephemeral tokens for the Codex Editor front-end.    | `apps/editor/pages/api/auth.ts`            |
+
+All HTTP payloads should be validated through AJV schemas defined under
+`packages/automation/src/validation` or JSON Schema artifacts in `codexbridge/src/schemas/`.
+When adding new endpoints, generate a schema via `pnpm run generate:schema` (see `package.json`
+for the TypeScript JSON schema script) and document it here.
+
+## Shared Data Models
+
+- **Agent Capability Registry (`codex-meta-intelligence/src/registry`)**: Each capability exports a
+  `CapabilityDefinition` typed via `src/shared/types.ts`. Update the registry index when adding new
+  capabilities and ensure the knowledge graph references the new node.
+- **Macro Definitions (`macro_system/definitions`)**: YAML-based macros parsed via
+  `macro_system/src/loader.ts`. Validate with `yamllint` and document preconditions/outputs in this
+  file to keep the automation catalog synchronised.
+- **QA Checklists (`qa_engine/checklists`)**: Markdown checklists consumed by the QA engine. Use
+  consistent headings so the context fetch script can parse them.
+
+## Validation & Tooling
+
+- Run `pnpm run validate:configs` (defined in `scripts/validate_configs.py`) after editing schemas to
+  ensure the JSON files remain consistent.
+- Use Zod or TypeScript interfaces when bridging typed and untyped layers. Record shared types in
+  `packages/automation/src/types.ts` and update the knowledge graph accordingly.

--- a/docs/context/best-practices.md
+++ b/docs/context/best-practices.md
@@ -1,0 +1,39 @@
+# Best Practices
+
+_Last updated: 2024-11-23_
+
+## Coding Standards
+
+- **TypeScript/JavaScript**: Enforce ESLint + Prettier via Husky. Prefer named exports and
+  immutable data structures. When side-effects are necessary, wrap them in functions that
+  receive explicit dependencies to ease testing.
+- **Python**: Run Ruff before committing. Align logging through `qa_engine/common/logging.py` and
+  avoid global state; use dependency injection for services so QA harnesses can mock them.
+- **Shell scripts**: Use `set -euo pipefail` and defensive quoting. Accept a configurable output
+  directory where relevant so the scripts are composable in CI pipelines.
+
+## Testing Strategy
+
+- **Unit tests**: Co-locate tests in `tests/` with `.test.js/.ts` suffixes. Use Node's native
+  test runner for JavaScript and `pytest` for Python packages. Always include failure-path
+  coverage.
+- **Integration tests**: House complex multi-service tests under `qa_engine/` and gate them behind
+  explicit PNPM scripts so they can be opt-in for local runs.
+- **Regression checks**: Update snapshot files deliberately and document any baseline changes in
+  the PR description.
+
+## Security & Compliance
+
+- Run `pnpm run scan:secrets` before pushing to perform a full-history gitleaks scan.
+- Review CodeQL and Semgrep alerts on every PR. Document mitigation steps for accepted risks in
+  `SECURITY.md` or link to follow-up tickets.
+- Store credentials exclusively in environment variables (`.env.example` documents expected
+  variables). Use secret managers in production deployments.
+
+## Operational Practices
+
+- Trigger Turbo tasks (`pnpm turbo run <task>`) to build only affected packages during CI or
+  large refactors.
+- Prefer `pnpm` scripts over raw binaries to ensure consistent tool versions.
+- Keep context documentation updated when APIs, workflows, or quality gates change so that the
+  fetch script distributes accurate guidance to downstream agents.

--- a/docs/context/design-patterns.md
+++ b/docs/context/design-patterns.md
@@ -1,0 +1,43 @@
+# Design Patterns & Anti-Patterns
+
+_Last updated: 2024-11-23_
+
+## Preferred Architectural Patterns
+
+- **Evented micro-frontends for editors (`apps/editor/`)**: Use Next.js routing with explicit
+  module boundaries. Components should consume shared utilities via workspace imports rather
+  than relative deep-links to keep the dependency graph observable by Turbo.
+- **Agent capability encapsulation (`codex-meta-intelligence/`)**: Package each capability as a
+  pure TypeScript module exporting factories through `src/shared/types.ts`. Prefer composition
+  over inheritance and enforce immutability where possible.
+- **Automation workflows (`packages/automation/`)**: Model long-running flows as state machines
+  persisted via JSON schemas defined in `packages/automation/schemas/`. Each transition must be
+  idempotent and implement a retry/backoff policy.
+- **Python utilities (`agents/`, `qa/`)**: Follow functional programming conventions and keep
+  side-effects behind small adapter functions. Use the shared logging helpers in
+  `qa_engine/common/logging.py` for consistent observability.
+
+## Reusable Components
+
+| Component           | Location                                      | Notes                                                                                            |
+| ------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Logger utility      | `codex-meta-intelligence/src/shared/utils.ts` | Emits structured logs with correlation IDs; import instead of `console.log`.                     |
+| Schema validation   | `packages/automation/src/validation`          | Builds AJV validators for JSON payloads; update central schema when adding properties.           |
+| Cursor bootstrap    | `scripts/auto_setup_cursor.py`                | Kickstarts IDE integration and compliance enforcement.                                           |
+| Mobile app controls | `src/mobile`                                  | Provides async interfaces for remote goal management; reuse rather than duplicating API clients. |
+
+## Anti-Patterns To Avoid
+
+- **Implicit context coupling**: Do not rely on hard-coded relative paths between apps and
+  packages. Use workspace aliases defined in `tsconfig.json` or convert to shared libraries.
+- **Unchecked async operations**: Always await Promises and capture errors through the shared
+  telemetry utilities; avoid fire-and-forget tasks unless intentionally queued.
+- **Duplicated secret-handling logic**: Centralise secret resolution via the helper functions in
+  `config/secrets.ts` to keep auditing manageable.
+- **Copying build scripts**: Extend the Turbo pipeline or `Makefile` tasks instead of creating
+  ad-hoc shell scripts that drift from the canonical workflow.
+
+## Extension Guidelines
+
+When introducing new modules, document them here and update the knowledge graph so future
+contributors and automated agents can discover the new capabilities automatically.

--- a/docs/context/getting-started.md
+++ b/docs/context/getting-started.md
@@ -1,0 +1,48 @@
+# Getting Started Guide
+
+_Last updated: 2024-11-23_
+
+This guide summarises the minimum steps required to prepare a local development environment or a
+fresh CI runner for CodexHUB.
+
+## Prerequisites
+
+- Node.js 20+
+- pnpm 9+ (`corepack enable pnpm`)
+- Python 3.11 with `pipx` (for `pip-audit` and auxiliary tooling)
+- Docker (optional) for running dependent services in integration tests
+
+## Bootstrap
+
+```bash
+pnpm install
+pnpm run setup             # installs Python deps and validates configs
+python scripts/auto_setup_cursor.py  # optional: ensures Cursor integration
+```
+
+## Quality Gates
+
+Run these commands locally before opening a pull request. They mirror the automated Husky pipeline.
+
+```bash
+pnpm lint
+pnpm test
+pnpm run typecheck
+pnpm run scan:secrets      # gitleaks full-history scan
+pnpm turbo run build --filter=...
+```
+
+## CI & Deployment
+
+- **GitHub Actions**: CI entrypoint is `.github/workflows/ci.yml`. Security gates live in
+  `security-pr.yml` and `codeql.yml`.
+- **Turbo**: Use `pnpm turbo run <task>` to execute graph-aware builds/tests across workspaces. The
+  pipeline definition is stored in `turbo.json`.
+- **Docker**: `docker-compose.yml` orchestrates optional local services when running E2E tests.
+
+## Troubleshooting
+
+- Review `TROUBLESHOOTING_SETUP.md` for known issues across major platforms.
+- Run `pnpm doctor` and `python scripts/validate_configs.py` to diagnose dependency or config
+  drift.
+- For Cursor integration problems, execute `pnpm cursor:validate` to confirm compliance state.

--- a/docs/context/knowledge-graph.md
+++ b/docs/context/knowledge-graph.md
@@ -1,0 +1,44 @@
+# Knowledge Graph Snapshot
+
+_Last updated: 2024-11-23_
+
+```mermaid
+graph TD
+  CLI[src/index.js] -->|uses| Common[src/common]
+  CLI --> Automation[packages/automation]
+  CLI --> MetaIntelligence[codex-meta-intelligence]
+  Editor[apps/editor] --> SharedLibs(packages/*)
+  Automation --> QAEngine[qa_engine]
+  MetaIntelligence --> Cursor[src/cursor]
+  Cursor --> Knowledge[src/knowledge]
+  Cursor --> Mobile[src/mobile]
+  Automation --> Backend[backend]
+  Backend --> SharedLibs
+```
+
+## Node Summaries
+
+- **CLI (`src/`)**: Orchestrates command execution, delegating to automation packages and the Meta
+  Intelligence runtime.
+- **Automation Packages (`packages/automation`)**: Provides state machines, schema validators, and
+  adapters for orchestrating agent workflows.
+- **Meta Intelligence (`codex-meta-intelligence`)**: Hosts the next-generation agent architecture,
+  including capability registries, analytics, and orchestration logic.
+- **Editor (`apps/editor`)**: Next.js front-end backed by shared TypeScript utilities.
+- **Cursor Integrations (`src/cursor`, `scripts/auto_setup_cursor.py`)**: Enforce IDE usage, manage
+  compliance, and bridge to knowledge systems.
+- **Knowledge Services (`src/knowledge`)**: Supplies curated context from NDJSON assets for agents.
+- **Mobile Control (`src/mobile`)**: Provides remote orchestration features consumed by automation
+  flows.
+- **QA Engine (`qa_engine`)**: Runs scenario-based evaluations with shared logging and reporting.
+- **Backend (`backend`)**: Express middleware for health checks and service bootstrap.
+
+## Edge Semantics
+
+- **Command Invocation**: CLI triggers automation and Meta Intelligence capabilities.
+- **Shared Utilities**: Both front-end and back-end components import TypeScript utilities from
+  `packages/` to avoid duplication.
+- **Compliance Enforcement**: Meta Intelligence depends on Cursor integration to guarantee agent
+  compliance with workspace rules.
+- **Telemetry Flow**: Automation modules and Meta Intelligence publish metrics via shared analytics
+  modules, consumed by dashboards defined in `docs/architecture.md`.

--- a/package.json
+++ b/package.json
@@ -66,7 +66,12 @@
     "cursor:integration": "python scripts/bootstrap_cursor_integration.py",
     "codex:status": "python scripts/codex_status.py",
     "env:example": "python scripts/generate_env_example.py",
-    "start": "node src/index.js"
+    "start": "node src/index.js",
+    "precommit:run": "pnpm lint-staged && python -m pre_commit run --hook-stage commit --show-diff-on-failure",
+    "scan:secrets": "bash scripts/scan-secrets.sh",
+    "scan:secrets:ci": "bash scripts/scan-secrets.sh results/security",
+    "scan:sast": "python -m pre_commit run semgrep --all-files",
+    "turbo:graph": "turbo run lint test build --dry=json"
   },
   "dependencies": {
     "ajv": "^8.17.1",
@@ -112,7 +117,8 @@
     "stylelint-prettier": "^5.0.3",
     "typescript": "^5.9.2",
     "typescript-json-schema": "^0.65.1",
-    "yaml-eslint-parser": "^1.3.0"
+    "yaml-eslint-parser": "^1.3.0",
+    "turbo": "^2.3.3"
   },
   "engines": {
     "node": ">=20"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       stylelint-prettier:
         specifier: ^5.0.3
         version: 5.0.3(prettier@3.6.2)(stylelint@16.24.0(typescript@5.9.2))
+      turbo:
+        specifier: ^2.3.3
+        version: 2.5.8
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
@@ -5840,6 +5843,40 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  turbo-darwin-64@2.5.8:
+    resolution: {integrity: sha512-Dh5bCACiHO8rUXZLpKw+m3FiHtAp2CkanSyJre+SInEvEr5kIxjGvCK/8MFX8SFRjQuhjtvpIvYYZJB4AGCxNQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  turbo-darwin-arm64@2.5.8:
+    resolution: {integrity: sha512-f1H/tQC9px7+hmXn6Kx/w8Jd/FneIUnvLlcI/7RGHunxfOkKJKvsoiNzySkoHQ8uq1pJnhJ0xNGTlYM48ZaJOQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  turbo-linux-64@2.5.8:
+    resolution: {integrity: sha512-hMyvc7w7yadBlZBGl/bnR6O+dJTx3XkTeyTTH4zEjERO6ChEs0SrN8jTFj1lueNXKIHh1SnALmy6VctKMGnWfw==}
+    cpu: [x64]
+    os: [linux]
+
+  turbo-linux-arm64@2.5.8:
+    resolution: {integrity: sha512-LQELGa7bAqV2f+3rTMRPnj5G/OHAe2U+0N9BwsZvfMvHSUbsQ3bBMWdSQaYNicok7wOZcHjz2TkESn1hYK6xIQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  turbo-windows-64@2.5.8:
+    resolution: {integrity: sha512-3YdcaW34TrN1AWwqgYL9gUqmZsMT4T7g8Y5Azz+uwwEJW+4sgcJkIi9pYFyU4ZBSjBvkfuPZkGgfStir5BBDJQ==}
+    cpu: [x64]
+    os: [win32]
+
+  turbo-windows-arm64@2.5.8:
+    resolution: {integrity: sha512-eFC5XzLmgXJfnAK3UMTmVECCwuBcORrWdewoiXBnUm934DY6QN8YowC/srhNnROMpaKaqNeRpoB5FxCww3eteQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  turbo@2.5.8:
+    resolution: {integrity: sha512-5c9Fdsr9qfpT3hA0EyYSFRZj1dVVsb6KIWubA9JBYZ/9ZEAijgUEae0BBR/Xl/wekt4w65/lYLTFaP3JmwSO8w==}
+    hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -12632,6 +12669,33 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  turbo-darwin-64@2.5.8:
+    optional: true
+
+  turbo-darwin-arm64@2.5.8:
+    optional: true
+
+  turbo-linux-64@2.5.8:
+    optional: true
+
+  turbo-linux-arm64@2.5.8:
+    optional: true
+
+  turbo-windows-64@2.5.8:
+    optional: true
+
+  turbo-windows-arm64@2.5.8:
+    optional: true
+
+  turbo@2.5.8:
+    optionalDependencies:
+      turbo-darwin-64: 2.5.8
+      turbo-darwin-arm64: 2.5.8
+      turbo-linux-64: 2.5.8
+      turbo-linux-arm64: 2.5.8
+      turbo-windows-64: 2.5.8
+      turbo-windows-arm64: 2.5.8
 
   type-check@0.4.0:
     dependencies:

--- a/scripts/fetch-context.sh
+++ b/scripts/fetch-context.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+OUTPUT_DIR=${1:-"$ROOT_DIR/.context-bundle"}
+
+CONTEXT_PATHS=(
+  "AGENT.md"
+  "AGENTS.md"
+  "ARCHITECTURE.md"
+  "README.md"
+  "SECURITY.md"
+  "docs/context"
+  "docs/architecture.md"
+  "docs/setup.md"
+  "docs/usage.md"
+  "docs/api.md"
+  "docs/GOVERNANCE.md"
+  "scripts/fetch-context.sh"
+  "scripts/scan-secrets.sh"
+  "scripts/auto_setup_cursor.py"
+  "package.json"
+  "pnpm-workspace.yaml"
+  "turbo.json"
+  ".pre-commit-config.yaml"
+  ".husky"
+)
+
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+
+MANIFEST="$OUTPUT_DIR/context-manifest.json"
+{
+  echo '{'
+  echo '  "generatedAt": '"\"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\""','
+  echo '  "root": '"\"$ROOT_DIR\""','
+  echo '  "files": ['
+} >"$MANIFEST"
+
+first_entry=true
+for path in "${CONTEXT_PATHS[@]}"; do
+  SOURCE_PATH="$ROOT_DIR/$path"
+  if [[ ! -e "$SOURCE_PATH" ]]; then
+    echo "[fetch-context] Skipping missing path: $path" >&2
+    continue
+  fi
+
+  DEST_PATH="$OUTPUT_DIR/$path"
+  mkdir -p "$(dirname "$DEST_PATH")"
+  cp -R "$SOURCE_PATH" "$DEST_PATH"
+
+  if [[ "$first_entry" = true ]]; then
+    first_entry=false
+  else
+    echo ',' >>"$MANIFEST"
+  fi
+
+  if [[ -d "$SOURCE_PATH" ]]; then
+    ENTRY_TYPE="directory"
+    ENTRY_SIZE=$(du -sk "$SOURCE_PATH" | awk '{print $1 * 1024}')
+  else
+    ENTRY_TYPE="file"
+    ENTRY_SIZE=$(stat -c%s "$SOURCE_PATH")
+  fi
+
+  printf '    {"path": "%s", "type": "%s", "size": %s}' \
+    "$path" "$ENTRY_TYPE" "$ENTRY_SIZE" >>"$MANIFEST"
+done
+
+echo '' >>"$MANIFEST"
+echo '  ]' >>"$MANIFEST"
+echo '}' >>"$MANIFEST"
+
+echo "Context bundle created at: $OUTPUT_DIR"
+echo "Manifest written to: $MANIFEST"

--- a/scripts/scan-secrets.sh
+++ b/scripts/scan-secrets.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+DEFAULT_REPORT_DIR="$ROOT_DIR/results/security"
+
+if [[ $# -gt 0 ]]; then
+  case "$1" in
+    --)
+      shift
+      ;;
+    -* )
+      # treat as option; keep default report dir
+      ;;
+    * )
+      DEFAULT_REPORT_DIR=${1%/}
+      shift
+      ;;
+  esac
+fi
+
+DEFAULT_REPORT_PATH="$DEFAULT_REPORT_DIR/gitleaks-report.sarif"
+mkdir -p "$DEFAULT_REPORT_DIR"
+
+ARGS=("$@")
+FORMAT_SET=false
+REPORT_SET=false
+OUTPUT_PATH="$DEFAULT_REPORT_PATH"
+
+for ((i = 0; i < ${#ARGS[@]}; i++)); do
+  arg="${ARGS[$i]}"
+  case "$arg" in
+    --report-format*)
+      FORMAT_SET=true
+      ;;
+    --report-path)
+      REPORT_SET=true
+      if (( i + 1 < ${#ARGS[@]} )); then
+        OUTPUT_PATH="${ARGS[$((i + 1))]}"
+      fi
+      ;;
+    --report-path=*)
+      REPORT_SET=true
+      OUTPUT_PATH="${arg#*=}"
+      ;;
+  esac
+done
+
+if [[ "$FORMAT_SET" = false ]]; then
+  ARGS+=("--report-format" "sarif")
+fi
+
+if [[ "$REPORT_SET" = false ]]; then
+  ARGS+=("--report-path" "$DEFAULT_REPORT_PATH")
+  OUTPUT_PATH="$DEFAULT_REPORT_PATH"
+fi
+
+if [[ ! "$OUTPUT_PATH" = /* ]]; then
+  OUTPUT_PATH="$ROOT_DIR/$OUTPUT_PATH"
+fi
+
+run_gitleaks() {
+  if command -v gitleaks >/dev/null 2>&1; then
+    gitleaks detect --source "$ROOT_DIR" --log-opts="--all" "${ARGS[@]}"
+  elif command -v docker >/dev/null 2>&1; then
+    local docker_args=("${ARGS[@]}")
+    local docker_path="/repo/${OUTPUT_PATH#$ROOT_DIR/}"
+    for ((i = 0; i < ${#docker_args[@]}; i++)); do
+      case "${docker_args[$i]}" in
+        --report-path)
+          if (( i + 1 < ${#docker_args[@]} )); then
+            docker_args[$((i + 1))]="$docker_path"
+          fi
+          ;;
+        --report-path=*)
+          docker_args[$i]="--report-path=$docker_path"
+          ;;
+      esac
+    done
+    docker run --rm -v "$ROOT_DIR:/repo" zricethezav/gitleaks:latest \
+      detect --source=/repo --log-opts="--all" "${docker_args[@]}"
+  else
+    echo "gitleaks is not installed and Docker is unavailable. Install gitleaks from https://github.com/gitleaks/gitleaks/releases." >&2
+    exit 1
+  fi
+}
+
+run_gitleaks
+
+echo "Gitleaks report written to $OUTPUT_PATH"

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "lint": {
+      "outputs": []
+    },
+    "test": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+    "typecheck": {
+      "dependsOn": ["^typecheck"],
+      "outputs": []
+    },
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", "build/**", "out/**"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a Context Hub documentation suite with patterns, APIs, onboarding, and a repository knowledge graph
- provide a fetch-context script plus turbo pipeline and Husky/pre-commit updates for tests, semgrep, and gitleaks integration
- extend security guidance, CodeQL coverage, and README instructions for automated quality gates and secret scanning

## Testing
- pnpm lint
- pnpm test
- pnpm run typecheck
- pnpm run scan:sast

------
https://chatgpt.com/codex/tasks/task_e_68d55527e5408321bf5fe484d076ba79