### PR TITLE
Fix Cursor bootstrap dependency guidance

### DIFF
--- a/AUDIT_REPORT_FINAL.md
+++ b/AUDIT_REPORT_FINAL.md
@@ -185,7 +185,7 @@ CodexHUB demonstrates a **comprehensive multi-agent architecture** with extensiv
 
 ### **🔧 Recommended Actions:**
 
-1. **Install Dependencies**: `pip install aiohttp watchdog pydantic`
+1. **Install Dependencies**: `pip install aiohttp watchfiles pydantic`
 2. **Configure Environment**: Ensure CURSOR_API_KEY is set in Codex environment
 3. **Test Integration**: Run `python scripts/simple_cursor_startup.py` for validation
 4. **Monitor Performance**: Use performance monitoring for optimization

--- a/cursor/PNPM_CURSOR_INTEGRATION.md
+++ b/cursor/PNPM_CURSOR_INTEGRATION.md
@@ -94,7 +94,7 @@ packages:
 {
   "dependencies": {
     "aiohttp": "^3.9.0",      # Async HTTP client for Cursor API
-    "watchdog": "^3.0.0",     # File watching for auto-invocation
+    "watchfiles": "^0.24.0",   # File watching for auto-invocation
     "pydantic": "^2.5.0"      # Data validation for Cursor requests
   }
 }

--- a/cursor/requirements-cursor.txt
+++ b/cursor/requirements-cursor.txt
@@ -5,7 +5,7 @@
 aiohttp>=3.9.0
 
 # File watching for auto-invocation
-watchdog>=3.0.0
+watchfiles>=0.24.0
 
 # Data validation for Cursor requests
 pydantic>=2.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+aiohttp==3.12.15
 mlflow==3.4.0
 pydantic==2.11.9
 pandas==2.3.2

--- a/scripts/auto_setup_cursor.py
+++ b/scripts/auto_setup_cursor.py
@@ -72,12 +72,21 @@ async def auto_start_cursor_integration() -> bool:
                 validate_cursor_compliance,
             )
         except ModuleNotFoundError as exc:
-            print("⚠️ Cursor integration package is unavailable.")
-            print("   Skipping auto-start until the package is installed.")
-            print(f"   Details: {exc}")
+            missing_module = getattr(exc, "name", str(exc))
+            print("⚠️ Cursor integration dependency is unavailable.")
+            print(
+                "   Install required Python packages with: "
+                "python -m pip install -r cursor/requirements-cursor.txt"
+            )
+            print("   Skipping auto-start until the dependency is installed.")
+            print(f"   Missing module: {missing_module}")
             return False
         except ImportError as exc:  # pragma: no cover - defensive logging
             print("⚠️ Failed to import Cursor integration dependencies.")
+            print(
+                "   Verify Python requirements via "
+                "python -m pip install -r cursor/requirements-cursor.txt"
+            )
             print("   Skipping auto-start until the package issues are resolved.")
             print(f"   Details: {exc}")
             return False

--- a/scripts/setup_pnpm_cursor.py
+++ b/scripts/setup_pnpm_cursor.py
@@ -5,11 +5,9 @@ Configures pnpm workspace and dependencies for Cursor integration.
 """
 
 import json
-import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Dict, Any, List
 
 
 def check_pnpm_installed():
@@ -45,7 +43,7 @@ def install_pnpm_dependencies():
             return False
 
         # Install Cursor-specific dependencies
-        cursor_deps = ["aiohttp@^3.9.0", "watchdog@^3.0.0", "pydantic@^2.5.0"]
+        cursor_deps = ["aiohttp@^3.9.0", "watchfiles@^0.24.0", "pydantic@^2.5.0"]
 
         for dep in cursor_deps:
             result = subprocess.run(["pnpm", "add", dep], capture_output=True, text=True)

--- a/scripts/simple_cursor_startup.py
+++ b/scripts/simple_cursor_startup.py
@@ -90,7 +90,7 @@ def check_python_dependencies():
 
     print("🐍 Checking Python Dependencies...")
 
-    required_packages = ["aiohttp", "watchdog", "pydantic"]
+    required_packages = ["aiohttp", "watchfiles", "pydantic"]
     missing_packages = []
 
     for package in required_packages:


### PR DESCRIPTION
## Summary
- add the missing aiohttp runtime dependency to the Python requirements so the Cursor client can initialize
- align Cursor dependency documentation and setup scripts to use watchfiles instead of the incorrect watchdog package
- surface actionable installation guidance when auto_setup_cursor.py encounters missing dependencies

## Testing
- python -m ruff check scripts/auto_setup_cursor.py scripts/simple_cursor_startup.py scripts/setup_pnpm_cursor.py
- python scripts/auto_setup_cursor.py

------
https://chatgpt.com/codex/tasks/task_e_68d55d3108bc83219988c0625d07895f