### PR TITLE
Add scheduled gitleaks scan and metrics playbook

### DIFF
--- a/.github/workflows/scheduled_security.yml
+++ b/.github/workflows/scheduled_security.yml
@@ -35,6 +35,14 @@ jobs:
       - name: Bandit
         run: bandit -q -r macro_system meta_agent qa -x macro_system/tests,meta_agent/tests,tests
 
+      - name: Run Gitleaks secret scan
+        run: bash scripts/scan-secrets.sh --report-format sarif --report-path results/security/gitleaks-report.sarif
+
+      - name: Upload Gitleaks SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results/security/gitleaks-report.sarif
+
       - name: Check for Snyk token
         id: snyk_token
         run: |

--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ Secret scanning can be executed on demand across the entire Git history with:
 pnpm run scan:secrets            # writes SARIF to results/security/gitleaks-report.sarif
 ```
 
+The scheduled GitHub Actions security workflow now executes the same `scripts/scan-secrets.sh`
+wrapper weekly and uploads the SARIF report alongside audit, Bandit, and Snyk scans so leaked
+credentials are surfaced even when developers forget to run the hook locally.
+
 Set `GITLEAKS_TOKEN` or configure Docker if you prefer running the official container image. Semgrep rules come from the `p/security-audit` policy; customise via `.semgrep.yml` if the default set is too noisy.
 
 ## Security Notes

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ manageable for the engineering team.
 | **Semgrep (incremental)**                | Every pull request                                                        | Only files changed in the PR compared against the base branch    | GitHub Security → Code Scanning Alerts + PR summary comment |
 | **Snyk Code**                            | Weekly schedule when `SNYK_TOKEN` secret is configured                    | Full repository scan with proprietary rules                      | GitHub Security → Code Scanning Alerts                      |
 | **Dependency, secret, and audit checks** | Every pull request + weekly schedule                                      | `pnpm audit`, `pip audit`, Bandit, TruffleHog, dependency review | GitHub Actions log + PR annotations                         |
-| **Gitleaks**                             | Manual (`pnpm run scan:secrets`) + optional CI invocation                 | Full Git history using `scripts/scan-secrets.sh`                 | `results/security/gitleaks-report.*`                        |
+| **Gitleaks**                             | Weekly scheduled workflow + manual (`pnpm run scan:secrets`) invocations  | Full Git history using `scripts/scan-secrets.sh`                 | `results/security/gitleaks-report.*`                        |
 
 ### Scheduling Strategy
 
@@ -110,4 +110,4 @@ is available.
 
 ### Secret Scanning Playbook
 
-Use `scripts/scan-secrets.sh [output_dir] [extra gitleaks args...]` to run ad-hoc scans. The script automatically selects a local gitleaks binary when available or falls back to the official Docker image. Provide `--redact` for reports that omit secret contents when sharing outside the security team.
+Use `scripts/scan-secrets.sh [output_dir] [extra gitleaks args...]` to run ad-hoc scans. The script automatically selects a local gitleaks binary when available or falls back to the official Docker image. Provide `--redact` for reports that omit secret contents when sharing outside the security team. When the scheduled GitHub Actions job detects a leak, rotate the affected credential immediately, purge it from git history if necessary (e.g., via `git filter-repo`), and replace the usage with environment variables or your chosen secret manager before closing the alert.

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -9,13 +9,14 @@ sources when available, and highlight how to apply the guidance in day-to-day de
 
 ## Directory Map
 
-| File                 | Description                                                               |
-| -------------------- | ------------------------------------------------------------------------- |
-| `design-patterns.md` | Canonical implementation patterns and anti-patterns for the codebase.     |
-| `best-practices.md`  | Consolidated coding, testing, security, and operational practices.        |
-| `api-schemas.md`     | High-level view of public APIs, shared data models, and validation flows. |
-| `getting-started.md` | Quick-start instructions for local setup, builds, and deployments.        |
-| `knowledge-graph.md` | Machine-readable summary of major subsystems and their dependencies.      |
+| File                        | Description                                                               |
+| --------------------------- | ------------------------------------------------------------------------- |
+| `design-patterns.md`        | Canonical implementation patterns and anti-patterns for the codebase.     |
+| `best-practices.md`         | Consolidated coding, testing, security, and operational practices.        |
+| `api-schemas.md`            | High-level view of public APIs, shared data models, and validation flows. |
+| `getting-started.md`        | Quick-start instructions for local setup, builds, and deployments.        |
+| `knowledge-graph.md`        | Machine-readable summary of major subsystems and their dependencies.      |
+| `continuous-improvement.md` | Metrics, reporting cadence, and guidance for sustaining repo health.      |
 
 ### Maintenance Rules
 

--- a/docs/context/continuous-improvement.md
+++ b/docs/context/continuous-improvement.md
@@ -1,0 +1,45 @@
+# Continuous Improvement & Metrics Playbook
+
+_Last updated: 2024-09-27_
+
+## Overview
+
+CodexHUB tracks a set of operational metrics to make sure automated scans, build
+pipelines, and manual reviews continue to deliver compounding benefits. This
+playbook consolidates the signals emitted by the existing tooling and explains
+how to extend them when new agents or services join the monorepo.
+
+## Core Metrics
+
+| Metric                                | Source                                           | Storage                                                  | Usage                                                                        |
+| ------------------------------------- | ------------------------------------------------ | -------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Build duration                        | `make quality` + GitHub Actions artifacts        | `results/performance/*.json`                             | Detect regressions in CI wall time and update Turbo task graph definitions.  |
+| Lint/test failure rate                | Husky pre-commit logs, CI annotations            | GitHub Actions dashboard                                 | Highlight noisy rules that require suppression or refactoring.               |
+| Secret scan findings                  | `scripts/scan-secrets.sh` SARIF, Gitleaks alerts | `results/security/gitleaks-report.sarif` + Code Scanning | Drive credential rotations and coverage of high-risk paths.                  |
+| SAST findings (Semgrep, CodeQL, Snyk) | CI security workflows                            | GitHub Security tab                                      | Prioritise remediation with severity/effort rubric defined in `SECURITY.md`. |
+| Agent compliance                      | `python scripts/auto_setup_cursor.py` telemetry  | `results/performance/cursor-status.json`                 | Ensure Cursor enforcement remains active for every automation task.          |
+
+## Reporting Cadence
+
+1. **Weekly security digest:** Triggered by the scheduled security workflow. Export
+   SARIF summaries and circulate high/critical findings with proposed owners.
+2. **Bi-weekly quality review:** Compare `results/performance/` timing deltas across
+   the last four `make quality` runs. Update Turbo dependencies or caching strategy
+   when durations climb >10% week-over-week.
+3. **Monthly governance sync:** Refresh the knowledge bundle with
+   `scripts/fetch-context.sh` and ensure docs in `docs/context/` reflect the latest
+   architecture, policies, and playbooks.
+
+## Extending the Pipeline
+
+- **New packages:** Add their build/test tasks to `turbo.json` and extend the
+  metrics table with package-specific telemetry targets.
+- **Additional scanners:** Wire SARIF outputs through the same upload step used by
+  CodeQL/Snyk/Gitleaks so findings land in the central dashboard.
+- **Agent orchestration:** Record acceptance/rejection stats for AI-assist
+  suggestions in `results/performance/cursor-status.json` to refine future review
+  workflows. Update this document with any new data sources as they appear.
+
+Keeping this playbook current gives both humans and automated agents a single
+source of truth for measuring progress and planning the next iteration of
+improvements.


### PR DESCRIPTION
## Summary
- run the gitleaks wrapper inside the scheduled security workflow and upload the SARIF report for visibility
- document the recurring secret scan in README/SECURITY and describe the rotation steps to take when a leak is detected
- add a continuous improvement playbook to the context hub so agents have an authoritative metrics and reporting cadence reference

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d5660db0a48321a57cbf616a003c5a