### PR TITLE
feat: implement stage3 dashboard and plugins

### DIFF
--- a/google-news-drive-sync/README.md
+++ b/google-news-drive-sync/README.md
@@ -6,10 +6,14 @@ folder for downstream consumption by analytics teams, AI researchers and automat
 
 ## Features
 
-- Fetches the latest headlines from a configurable news API using per-topic queries.
-- Formats articles into Markdown documents with consistent structure and metadata.
-- Uploads generated documents to a target Google Drive folder via OAuth credentials.
-- Provides a lightweight scheduler for recurring synchronisation jobs.
+- Asynchronously fetches headlines from NewsAPI with per-topic concurrency.
+- Aggregates RSS feeds alongside API responses, deduplicates the combined results and records them in a SQLite repository.
+- Plugin loader discovers custom fetchers at runtime so new sources can be added without touching core code.
+- FastAPI dashboard exposes `/articles`, `/sources`, `/status`, `/metrics` and `/health` endpoints for downstream systems.
+- React-based UI (under `ui/`) provides a searchable, accessible feed for analysts and stakeholders.
+- Persists seen articles and stores pipeline metrics to drive both deduplication and observability dashboards.
+- Encrypts optional Drive tokens at rest and loads secrets from environment variables or `.env` files.
+- Uses APScheduler (with a thread-based fallback) for recurring or cron-based synchronisation.
 
 ## Project Structure
 
@@ -26,25 +30,50 @@ folder for downstream consumption by analytics teams, AI researchers and automat
 │   └── run_sync.sh
 ├── src/
 │   ├── __init__.py
+│   ├── api_router.py
+│   ├── article_repository.py
+│   ├── cache.py
 │   ├── document_formatter.py
 │   ├── drive_client.py
 │   ├── main.py
+│   ├── monitor.py
 │   ├── news_fetcher.py
+│   ├── plugin_manager.py
+│   ├── plugins/
+│   │   └── sample_plugin.py
+│   ├── rss_fetcher.py
 │   ├── scheduler.py
+│   ├── server.py
 │   └── utils.py
+├── ui/
+│   ├── package.json
+│   └── src/
+│       ├── App.tsx
+│       ├── components/
+│       │   ├── ArticleList.tsx
+│       │   ├── ArticlePreview.tsx
+│       │   └── SearchBar.tsx
+│       └── main.tsx
 └── tests/
     ├── __init__.py
+    ├── test_api_router.py
+    ├── test_article_repository.py
+    ├── test_cache.py
     ├── test_document_formatter.py
     ├── test_drive_client.py
     ├── test_integration.py
+    ├── test_monitor.py
     ├── test_news_fetcher.py
-    └── test_scheduler.py
+    ├── test_plugin_manager.py
+    ├── test_rss_fetcher.py
+    ├── test_scheduler.py
+    └── test_server.py
 ```
 
 ## Getting Started
 
-1. Create and populate `config/config.yaml` with your API keys, query parameters and Google Drive settings. See the example in this
-   repository for the expected structure. **Do not commit real credentials.**
+1. Create and populate `config/config.yaml` with your API keys, query parameters, RSS feeds and Google Drive settings. See the example in this
+   repository for the expected structure. **Do not commit real credentials.** You may also reference a `.env` file for sensitive values.
 2. Install dependencies:
 
 ```bash
@@ -61,6 +90,34 @@ python -m src.main --config config/config.yaml
 
 The script loads the configuration, fetches news articles, formats them and uploads the resulting document to Google Drive.
 
+### Dashboard & API
+
+Expose the FastAPI dashboard and Prometheus metrics alongside the scheduler by supplying the `--serve` flag:
+
+```bash
+python -m src.main --config config/config.yaml --serve --host 0.0.0.0 --port 8080
+```
+
+The API surfaces:
+
+- `GET /articles` – Paginated article feed with optional `source` and `q` filters.
+- `GET /sources` – Distinct list of configured sources.
+- `GET /status` – Combined repository statistics and monitoring counters.
+- `GET /metrics` – Prometheus-formatted metrics.
+- `GET /health` – Lightweight health probe for orchestrators.
+
+### Web UI
+
+The React dashboard in `ui/` consumes the API and renders a searchable news feed with accessible components:
+
+```bash
+cd ui
+pnpm install
+pnpm run dev
+```
+
+The UI uses Tailwind CSS and Material-inspired components with keyboard navigation, ARIA labelling and high-contrast theme support.
+
 ## Running Tests
 
 Execute the unit test suite and lint checks before contributing changes:
@@ -68,20 +125,24 @@ Execute the unit test suite and lint checks before contributing changes:
 ```bash
 python -m pytest tests/
 flake8 src/
+python -m ruff check src/ tests/
 ```
 
 ## Scheduling
 
-To run the synchronisation at regular intervals, configure the `update_interval_minutes` value in `config/config.yaml`. You can
-also invoke `scripts/run_sync.sh` from cron or another scheduling system to trigger the pipeline on demand.
+To run the synchronisation at regular intervals, configure `scheduler.update_interval_minutes` or provide a cron expression via
+`scheduler.cron` in `config/config.yaml`. APScheduler powers the recurring execution when available; otherwise the project falls
+back to a lightweight threaded scheduler. `scripts/run_sync.sh` remains available for ad-hoc execution from cron or other
+orchestrators.
 
 ## Security Considerations
 
-- Store API keys and OAuth credentials outside version control (e.g., environment variables or secret managers).
-- Respect the terms of service for the news API and Google Drive.
-- Limit the number of fetched articles to stay within API rate limits and avoid excessive Drive storage usage.
+- Store API keys and OAuth credentials outside version control (e.g., environment variables, `.env` files excluded from commits or secret managers).
+- Provide a `TOKEN_ENCRYPTION_KEY` environment variable (or configure `secrets.encryption_key`) to encrypt stored Drive tokens.
+- Respect the terms of service for the news API and Google Drive while limiting article volume to stay within rate limits and storage budgets.
 
 ## Future Enhancements
 
-Stage 2 and Stage 3 will extend the project with asynchronous fetching, multi-source aggregation, user-facing dashboards and a
-plugin architecture for new sources.
+- Ship optional summarisation plugins that use LLMs to condense long-form articles before upload.
+- Extend the dashboard with authentication and per-user preferences.
+- Introduce performance and load tests for the FastAPI layer alongside bundle-size budgets for the UI.

--- a/google-news-drive-sync/config/config.yaml
+++ b/google-news-drive-sync/config/config.yaml
@@ -12,6 +12,11 @@ news_api:
   page_size: 20
   max_articles: 50
 
+sources:
+  rss:
+    - 'https://hnrss.org/frontpage'
+  rss_limit_per_feed: 10
+
 document:
   format: markdown
   timezone: UTC
@@ -19,6 +24,35 @@ document:
 drive:
   folder_name: 'Shared News Feed'
   oauth_credentials_path: 'credentials.json'
+  token_storage_path: '../cache/drive_token.enc'
 
 scheduler:
+  enabled: true
   update_interval_minutes: 180
+  timezone: UTC
+  cron: null
+
+cache:
+  path: '../cache/articles.db'
+  retention_days: 14
+
+repository:
+  enabled: true
+  path: '../cache/articles.db'
+
+plugins:
+  enabled: false
+  packages:
+    - 'src.plugins.sample_plugin'
+  paths: []
+  settings:
+    sample:
+      enabled: false
+
+server:
+  host: '127.0.0.1'
+  port: 8000
+
+secrets:
+  env_file: '../.env'
+  encryption_key_env: 'TOKEN_ENCRYPTION_KEY'

--- a/google-news-drive-sync/metadata/stage.json
+++ b/google-news-drive-sync/metadata/stage.json
@@ -1,13 +1,12 @@
 {
-  "stage": "stage1",
+  "stage": "stage3",
   "stage_complete": true,
-  "task_id": "stage1",
+  "task_id": "stage3",
   "variants_compared": true,
   "tests_pass": true,
-  "security_risks_identified": [
-    "API key exposure",
-    "credential leakage",
-    "DoS via unbounded fetch"
-  ],
-  "mitigation_plans": ["Use env vars for secrets", "OAuth token refresh", "Rate limiting"]
+  "security_risks_identified": ["XSS in dashboard", "Plugin execution risks"],
+  "mitigation_plans": [
+    "Sanitise all user input",
+    "Sandbox plugins and review code before activation"
+  ]
 }

--- a/google-news-drive-sync/src/__init__.py
+++ b/google-news-drive-sync/src/__init__.py
@@ -1,10 +1,17 @@
 """Google News Drive Sync package exports."""
 
+from .api_router import fetch_all_articles
+from .article_repository import ArticleRepository
 from .main import main
-from .news_fetcher import NewsArticle, fetch_news
+from .news_fetcher import NewsArticle, fetch_news, fetch_news_async
+from .server import create_app
 
 __all__ = [
     "main",
     "NewsArticle",
+    "ArticleRepository",
+    "create_app",
     "fetch_news",
+    "fetch_news_async",
+    "fetch_all_articles",
 ]

--- a/google-news-drive-sync/src/api_router.py
+++ b/google-news-drive-sync/src/api_router.py
@@ -1,0 +1,154 @@
+"""Coordinate fetching articles from multiple sources."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Dict, Iterable, List, Sequence
+
+from .cache import ArticleCache
+from .news_fetcher import NewsArticle, fetch_news_async
+from .monitor import MonitoringClient
+from .rss_fetcher import fetch_rss_async
+from .plugin_manager import discover_plugins, execute_plugins
+
+logger = logging.getLogger(__name__)
+
+
+async def _gather_results(
+    tasks: Sequence[asyncio.Task],
+    sources: Sequence[str],
+    monitor: MonitoringClient | None,
+) -> List[NewsArticle]:
+    articles: List[NewsArticle] = []
+    gathered = await asyncio.gather(*tasks, return_exceptions=True)
+    for source_name, result in zip(sources, gathered, strict=False):
+        if isinstance(result, Exception):
+            logger.exception("Source %s failed", source_name, exc_info=result)
+            if monitor is not None:
+                monitor.record_error(source_name, result)
+            continue
+        articles.extend(result)
+        if monitor is not None:
+            monitor.record_articles(source_name, len(result))
+    return articles
+
+
+def _deduplicate(articles: Iterable[NewsArticle]) -> List[NewsArticle]:
+    seen: Dict[str, NewsArticle] = {}
+    for article in articles:
+        key = article.url or article.title
+        if not key:
+            continue
+        if key not in seen:
+            seen[key] = article
+    return list(seen.values())
+
+
+async def fetch_all_articles(
+    config: Dict[str, Any],
+    *,
+    cache: ArticleCache | None = None,
+    monitor: MonitoringClient | None = None,
+    news_fetcher: Callable[..., Awaitable[List[NewsArticle]]] | None = None,
+    rss_fetcher: Callable[..., Awaitable[List[NewsArticle]]] | None = None,
+    base_dir: Path | None = None,
+) -> List[NewsArticle]:
+    """Fetch articles from all configured sources concurrently."""
+
+    news_fetcher = news_fetcher or fetch_news_async
+    rss_fetcher = rss_fetcher or fetch_rss_async
+
+    tasks: List[asyncio.Task] = []
+    labels: List[str] = []
+
+    news_cfg = config.get("news_api", {})
+    api_key = news_cfg.get("api_key")
+    if api_key:
+        base_query = {
+            "language": news_cfg.get("language", "en"),
+            "country": news_cfg.get("country"),
+            "pageSize": news_cfg.get(
+                "page_size",
+                news_cfg.get("pageSize", 20),
+            ),
+        }
+        max_articles = news_cfg.get("max_articles")
+        topics: Sequence[str] = news_cfg.get("topics") or []
+        base_url = news_cfg.get(
+            "base_url",
+            "https://newsapi.org/v2/top-headlines",
+        )
+        tasks.append(
+            asyncio.create_task(
+                news_fetcher(
+                    api_key,
+                    base_query,
+                    base_url=base_url,
+                    max_articles=max_articles,
+                    topics=topics,
+                )
+            )
+        )
+        labels.append("news_api")
+    else:
+        logger.warning("news_api.api_key missing; skipping NewsAPI source")
+
+    sources_cfg = config.get("sources", {})
+    rss_feeds: Sequence[str] = []
+    rss_limit = None
+    if sources_cfg:
+        rss_feeds = sources_cfg.get("rss", [])
+        rss_limit = sources_cfg.get("rss_limit_per_feed")
+    if rss_feeds:
+        tasks.append(asyncio.create_task(rss_fetcher(rss_feeds, limit_per_feed=rss_limit)))
+        labels.append("rss")
+
+    plugin_articles: List[NewsArticle] = []
+    plugin_cfg = config.get("plugins", {})
+    plugin_enabled = plugin_cfg.get("enabled", True)
+
+    if not tasks and not (plugin_enabled and plugin_cfg):
+        logger.warning("No news sources configured; returning empty result set")
+        return []
+
+    articles: List[NewsArticle] = []
+    if tasks:
+        articles.extend(await _gather_results(tasks, labels, monitor))
+
+    if plugin_enabled and plugin_cfg:
+        package_names: Sequence[str] = plugin_cfg.get("packages", [])
+        file_paths: Sequence[str] = plugin_cfg.get("paths", [])
+        base_path = base_dir or Path.cwd()
+        resolved_paths: List[Path] = []
+        for item in file_paths:
+            candidate = Path(item)
+            if not candidate.is_absolute():
+                candidate = base_path / candidate
+            resolved_paths.append(candidate)
+        plugins = discover_plugins(
+            packages=package_names,
+            paths=resolved_paths,
+        )
+        if plugins:
+            plugin_settings = plugin_cfg.get("settings", {})
+            plugin_articles = await execute_plugins(
+                plugins,
+                plugin_settings,
+                cache=cache,
+                monitor=monitor,
+            )
+            articles.extend(plugin_articles)
+
+    deduped = _deduplicate(articles)
+
+    if cache is not None:
+        fresh = cache.filter_new(deduped)
+        cache.record(fresh)
+        return fresh
+
+    return deduped
+
+
+__all__ = ["fetch_all_articles"]

--- a/google-news-drive-sync/src/article_repository.py
+++ b/google-news-drive-sync/src/article_repository.py
@@ -1,0 +1,184 @@
+"""Persistence layer for storing aggregated articles."""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, List, Optional
+
+from .news_fetcher import NewsArticle
+
+
+@dataclass(frozen=True)
+class ArticleRecord:
+    """Serializable representation of an article stored in SQLite."""
+
+    id: str
+    title: str
+    description: str | None
+    url: str
+    source: str | None
+    published_at: datetime | None
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "description": self.description,
+            "url": self.url,
+            "source": self.source,
+            "published_at": self.published_at.isoformat()
+            if isinstance(self.published_at, datetime)
+            else None,
+        }
+
+
+class ArticleRepository:
+    """Store article metadata for the dashboard and API."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._initialise()
+
+    @contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
+        connection = sqlite3.connect(self.path)
+        try:
+            yield connection
+        finally:
+            connection.close()
+
+    def _initialise(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS article_records (
+                    id TEXT PRIMARY KEY,
+                    title TEXT NOT NULL,
+                    description TEXT,
+                    url TEXT NOT NULL,
+                    source TEXT,
+                    published_at TEXT,
+                    inserted_at TEXT NOT NULL
+                )
+                """
+            )
+            conn.commit()
+
+    def _article_id(self, article: NewsArticle) -> str:
+        return article.url or article.title
+
+    def persist(self, articles: Iterable[NewsArticle]) -> None:
+        now = datetime.utcnow().isoformat()
+        payload: List[tuple[str, str, str | None, str, str | None, str | None, str]] = []
+        for article in articles:
+            identifier = self._article_id(article)
+            if not identifier:
+                continue
+            published = article.published_at.isoformat() if article.published_at else None
+            payload.append(
+                (
+                    identifier,
+                    article.title,
+                    article.description,
+                    article.url,
+                    article.source,
+                    published,
+                    now,
+                )
+            )
+
+        if not payload:
+            return
+
+        with self._connect() as conn:
+            conn.executemany(
+                (
+                    "INSERT OR REPLACE INTO article_records "
+                    "(id, title, description, url, source, "
+                    "published_at, inserted_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
+                ),
+                payload,
+            )
+            conn.commit()
+
+    def list_articles(
+        self,
+        *,
+        limit: Optional[int] = None,
+        source: str | None = None,
+        query: str | None = None,
+    ) -> List[ArticleRecord]:
+        clauses: List[str] = []
+        params: List[object] = []
+
+        if source:
+            clauses.append("source = ?")
+            params.append(source)
+        if query:
+            like = f"%{query.lower()}%"
+            clauses.append("(lower(title) LIKE ? OR lower(description) LIKE ?)")
+            params.extend([like, like])
+
+        statement = [
+            "SELECT id, title, description, url, source, published_at",
+            "FROM article_records",
+        ]
+        if clauses:
+            statement.append("WHERE " + " AND ".join(clauses))
+        statement.append("ORDER BY COALESCE(published_at, inserted_at) DESC")
+        if limit:
+            statement.append("LIMIT ?")
+            params.append(limit)
+
+        query_str = " ".join(statement)
+        with self._connect() as conn:
+            rows = conn.execute(query_str, params).fetchall()
+
+        results: List[ArticleRecord] = []
+        for row in rows:
+            published = None
+            if row[5]:
+                published = datetime.fromisoformat(row[5])
+            results.append(
+                ArticleRecord(
+                    id=row[0],
+                    title=row[1],
+                    description=row[2],
+                    url=row[3],
+                    source=row[4],
+                    published_at=published,
+                )
+            )
+        return results
+
+    def list_sources(self) -> List[str]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                (
+                    "SELECT DISTINCT source FROM article_records "
+                    "WHERE source IS NOT NULL ORDER BY source"
+                )
+            ).fetchall()
+        return [row[0] for row in rows if row[0]]
+
+    def count(self) -> int:
+        with self._connect() as conn:
+            row = conn.execute("SELECT COUNT(*) FROM article_records").fetchone()
+        return int(row[0]) if row else 0
+
+    def latest_published(self) -> datetime | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                ("SELECT published_at FROM article_records " "ORDER BY published_at DESC LIMIT 1")
+            ).fetchone()
+        if not row or row[0] is None:
+            return None
+        return datetime.fromisoformat(row[0])
+
+
+__all__ = ["ArticleRecord", "ArticleRepository"]

--- a/google-news-drive-sync/src/cache.py
+++ b/google-news-drive-sync/src/cache.py
@@ -1,0 +1,88 @@
+"""Lightweight caching utilities to avoid duplicate uploads."""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from contextlib import contextmanager
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Iterable, Iterator, List
+
+from .news_fetcher import NewsArticle
+
+
+class ArticleCache:
+    """Store seen article identifiers in a SQLite database."""
+
+    def __init__(self, path: str | Path, *, retention_days: int = 7) -> None:
+        self.path = Path(path)
+        self.retention_days = retention_days
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._initialise()
+
+    @contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
+        connection = sqlite3.connect(self.path)
+        try:
+            yield connection
+        finally:
+            connection.close()
+
+    def _initialise(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS articles (
+                    id TEXT PRIMARY KEY,
+                    url TEXT NOT NULL,
+                    published_at TEXT
+                )
+                """
+            )
+            conn.commit()
+
+    def _article_key(self, article: NewsArticle) -> str:
+        data = article.url or article.title
+        digest = hashlib.sha256(data.encode("utf-8")).hexdigest()
+        return digest
+
+    def filter_new(self, articles: Iterable[NewsArticle]) -> List[NewsArticle]:
+        fresh: List[NewsArticle] = []
+        with self._connect() as conn:
+            for article in articles:
+                if not article.url and not article.title:
+                    continue
+                key = self._article_key(article)
+                cursor = conn.execute(
+                    "SELECT 1 FROM articles WHERE id = ?",
+                    (key,),
+                )
+                if cursor.fetchone():
+                    continue
+                fresh.append(article)
+        return fresh
+
+    def record(self, articles: Iterable[NewsArticle]) -> None:
+        now = datetime.utcnow()
+        cutoff = now - timedelta(days=self.retention_days)
+        with self._connect() as conn:
+            conn.executemany(
+                ("INSERT OR REPLACE INTO articles " "(id, url, published_at) VALUES (?, ?, ?)"),
+                [
+                    (
+                        self._article_key(article),
+                        article.url or article.title,
+                        (article.published_at or now).isoformat(),
+                    )
+                    for article in articles
+                ],
+            )
+            conn.execute(
+                "DELETE FROM articles WHERE published_at < ?",
+                (cutoff.isoformat(),),
+            )
+            conn.commit()
+
+
+__all__ = ["ArticleCache"]

--- a/google-news-drive-sync/src/main.py
+++ b/google-news-drive-sync/src/main.py
@@ -3,49 +3,136 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import logging
+import os
+import threading
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
+from .api_router import fetch_all_articles
+from .cache import ArticleCache
 from .document_formatter import create_document
-from .drive_client import DriveClient, DriveClientError
-from .news_fetcher import fetch_news
-from .scheduler import schedule
-from .utils import load_config, setup_logging
+from .drive_client import DriveClient, DriveClientError, TokenStorage
+from .news_fetcher import NewsArticle
+from .article_repository import ArticleRepository
+from .monitor import MonitoringClient
+from .scheduler import SchedulerHandle, schedule
+from .utils import (
+    TokenEncryptor,
+    load_config,
+    load_env_file,
+    setup_logging,
+)
+from .server import create_app, run_server
 
 logger = logging.getLogger(__name__)
 
 
-def _run_once(config: Dict[str, Any]) -> None:
-    news_cfg = config.get("news_api", {})
+def _build_cache(
+    config: Dict[str, Any],
+    base_dir: Path,
+) -> ArticleCache | None:
+    cache_cfg = config.get("cache", {})
+    if cache_cfg and not cache_cfg.get("enabled", True):
+        return None
+    default_path = base_dir.parent / "cache" / "articles.db"
+    cache_path = cache_cfg.get("path", default_path)
+    cache_path = Path(cache_path)
+    if not cache_path.is_absolute():
+        cache_path = base_dir / cache_path
+    retention = int(cache_cfg.get("retention_days", 7))
+    return ArticleCache(cache_path, retention_days=retention)
+
+
+def _resolve_encryptor(config: Dict[str, Any]) -> Optional[TokenEncryptor]:
+    secrets_cfg = config.get("secrets", {})
+    password = secrets_cfg.get("encryption_key")
+    env_var = secrets_cfg.get("encryption_key_env", "TOKEN_ENCRYPTION_KEY")
+    password = password or os.environ.get(env_var)
+    if not password:
+        return None
+    try:
+        return TokenEncryptor.from_password(password)
+    except ValueError:
+        logger.warning("Invalid encryption key; Drive tokens will not be encrypted")
+        return None
+
+
+async def _collect_articles(
+    config: Dict[str, Any],
+    cache: ArticleCache | None,
+    monitor: MonitoringClient | None,
+    base_dir: Path,
+) -> list[NewsArticle]:
+    articles = await fetch_all_articles(
+        config,
+        cache=cache,
+        monitor=monitor,
+        base_dir=base_dir,
+    )
+    if monitor is not None:
+        monitor.record_articles("aggregated", len(articles))
+    return articles
+
+
+def _create_drive_client(
+    drive_cfg: Dict[str, Any],
+    encryptor: TokenEncryptor | None,
+    base_dir: Path,
+) -> DriveClient:
+    credentials_path = drive_cfg.get(
+        "oauth_credentials_path",
+        "credentials.json",
+    )
+    credentials_path = Path(credentials_path)
+    if not credentials_path.is_absolute():
+        credentials_path = base_dir / credentials_path
+
+    token_storage: TokenStorage | None = None
+    token_path = drive_cfg.get("token_storage_path")
+    if token_path:
+        token_path = Path(token_path)
+        if not token_path.is_absolute():
+            token_path = base_dir / token_path
+        token_storage = TokenStorage(token_path, encryptor=encryptor)
+
+    return DriveClient(
+        str(credentials_path),
+        token_storage=token_storage,
+    )
+
+
+def _run_once(
+    config: Dict[str, Any],
+    *,
+    cache: ArticleCache | None,
+    monitor: MonitoringClient | None,
+    encryptor: TokenEncryptor | None,
+    base_dir: Path,
+    repository: ArticleRepository | None,
+) -> None:
     document_cfg = config.get("document", {})
     drive_cfg = config.get("drive", {})
 
-    api_key = news_cfg.get("api_key")
-    if not api_key:
-        raise ValueError("news_api.api_key is required")
+    if monitor is not None:
+        monitor.start_run()
 
-    topics = news_cfg.get("topics") or []
-    query = {
-        "language": news_cfg.get("language", "en"),
-        "country": news_cfg.get("country"),
-        "pageSize": news_cfg.get("page_size", 20),
-    }
-    if topics:
-        query["q"] = " OR ".join(topics)
-    if news_cfg.get("max_articles"):
-        query["max_articles"] = news_cfg["max_articles"]
+    try:
+        articles = asyncio.run(_collect_articles(config, cache, monitor, base_dir))
+    except Exception:
+        if monitor is not None:
+            monitor.complete_run(status="error")
+        raise
 
-    base_url = news_cfg.get("base_url", "https://newsapi.org/v2/top-headlines")
-    articles = fetch_news(
-        api_key,
-        query,
-        base_url=base_url,
-        max_articles=news_cfg.get("max_articles"),
-    )
     if not articles:
-        logger.warning("No articles retrieved; skipping upload.")
+        logger.warning("No new articles retrieved; skipping upload.")
+        if monitor is not None:
+            monitor.complete_run(status="skipped")
         return
+
+    if repository is not None:
+        repository.persist(articles)
 
     filename, content = create_document(
         articles,
@@ -53,14 +140,16 @@ def _run_once(config: Dict[str, Any]) -> None:
         timezone_name=document_cfg.get("timezone"),
     )
 
-    credentials_key = "oauth_credentials_path"
-    credentials_path = drive_cfg.get(credentials_key, "credentials.json")
-    client = DriveClient(credentials_path)
+    client = _create_drive_client(drive_cfg, encryptor, base_dir)
     client.authenticate()
     folder_name = drive_cfg.get("folder_name", "News")
     folder_id = client.get_or_create_folder(folder_name)
     client.upload_document(folder_id, filename, content)
     logger.info("Uploaded document %s", filename)
+    if monitor is not None:
+        monitor.record_document_upload()
+        monitor.complete_run(status="success")
+        monitor.emit()
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -75,13 +164,64 @@ def main(argv: list[str] | None = None) -> None:
         action="store_true",
         help="Run the pipeline once and skip scheduling.",
     )
+    parser.add_argument(
+        "--serve",
+        action="store_true",
+        help="Expose the FastAPI dashboard while the scheduler runs.",
+    )
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Hostname for the dashboard server.",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Port for the dashboard server.",
+    )
     args = parser.parse_args(argv)
 
     setup_logging()
-    config = load_config(args.config)
+    config_path = Path(args.config)
+    config = load_config(config_path)
+
+    secrets_cfg = config.get("secrets", {})
+    env_file = secrets_cfg.get("env_file")
+    if env_file:
+        env_path = Path(env_file)
+        if not env_path.is_absolute():
+            env_path = config_path.parent / env_file
+        load_env_file(env_path)
+
+    base_dir = config_path.parent
+    cache = _build_cache(config, base_dir)
+    repository_cfg = config.get("repository", {})
+    repository: ArticleRepository | None = None
+    if repository_cfg.get("enabled", True):
+        repo_path = repository_cfg.get("path")
+        if repo_path:
+            repo_path = Path(repo_path)
+            if not repo_path.is_absolute():
+                repo_path = base_dir / repo_path
+        else:
+            repo_path = base_dir / "../cache/articles.db"
+        repository = ArticleRepository(repo_path)
+    monitor = MonitoringClient()
+    encryptor = _resolve_encryptor(config)
+    server_cfg = config.get("server", {})
+    server_host = server_cfg.get("host", args.host)
+    server_port = int(server_cfg.get("port", args.port))
 
     try:
-        _run_once(config)
+        _run_once(
+            config,
+            cache=cache,
+            monitor=monitor,
+            encryptor=encryptor,
+            base_dir=base_dir,
+            repository=repository,
+        )
     except DriveClientError:
         logger.exception("Drive upload failed")
         raise
@@ -90,13 +230,48 @@ def main(argv: list[str] | None = None) -> None:
         return
 
     scheduler_cfg = config.get("scheduler", {})
-    interval = scheduler_cfg.get("update_interval_minutes")
-    if not interval:
+    enabled = scheduler_cfg.get("enabled", True)
+    if not enabled:
         return
 
-    schedule(lambda: _run_once(config), int(interval))
+    interval = scheduler_cfg.get("update_interval_minutes")
+    cron_cfg = scheduler_cfg.get("cron")
+    timezone = scheduler_cfg.get("timezone")
 
-    # Keep the main thread alive when scheduling is enabled.
+    if not interval and not cron_cfg:
+        logger.warning("Scheduler enabled but no interval or cron specified; skipping")
+        return
+
+    def job() -> None:
+        _run_once(
+            config,
+            cache=cache,
+            monitor=monitor,
+            encryptor=encryptor,
+            base_dir=base_dir,
+            repository=repository,
+        )
+
+    handle: SchedulerHandle = schedule(
+        job,
+        interval_minutes=int(interval) if interval else None,
+        cron=cron_cfg,
+        timezone=timezone,
+    )
+
+    server_thread: threading.Thread | None = None
+    if args.serve:
+        app = create_app(repository=repository, monitor=monitor)
+
+        def _serve() -> None:  # pragma: no cover - interactive behaviour
+            run_server(app, host=server_host, port=server_port)
+
+        server_thread = threading.Thread(
+            target=_serve,
+            daemon=True,
+        )
+        server_thread.start()
+
     try:  # pragma: no cover - interactive run loop
         import time
 
@@ -104,6 +279,7 @@ def main(argv: list[str] | None = None) -> None:
             time.sleep(3600)
     except KeyboardInterrupt:
         logger.info("Received shutdown signal; exiting.")
+        handle.shutdown()
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/google-news-drive-sync/src/monitor.py
+++ b/google-news-drive-sync/src/monitor.py
@@ -1,0 +1,126 @@
+"""Monitoring utilities for the sync pipeline."""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MonitoringSnapshot:
+    """Serializable snapshot of collected metrics."""
+
+    articles_processed: int = 0
+    errors: int = 0
+    source_counts: Dict[str, int] = field(default_factory=dict)
+    documents_uploaded: int = 0
+    runs: int = 0
+    last_run_started: Optional[datetime] = None
+    last_run_completed: Optional[datetime] = None
+    last_status: str = "idle"
+
+
+class MonitoringClient:
+    """Collect lightweight metrics during pipeline execution."""
+
+    def __init__(self) -> None:
+        self._articles_processed = 0
+        self._errors = 0
+        self._sources: Counter[str] = Counter()
+        self._documents_uploaded = 0
+        self._runs = 0
+        self._last_run_started: datetime | None = None
+        self._last_run_completed: datetime | None = None
+        self._last_status: str = "idle"
+
+    def record_articles(self, source: str, count: int) -> None:
+        self._articles_processed += count
+        self._sources[source] += count
+        logger.debug("Recorded %s articles from %s", count, source)
+
+    def record_error(self, source: str, error: Exception) -> None:
+        self._errors += 1
+        logger.error("Error in source %s: %s", source, error)
+
+    def start_run(self) -> None:
+        self._last_run_started = datetime.utcnow()
+        self._last_status = "running"
+
+    def complete_run(self, *, status: str = "success") -> None:
+        self._runs += 1
+        self._last_run_completed = datetime.utcnow()
+        self._last_status = status
+
+    def record_document_upload(self) -> None:
+        self._documents_uploaded += 1
+
+    def snapshot(self) -> MonitoringSnapshot:
+        return MonitoringSnapshot(
+            articles_processed=self._articles_processed,
+            errors=self._errors,
+            source_counts=dict(self._sources),
+            documents_uploaded=self._documents_uploaded,
+            runs=self._runs,
+            last_run_started=self._last_run_started,
+            last_run_completed=self._last_run_completed,
+            last_status=self._last_status,
+        )
+
+    def emit(self) -> None:
+        snap = self.snapshot()
+        logger.info(
+            "Metrics - articles: %s, errors: %s, sources: %s",
+            snap.articles_processed,
+            snap.errors,
+            snap.source_counts,
+        )
+
+    def metrics(self) -> Dict[str, object]:
+        snap = self.snapshot()
+        return {
+            "articles_processed": snap.articles_processed,
+            "errors": snap.errors,
+            "documents_uploaded": snap.documents_uploaded,
+            "runs": snap.runs,
+            "last_run_started": snap.last_run_started.isoformat()
+            if snap.last_run_started
+            else None,
+            "last_run_completed": snap.last_run_completed.isoformat()
+            if snap.last_run_completed
+            else None,
+            "last_status": snap.last_status,
+            "source_counts": snap.source_counts,
+        }
+
+    def render_prometheus(self) -> str:
+        snap = self.snapshot()
+        lines = [
+            "# TYPE gnds_articles_processed_total counter",
+            f"gnds_articles_processed_total {snap.articles_processed}",
+            "# TYPE gnds_errors_total counter",
+            f"gnds_errors_total {snap.errors}",
+            "# TYPE gnds_documents_uploaded_total counter",
+            f"gnds_documents_uploaded_total {snap.documents_uploaded}",
+            "# TYPE gnds_runs_total counter",
+            f"gnds_runs_total {snap.runs}",
+        ]
+        for source, count in snap.source_counts.items():
+            lines.append(f'gnds_source_articles_total{{source="{source}"}} {count}')
+        if snap.last_run_started:
+            lines.append(
+                ("gnds_last_run_started_timestamp " f"{snap.last_run_started.timestamp()}")
+            )
+        if snap.last_run_completed:
+            lines.append(
+                ("gnds_last_run_completed_timestamp " f"{snap.last_run_completed.timestamp()}")
+            )
+        lines.append(f'gnds_last_status{{status="{snap.last_status}"}} 1')
+        return "\n".join(lines)
+
+
+__all__ = ["MonitoringClient", "MonitoringSnapshot"]

--- a/google-news-drive-sync/src/news_fetcher.py
+++ b/google-news-drive-sync/src/news_fetcher.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Dict, Iterable, List, Optional
-
-import requests
-from requests import Response
+from typing import Any, Dict, Iterable, List, Optional, Sequence
 
 logger = logging.getLogger(__name__)
+
+
+try:  # pragma: no cover - optional dependency used in production
+    import aiohttp
+except Exception:  # pragma: no cover - aiohttp may be unavailable during tests
+    aiohttp = None  # type: ignore[assignment]
 
 
 class NewsFetcherError(RuntimeError):
@@ -52,32 +56,107 @@ class NewsArticle:
         )
 
 
-def _handle_error(response: Response) -> None:
-    if response.status_code == 429:
-        raise NewsFetcherError("Rate limit exceeded while fetching news.")
-    try:
-        response.raise_for_status()
-    except requests.HTTPError as exc:  # pragma: no cover
-        raise NewsFetcherError("News API request failed") from exc
+async def _request_page(
+    session: Any,
+    *,
+    base_url: str,
+    params: Dict[str, Any],
+    api_key: str,
+    timeout: int,
+) -> Dict[str, Any]:
+    """Perform an HTTP GET request for a page of articles."""
+
+    headers = {"X-Api-Key": api_key}
+    async with session.get(
+        base_url,
+        params=params,
+        headers=headers,
+        timeout=timeout,
+    ) as response:
+        status = getattr(response, "status", None)
+        if status == 429:
+            raise NewsFetcherError("Rate limit exceeded while fetching news.")
+        if status is not None and status >= 400:
+            text = await response.text()
+            message = f"News API request failed with status {status}: {text}"
+            raise NewsFetcherError(message)
+        return await response.json()
 
 
-def fetch_news(
+def _parse_articles(payload: Dict[str, Any]) -> List[NewsArticle]:
+    raw_articles: Iterable[Dict[str, Any]] = payload.get("articles") or []
+    parsed: List[NewsArticle] = []
+    for item in raw_articles:
+        if not isinstance(item, dict):
+            continue
+        article = NewsArticle.from_payload(item)
+        if not article.title or not article.url:
+            continue
+        parsed.append(article)
+    return parsed
+
+
+async def _collect_topic(
+    session: Any,
+    api_key: str,
+    base_url: str,
+    params: Dict[str, Any],
+    *,
+    topic: str | None,
+    limit: Optional[int],
+    timeout: int,
+    max_pages: int,
+) -> List[NewsArticle]:
+    topic_params = dict(params)
+    if topic:
+        topic_params["q"] = topic
+
+    articles: List[NewsArticle] = []
+    total_results: Optional[int] = None
+    current_page = 1
+
+    while True:
+        topic_params["page"] = current_page
+        payload = await _request_page(
+            session,
+            base_url=base_url,
+            params=topic_params,
+            api_key=api_key,
+            timeout=timeout,
+        )
+
+        if total_results is None:
+            total_results = payload.get("totalResults")
+
+        batch = _parse_articles(payload)
+        articles.extend(batch)
+
+        if limit and len(articles) >= limit:
+            return articles[:limit]
+        if not batch:
+            break
+        if total_results is not None and len(articles) >= total_results:
+            break
+
+        current_page += 1
+        if current_page > max_pages:
+            break
+
+    return articles
+
+
+async def fetch_news_async(
     api_key: str,
     query: Dict[str, Any],
     *,
-    session: Optional[requests.Session] = None,
     base_url: str = "https://newsapi.org/v2/top-headlines",
     max_articles: Optional[int] = None,
+    topics: Optional[Sequence[str]] = None,
+    session: Any | None = None,
+    timeout: int = 10,
+    max_pages: int = 5,
 ) -> List[NewsArticle]:
-    """Fetch news articles from the configured API.
-
-    Args:
-        api_key: API key for the news provider.
-        query: Dictionary of query parameters (e.g., topics, language).
-        session: Optional requests session for connection reuse.
-        base_url: API endpoint to query.
-        max_articles: Optional hard limit on articles to fetch.
-    """
+    """Fetch news articles concurrently for each configured topic."""
 
     if not api_key:
         raise ValueError("API key is required to fetch news.")
@@ -85,54 +164,104 @@ def fetch_news(
     params = dict(query)
     page_size = int(params.get("pageSize", params.get("page_size", 20)))
     params.setdefault("pageSize", page_size)
+    params.pop("q", None)  # topic-specific queries are handled per task
 
+    topics = topics or []
     limit = max_articles or int(params.get("max_articles", 0)) or None
-    articles: List[NewsArticle] = []
-    current_page = 1
-    session_to_use = session or requests.Session()
-    total_results: Optional[int] = None
 
-    while True:
-        params["page"] = current_page
-        logger.debug("Requesting news page %s", current_page)
+    if session is None:
+        if aiohttp is None:
+            raise NewsFetcherError(
+                ("aiohttp is required for asynchronous fetching " "but is not installed.")
+            )
 
-        response = session_to_use.get(
-            base_url,
-            params=params,
-            timeout=10,
-            headers={"X-Api-Key": api_key},
+        # pragma: no cover - requires aiohttp
+        async with aiohttp.ClientSession() as auto_session:
+            return await fetch_news_async(
+                api_key,
+                params,
+                base_url=base_url,
+                max_articles=limit,
+                topics=topics,
+                session=auto_session,
+                timeout=timeout,
+                max_pages=max_pages,
+            )
+
+    tasks = []
+    task_topics: Sequence[str | None] = topics or [None]
+    per_topic_limit: Optional[int] = None
+    if limit and task_topics:
+        per_topic_limit = max(1, limit // len(task_topics))
+
+    for topic in task_topics:
+        tasks.append(
+            asyncio.create_task(
+                _collect_topic(
+                    session,
+                    api_key,
+                    base_url,
+                    params,
+                    topic=topic,
+                    limit=per_topic_limit,
+                    timeout=timeout,
+                    max_pages=max_pages,
+                )
+            )
         )
-        _handle_error(response)
-        payload = response.json()
 
-        if total_results is None:
-            total_results = payload.get("totalResults")
+    articles: List[NewsArticle] = []
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    for result in results:
+        if isinstance(result, Exception):
+            logger.exception("Topic fetch failed", exc_info=result)
+            continue
+        articles.extend(result)
 
-        raw_articles: Iterable[Dict[str, Any]] = payload.get("articles") or []
-        batch: List[NewsArticle] = []
-        for item in raw_articles:
-            if not isinstance(item, dict):
-                continue
-            article = NewsArticle.from_payload(item)
-            if not article.title or not article.url:
-                continue
-            batch.append(article)
+    articles.sort(
+        key=lambda item: item.published_at or datetime.min,
+        reverse=True,
+    )
+    if limit:
+        articles = articles[:limit]
 
-        articles.extend(batch)
-
-        if limit and len(articles) >= limit:
-            articles = articles[:limit]
-            break
-
-        if not batch:
-            break
-
-        if total_results is not None and len(articles) >= total_results:
-            break
-
-        current_page += 1
-        if current_page > 5:  # Safety cap for Stage 1
-            break
-
-    logger.info("Fetched %s articles", len(articles))
+    logger.info(
+        "Fetched %s articles across %s topics",
+        len(articles),
+        len(task_topics),
+    )
     return articles
+
+
+def fetch_news(
+    api_key: str,
+    query: Dict[str, Any],
+    *,
+    base_url: str = "https://newsapi.org/v2/top-headlines",
+    max_articles: Optional[int] = None,
+    topics: Optional[Sequence[str]] = None,
+    session: Any | None = None,
+    timeout: int = 10,
+    max_pages: int = 5,
+) -> List[NewsArticle]:
+    """Synchronous wrapper around :func:`fetch_news_async`."""
+
+    coroutine = fetch_news_async(
+        api_key,
+        query,
+        base_url=base_url,
+        max_articles=max_articles,
+        topics=topics,
+        session=session,
+        timeout=timeout,
+        max_pages=max_pages,
+    )
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coroutine)
+
+    raise RuntimeError(
+        ("fetch_news cannot be invoked from an active event loop; " "use fetch_news_async instead.")
+    )

--- a/google-news-drive-sync/src/plugin_manager.py
+++ b/google-news-drive-sync/src/plugin_manager.py
@@ -1,0 +1,121 @@
+"""Utilities for loading and executing news plugins."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import importlib.util
+import inspect
+import logging
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Dict, Iterable, List, Sequence
+
+from .news_fetcher import NewsArticle
+from .plugins import NewsPlugin, PluginError
+
+logger = logging.getLogger(__name__)
+
+
+def _load_module(path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    if spec is None or spec.loader is None:
+        raise PluginError(f"Unable to load plugin from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[call-arg]
+    return module
+
+
+def _iter_candidates(module: ModuleType) -> Iterable[NewsPlugin]:
+    for attribute in module.__dict__.values():
+        if inspect.isclass(attribute) and issubclass(attribute, object):
+            if hasattr(attribute, "fetch") and hasattr(attribute, "name"):
+                instance = attribute()  # type: ignore[call-arg]
+                if isinstance(instance, NewsPlugin):
+                    yield instance
+        elif isinstance(attribute, NewsPlugin):
+            yield attribute
+
+
+def discover_plugins(
+    *,
+    packages: Sequence[str] | None = None,
+    paths: Sequence[Path] | None = None,
+) -> List[NewsPlugin]:
+    """Discover plugin instances from *packages* and file *paths*."""
+
+    plugins: List[NewsPlugin] = []
+
+    for module_name in packages or []:
+        try:
+            module = importlib.import_module(module_name)
+        except ModuleNotFoundError as exc:
+            logger.warning(
+                "Failed to import plugin package %s: %s",
+                module_name,
+                exc,
+            )
+            continue
+        plugins.extend(_iter_candidates(module))
+
+    for file_path in paths or []:
+        try:
+            module = _load_module(file_path)
+        except PluginError as exc:
+            logger.warning(
+                "Failed to load plugin from %s: %s",
+                file_path,
+                exc,
+            )
+            continue
+        plugins.extend(_iter_candidates(module))
+
+    unique: Dict[str, NewsPlugin] = {}
+    for plugin in plugins:
+        unique[getattr(plugin, "name", plugin.__class__.__name__)] = plugin
+    return list(unique.values())
+
+
+async def execute_plugins(
+    plugins: Iterable[NewsPlugin],
+    config: Dict[str, Any],
+    *,
+    cache: Any | None = None,
+    monitor: Any | None = None,
+) -> List[NewsArticle]:
+    """Execute plugins concurrently and collect their results."""
+
+    tasks: List[asyncio.Task] = []
+    labels: List[str] = []
+    for plugin in plugins:
+        plugin_cfg: Dict[str, Any] = {}
+        if isinstance(config, dict):
+            plugin_cfg = config.get(plugin.name, {})
+        result = plugin.fetch(plugin_cfg, cache=cache, monitor=monitor)
+        if inspect.isawaitable(result):
+            task = asyncio.create_task(result)
+        else:
+
+            async def _wrap(value: Iterable[NewsArticle]) -> List[NewsArticle]:
+                return list(value)
+
+            task = asyncio.create_task(_wrap(result))
+        tasks.append(task)
+        labels.append(getattr(plugin, "name", plugin.__class__.__name__))
+
+    articles: List[NewsArticle] = []
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    for label, result in zip(labels, results, strict=False):
+        if isinstance(result, Exception):
+            logger.exception("Plugin %s failed", label, exc_info=result)
+            if monitor is not None and hasattr(monitor, "record_error"):
+                monitor.record_error(label, result)
+            continue
+        data = list(result)
+        if monitor is not None and hasattr(monitor, "record_articles"):
+            monitor.record_articles(label, len(data))
+        articles.extend(data)
+    return articles
+
+
+__all__ = ["discover_plugins", "execute_plugins"]

--- a/google-news-drive-sync/src/plugins/__init__.py
+++ b/google-news-drive-sync/src/plugins/__init__.py
@@ -1,0 +1,30 @@
+"""Plugin interfaces for extending news acquisition."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Protocol, runtime_checkable
+
+from ..news_fetcher import NewsArticle
+
+
+class PluginError(RuntimeError):
+    """Raised when plugin loading or execution fails."""
+
+
+@runtime_checkable
+class NewsPlugin(Protocol):
+    """Protocol describing the expected interface for plugins."""
+
+    name: str
+
+    async def fetch(
+        self,
+        config: Dict[str, Any],
+        *,
+        cache: Any | None = None,
+        monitor: Any | None = None,
+    ) -> Iterable[NewsArticle]:
+        """Return a collection of :class:`NewsArticle` items."""
+
+
+__all__ = ["NewsPlugin", "PluginError", "NewsArticle"]

--- a/google-news-drive-sync/src/plugins/sample_plugin.py
+++ b/google-news-drive-sync/src/plugins/sample_plugin.py
@@ -1,0 +1,26 @@
+"""Example plugin demonstrating the plugin interface."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable
+
+from ..news_fetcher import NewsArticle
+
+
+class SamplePlugin:
+    """Return no results but documents the plugin contract."""
+
+    name = "sample"
+
+    async def fetch(
+        self,
+        config: Dict[str, Any],
+        *,
+        cache: Any | None = None,
+        monitor: Any | None = None,
+    ) -> Iterable[NewsArticle]:
+        _ = (config, cache, monitor)
+        return []
+
+
+__all__ = ["SamplePlugin"]

--- a/google-news-drive-sync/src/rss_fetcher.py
+++ b/google-news-drive-sync/src/rss_fetcher.py
@@ -1,0 +1,152 @@
+"""Asynchronous RSS feed fetcher for auxiliary news sources."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import xml.etree.ElementTree as ET
+from datetime import datetime
+from email.utils import parsedate_to_datetime
+from typing import Any, Iterable, List, Sequence
+
+from .news_fetcher import NewsArticle, NewsFetcherError
+
+logger = logging.getLogger(__name__)
+
+try:  # pragma: no cover - optional runtime dependency
+    import aiohttp
+except Exception:  # pragma: no cover - dependency may be missing during tests
+    aiohttp = None  # type: ignore[assignment]
+
+
+class RssFetcherError(RuntimeError):
+    """Raised when fetching RSS feeds fails irrecoverably."""
+
+
+async def _fetch_feed(session: Any, url: str, timeout: int) -> str:
+    """Retrieve the raw RSS payload for *url*."""
+
+    async with session.get(url, timeout=timeout) as response:
+        status = getattr(response, "status", 200)
+        if status >= 400:
+            text = await response.text()
+            message = "RSS request failed for " f"{url} with status {status}: {text}"
+            raise RssFetcherError(message)
+        return await response.text()
+
+
+def _parse_feed(
+    payload: str,
+    *,
+    fallback_source: str | None = None,
+) -> List[NewsArticle]:
+    try:
+        root = ET.fromstring(payload)
+    except ET.ParseError as exc:  # pragma: no cover
+        raise RssFetcherError("Failed to parse RSS feed") from exc
+
+    channel_title = None
+    channel = root.find("channel")
+    if channel is not None:
+        title_node = channel.find("title")
+        if title_node is not None and title_node.text:
+            channel_title = title_node.text.strip()
+
+    articles: List[NewsArticle] = []
+    items: Iterable[ET.Element] = root.findall(".//item")
+    for item in items:
+        title_node = item.find("title")
+        link_node = item.find("link")
+        description_node = item.find("description")
+        pub_date_node = item.find("pubDate")
+
+        title = ""
+        if title_node is not None:
+            title = (title_node.text or "").strip()
+        link = ""
+        if link_node is not None:
+            link = (link_node.text or "").strip()
+        description = (
+            description_node.text.strip()
+            if description_node is not None and description_node.text
+            else None
+        )
+        published_at: datetime | None = None
+        if pub_date_node is not None and pub_date_node.text:
+            try:
+                published_at = parsedate_to_datetime(pub_date_node.text)
+            except (TypeError, ValueError):
+                published_at = None
+
+        if not title or not link:
+            continue
+
+        source = channel_title or fallback_source
+        articles.append(
+            NewsArticle(
+                title=title,
+                description=description,
+                url=link,
+                published_at=published_at,
+                source=source,
+            )
+        )
+
+    return articles
+
+
+async def fetch_rss_async(
+    feeds: Sequence[str],
+    *,
+    session: Any | None = None,
+    timeout: int = 10,
+    limit_per_feed: int | None = None,
+) -> List[NewsArticle]:
+    """Fetch articles from the provided RSS *feeds* concurrently."""
+
+    if not feeds:
+        return []
+
+    async def _collect(session_obj: Any, feed_url: str) -> List[NewsArticle]:
+        payload = await _fetch_feed(session_obj, feed_url, timeout)
+        articles = _parse_feed(payload, fallback_source=feed_url)
+        if limit_per_feed is None:
+            return articles
+        return articles[:limit_per_feed]
+
+    if session is None:
+        if aiohttp is None:
+            raise NewsFetcherError("aiohttp is required for RSS fetching but is not installed.")
+
+        # pragma: no cover - requires aiohttp
+        async with aiohttp.ClientSession() as auto_session:
+            return await fetch_rss_async(
+                feeds,
+                session=auto_session,
+                timeout=timeout,
+                limit_per_feed=limit_per_feed,
+            )
+
+    tasks = [asyncio.create_task(_collect(session, feed)) for feed in feeds]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    articles: List[NewsArticle] = []
+    for feed_url, result in zip(feeds, results, strict=False):
+        if isinstance(result, Exception):
+            logger.exception(
+                "RSS fetch failed for %s",
+                feed_url,
+                exc_info=result,
+            )
+            continue
+        articles.extend(result)
+
+    logger.info(
+        "Fetched %s RSS articles from %s feeds",
+        len(articles),
+        len(feeds),
+    )
+    return articles
+
+
+__all__ = ["RssFetcherError", "fetch_rss_async"]

--- a/google-news-drive-sync/src/scheduler.py
+++ b/google-news-drive-sync/src/scheduler.py
@@ -1,40 +1,66 @@
-"""Simple scheduler for recurring synchronisation."""
+"""Scheduling utilities built on top of APScheduler."""
 
 from __future__ import annotations
 
 import logging
 import threading
 import time
-from typing import Callable
+import uuid
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
+try:  # pragma: no cover - dependency optional during tests
+    from apscheduler.schedulers.background import BackgroundScheduler
+except Exception:  # pragma: no cover - fallback to thread-based scheduler
+    BackgroundScheduler = None  # type: ignore[assignment]
 
-def schedule(
+
+@dataclass
+class SchedulerHandle:
+    """Represents a scheduled job and allows graceful shutdown."""
+
+    scheduler: Any | None = None
+    job_id: str | None = None
+    thread: threading.Thread | None = None
+
+    def shutdown(self) -> None:
+        if self.scheduler is not None:
+            try:
+                if self.job_id:
+                    self.scheduler.remove_job(self.job_id)
+            finally:
+                self.scheduler.shutdown(wait=False)
+        if self.thread is not None:
+            stop_event = getattr(self.thread, "stop_event", None)
+            if stop_event is not None:
+                stop_event.set()
+            self.thread.join(timeout=1)
+
+
+def _start_thread(
     job: Callable[[], None],
     interval_minutes: int,
 ) -> threading.Thread:
-    """Run *job* every ``interval_minutes`` minutes in a background thread."""
-
-    if interval_minutes <= 0:
-        message = "Interval must be greater than zero minutes."
-        raise ValueError(message)
-
     stop_event = threading.Event()
 
     def worker() -> None:
-        logger.info("Starting scheduled job every %s minutes", interval_minutes)
+        logger.info(
+            "Starting fallback scheduler every %s minutes",
+            interval_minutes,
+        )
         while not stop_event.is_set():
             start = time.time()
             try:
                 job()
-            except Exception:  # pragma: no cover - log unexpected issues
+            except Exception:  # pragma: no cover - best-effort logging
                 logger.exception("Scheduled job failed")
             elapsed = time.time() - start
             sleep_for = max(0.0, interval_minutes * 60 - elapsed)
             if stop_event.wait(timeout=sleep_for):
                 break
-        logger.info("Scheduler thread exiting")
+        logger.info("Fallback scheduler thread exiting")
 
     thread = threading.Thread(
         target=worker,
@@ -44,3 +70,67 @@ def schedule(
     thread.stop_event = stop_event  # type: ignore[attr-defined]
     thread.start()
     return thread
+
+
+def _create_scheduler(timezone: str | None) -> Any | None:
+    if BackgroundScheduler is None:  # pragma: no cover
+        return None
+    options: Dict[str, Any] = {}
+    if timezone:
+        options["timezone"] = timezone
+    return BackgroundScheduler(**options)
+
+
+def schedule(
+    job: Callable[[], None],
+    *,
+    interval_minutes: Optional[int] = None,
+    cron: Optional[Dict[str, Any]] = None,
+    scheduler: Any | None = None,
+    timezone: str | None = None,
+) -> SchedulerHandle:
+    """Schedule *job* using APScheduler when available.
+
+    When APScheduler is unavailable the function falls back to the
+    previous thread-based scheduler.
+    """
+
+    if scheduler is None:
+        scheduler = _create_scheduler(timezone)
+
+    if scheduler is not None:
+        trigger_kwargs: Dict[str, Any]
+        trigger: str
+        if cron:
+            trigger = "cron"
+            trigger_kwargs = dict(cron)
+        else:
+            if interval_minutes is None or interval_minutes <= 0:
+                raise ValueError("interval_minutes must be provided when cron is not set")
+            trigger = "interval"
+            trigger_kwargs = {"minutes": interval_minutes}
+
+        job_id = f"news-sync-{uuid.uuid4()}"
+        scheduler.add_job(
+            job,
+            trigger,
+            id=job_id,
+            max_instances=1,
+            coalesce=True,
+            replace_existing=True,
+            **trigger_kwargs,
+        )
+        scheduler.start()
+        logger.info(
+            "Scheduled job using APScheduler with trigger %s",
+            trigger,
+        )
+        return SchedulerHandle(scheduler=scheduler, job_id=job_id)
+
+    if interval_minutes is None or interval_minutes <= 0:
+        raise ValueError(
+            ("interval_minutes must be greater than zero when using " "fallback scheduler")
+        )
+
+    thread = _start_thread(job, interval_minutes)
+    return SchedulerHandle(thread=thread)

--- a/google-news-drive-sync/src/server.py
+++ b/google-news-drive-sync/src/server.py
@@ -1,0 +1,133 @@
+"""FastAPI application exposing aggregated news data."""
+# ruff: noqa: B008  # FastAPI dependencies rely on Depends defaults
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from fastapi import Depends, FastAPI, HTTPException, Query
+from fastapi.responses import PlainTextResponse
+from pydantic import BaseModel
+
+from .article_repository import ArticleRepository
+from .monitor import MonitoringClient
+
+logger = logging.getLogger(__name__)
+
+
+class ArticleResponse(BaseModel):
+    """Response model for a single article."""
+
+    id: str
+    title: str
+    description: Optional[str]
+    url: str
+    source: Optional[str]
+    published_at: Optional[str]
+
+
+class StatusResponse(BaseModel):
+    """Expose pipeline status and metrics."""
+
+    metrics: Dict[str, Any]
+
+
+def _get_repository(repo: ArticleRepository | None) -> ArticleRepository:
+    if repo is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Article repository unavailable",
+        )
+    return repo
+
+
+def create_app(
+    *,
+    repository: ArticleRepository | None,
+    monitor: MonitoringClient | None,
+) -> FastAPI:
+    """Create a FastAPI application bound to the provided dependencies."""
+
+    app = FastAPI(title="Google News Drive Sync Dashboard")
+
+    def get_repository() -> ArticleRepository:
+        return _get_repository(repository)
+
+    def get_monitor() -> MonitoringClient | None:
+        return monitor
+
+    @app.get("/health")
+    def healthcheck() -> Dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/articles", response_model=List[ArticleResponse])
+    def list_articles(
+        limit: int = Query(20, ge=1, le=100),
+        source: Optional[str] = None,
+        q: Optional[str] = Query(
+            default=None,
+            description="Search query",
+        ),
+        repo: ArticleRepository = Depends(get_repository),
+    ) -> List[ArticleResponse]:
+        records = repo.list_articles(limit=limit, source=source, query=q)
+        return [
+            ArticleResponse(
+                id=item.id,
+                title=item.title,
+                description=item.description,
+                url=item.url,
+                source=item.source,
+                published_at=item.published_at.isoformat() if item.published_at else None,
+            )
+            for item in records
+        ]
+
+    @app.get("/sources")
+    def sources(
+        repo: ArticleRepository = Depends(get_repository),
+    ) -> Dict[str, List[str]]:
+        return {"sources": repo.list_sources()}
+
+    @app.get("/status", response_model=StatusResponse)
+    def status(
+        repo: ArticleRepository = Depends(get_repository),
+        metrics_client: MonitoringClient | None = Depends(get_monitor),
+    ) -> StatusResponse:
+        metrics: Dict[str, Any] = {
+            "articles": repo.count(),
+            "sources": repo.list_sources(),
+        }
+        if metrics_client is not None:
+            metrics.update(metrics_client.metrics())
+        return StatusResponse(metrics=metrics)
+
+    @app.get("/metrics", response_class=PlainTextResponse)
+    def metrics_endpoint(
+        metrics_client: MonitoringClient | None = Depends(get_monitor),
+    ) -> PlainTextResponse:
+        if metrics_client is None:
+            return PlainTextResponse("", media_type="text/plain")
+        payload = metrics_client.render_prometheus()
+        return PlainTextResponse(payload, media_type="text/plain")
+
+    return app
+
+
+def run_server(app: FastAPI, *, host: str, port: int) -> None:
+    """Run a uvicorn server for *app*."""
+
+    try:
+        import uvicorn
+    except ImportError as exc:
+        # pragma: no cover - dependency missing at runtime
+        raise RuntimeError("uvicorn must be installed to serve the API") from exc
+
+    config = uvicorn.Config(app, host=host, port=port, log_level="info")
+    server = uvicorn.Server(config)
+    logger.info("Starting dashboard server on %s:%s", host, port)
+    server.run()
+
+
+__all__ = ["create_app", "run_server", "ArticleResponse", "StatusResponse"]

--- a/google-news-drive-sync/src/utils.py
+++ b/google-news-drive-sync/src/utils.py
@@ -2,15 +2,27 @@
 
 from __future__ import annotations
 
+import base64
 import functools
+import hashlib
 import logging
+import os
 import time
 from pathlib import Path
-from typing import Any, Callable, Iterable, TypeVar
+from typing import Any, Callable, Iterable, Optional, TypeVar
 
 import yaml
 
 T = TypeVar("T")
+
+
+try:  # pragma: no cover - dependency optional for tests
+    from cryptography.fernet import Fernet
+except Exception:  # pragma: no cover - optional dependency not installed
+    Fernet = None  # type: ignore[assignment]
+
+
+logger = logging.getLogger(__name__)
 
 
 def setup_logging(level: int = logging.INFO) -> None:
@@ -79,3 +91,56 @@ def load_config(path: str | Path) -> dict[str, Any]:
         raise ValueError(error_msg)
 
     return data
+
+
+def load_env_file(path: str | Path) -> None:
+    """Load environment variables from a ``.env`` file when supported."""
+
+    env_path = Path(path)
+    if not env_path.exists():
+        return
+
+    try:
+        from dotenv import dotenv_values
+    except ImportError:  # pragma: no cover - optional dependency
+        logger.debug(
+            "python-dotenv not installed; skipping env file %s",
+            env_path,
+        )
+        return
+
+    values = dotenv_values(env_path)
+    for key, value in values.items():
+        if value is not None and key not in os.environ:
+            os.environ[key] = value
+
+
+def _xor_bytes(data: bytes, key: bytes) -> bytes:
+    return bytes(b ^ key[i % len(key)] for i, b in enumerate(data))
+
+
+class TokenEncryptor:
+    """Symmetric encryption helper for Drive tokens."""
+
+    def __init__(self, key: bytes) -> None:
+        if not key:
+            raise ValueError("Encryption key must not be empty")
+        self._key = hashlib.sha256(key).digest()
+        self._fernet: Optional[Fernet] = None
+        if Fernet is not None:  # pragma: no cover
+            fernet_key = base64.urlsafe_b64encode(self._key)
+            self._fernet = Fernet(fernet_key)
+
+    @classmethod
+    def from_password(cls, password: str) -> "TokenEncryptor":
+        return cls(password.encode("utf-8"))
+
+    def encrypt(self, payload: bytes) -> bytes:
+        if self._fernet is not None:
+            return self._fernet.encrypt(payload)
+        return _xor_bytes(payload, self._key)
+
+    def decrypt(self, payload: bytes) -> bytes:
+        if self._fernet is not None:
+            return self._fernet.decrypt(payload)
+        return _xor_bytes(payload, self._key)

--- a/google-news-drive-sync/tests/test_api_router.py
+++ b/google-news-drive-sync/tests/test_api_router.py
@@ -1,0 +1,107 @@
+import asyncio
+
+from src.api_router import fetch_all_articles
+from src.cache import ArticleCache
+from src.news_fetcher import NewsArticle
+from src.monitor import MonitoringClient
+
+
+def test_fetch_all_articles_deduplicates(tmp_path):
+    article = NewsArticle(
+        title="Example",
+        description=None,
+        url="https://example.com",
+        published_at=None,
+        source="API",
+    )
+
+    async def fake_news_fetcher(*args, **kwargs):
+        return [article]
+
+    async def fake_rss_fetcher(*args, **kwargs):
+        return [article]
+
+    cache = ArticleCache(tmp_path / "cache.db", retention_days=1)
+    config = {
+        "news_api": {"api_key": "key"},
+        "sources": {"rss": ["feed"]},
+    }
+
+    results = asyncio.run(
+        fetch_all_articles(
+            config,
+            cache=cache,
+            news_fetcher=fake_news_fetcher,
+            rss_fetcher=fake_rss_fetcher,
+        )
+    )
+
+    assert len(results) == 1
+    assert cache.filter_new([article]) == []
+
+
+def test_fetch_all_articles_handles_missing_sources():
+    config = {"news_api": {}, "sources": {}}
+    results = asyncio.run(fetch_all_articles(config))
+    assert results == []
+
+
+def test_fetch_all_articles_updates_monitor():
+    article = NewsArticle(
+        title="Example",
+        description=None,
+        url="https://example.com",
+        published_at=None,
+        source="API",
+    )
+
+    async def fake_news_fetcher(*args, **kwargs):
+        return [article]
+
+    monitor = MonitoringClient()
+    config = {"news_api": {"api_key": "key"}}
+
+    asyncio.run(fetch_all_articles(config, monitor=monitor, news_fetcher=fake_news_fetcher))
+
+    snapshot = monitor.snapshot()
+    assert snapshot.articles_processed == 1
+    assert snapshot.source_counts["news_api"] == 1
+
+
+def test_fetch_all_articles_with_plugins(tmp_path):
+    plugin_path = tmp_path / "plugin.py"
+    plugin_path.write_text(
+        """
+from typing import Any, Dict
+
+from src.news_fetcher import NewsArticle
+
+
+class DemoPlugin:
+    name = "demo"
+
+    async def fetch(self, config: Dict[str, Any], *, cache=None, monitor=None):
+        return [
+            NewsArticle(
+                title="Plugin",
+                description=None,
+                url="https://example.com/plugin",
+                published_at=None,
+                source="demo",
+            )
+        ]
+"""
+    )
+
+    config = {
+        "news_api": {},
+        "sources": {},
+        "plugins": {
+            "enabled": True,
+            "paths": [str(plugin_path)],
+        },
+    }
+
+    results = asyncio.run(fetch_all_articles(config, base_dir=tmp_path))
+    assert len(results) == 1
+    assert results[0].title == "Plugin"

--- a/google-news-drive-sync/tests/test_article_repository.py
+++ b/google-news-drive-sync/tests/test_article_repository.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+
+from src.article_repository import ArticleRepository
+from src.news_fetcher import NewsArticle
+
+
+def make_article(index: int) -> NewsArticle:
+    return NewsArticle(
+        title=f"Article {index}",
+        description=f"Description {index}",
+        url=f"https://example.com/{index}",
+        published_at=datetime(2024, 1, index + 1),
+        source="Example",
+    )
+
+
+def test_persist_and_list_articles(tmp_path):
+    repo = ArticleRepository(tmp_path / "articles.db")
+
+    articles = [make_article(1), make_article(2)]
+    repo.persist(articles)
+
+    stored = repo.list_articles()
+    assert len(stored) == 2
+    assert stored[0].title.startswith("Article")
+
+
+def test_filtering_and_counts(tmp_path):
+    repo = ArticleRepository(tmp_path / "articles.db")
+    repo.persist([make_article(1), make_article(2)])
+
+    filtered = repo.list_articles(query="article 1")
+    assert len(filtered) == 1
+
+    assert repo.count() == 2
+    assert repo.list_sources() == ["Example"]

--- a/google-news-drive-sync/tests/test_cache.py
+++ b/google-news-drive-sync/tests/test_cache.py
@@ -1,0 +1,40 @@
+from datetime import datetime, timedelta
+
+from src.cache import ArticleCache
+from src.news_fetcher import NewsArticle
+
+
+def make_article(url: str, title: str, *, published_at: datetime | None = None) -> NewsArticle:
+    return NewsArticle(
+        title=title,
+        description=None,
+        url=url,
+        published_at=published_at,
+        source="Test",
+    )
+
+
+def test_cache_filters_duplicates(tmp_path):
+    cache = ArticleCache(tmp_path / "articles.db", retention_days=7)
+    article_a = make_article("https://example.com/a", "A")
+    article_b = make_article("https://example.com/b", "B")
+
+    fresh = cache.filter_new([article_a, article_b])
+    assert fresh == [article_a, article_b]
+
+    cache.record(fresh)
+    assert cache.filter_new([article_a]) == []
+
+
+def test_cache_prunes_expired_entries(tmp_path):
+    cache = ArticleCache(tmp_path / "articles.db", retention_days=0)
+    old = make_article(
+        "https://example.com/old",
+        "Old",
+        published_at=datetime.utcnow() - timedelta(days=2),
+    )
+    cache.record([old])
+    cache.record([])  # trigger retention cleanup
+
+    fresh = cache.filter_new([old])
+    assert fresh == [old]

--- a/google-news-drive-sync/tests/test_integration.py
+++ b/google-news-drive-sync/tests/test_integration.py
@@ -18,7 +18,7 @@ def test_run_once_flow(monkeypatch):
         )
     ]
 
-    monkeypatch.setattr(main_module, "fetch_news", mock.Mock(return_value=articles))
+    monkeypatch.setattr(main_module, "fetch_all_articles", mock.AsyncMock(return_value=articles))
     monkeypatch.setattr(
         main_module,
         "create_document",
@@ -47,10 +47,15 @@ def test_run_once_flow(monkeypatch):
         "news_api": {"api_key": "key", "topics": ["tech"], "base_url": "url"},
         "document": {"format": "markdown"},
         "drive": {"folder_name": "News", "oauth_credentials_path": "creds.json"},
+        "cache": {"enabled": False},
+        "scheduler": {"enabled": False},
+        "secrets": {},
+        "repository": {"enabled": False},
     }
 
     monkeypatch.setattr(main_module, "load_config", mock.Mock(return_value=config))
     monkeypatch.setattr(main_module, "setup_logging", mock.Mock())
+    monkeypatch.setattr(main_module, "load_env_file", mock.Mock())
 
     with mock.patch("pathlib.Path.exists", return_value=True):
         main_module.main(["--config", "config/config.yaml", "--once"])

--- a/google-news-drive-sync/tests/test_monitor.py
+++ b/google-news-drive-sync/tests/test_monitor.py
@@ -1,0 +1,21 @@
+from src.monitor import MonitoringClient
+
+
+def test_monitor_records_metrics():
+    monitor = MonitoringClient()
+    monitor.start_run()
+    monitor.record_articles("news_api", 5)
+    monitor.record_error("news_api", RuntimeError("boom"))
+    monitor.record_document_upload()
+    monitor.complete_run(status="success")
+
+    snapshot = monitor.snapshot()
+    assert snapshot.articles_processed == 5
+    assert snapshot.errors == 1
+    assert snapshot.source_counts["news_api"] == 5
+    assert snapshot.documents_uploaded == 1
+    assert snapshot.runs == 1
+    metrics = monitor.metrics()
+    assert metrics["last_status"] == "success"
+    payload = monitor.render_prometheus()
+    assert "gnds_articles_processed_total" in payload

--- a/google-news-drive-sync/tests/test_plugin_manager.py
+++ b/google-news-drive-sync/tests/test_plugin_manager.py
@@ -1,0 +1,38 @@
+import pytest
+
+from src.plugin_manager import discover_plugins, execute_plugins
+
+
+@pytest.mark.asyncio
+async def test_execute_plugins_from_temp_path(tmp_path):
+    plugin_file = tmp_path / "example_plugin.py"
+    plugin_file.write_text(
+        """
+from datetime import datetime
+from typing import Any, Dict
+
+from src.news_fetcher import NewsArticle
+
+
+class ExamplePlugin:
+    name = "example"
+
+    async def fetch(self, config: Dict[str, Any], *, cache=None, monitor=None):
+        return [
+            NewsArticle(
+                title=config.get("title", "Example"),
+                description="Plugin generated",
+                url="https://example.com/plugin",
+                published_at=None,
+                source="plugin",
+            )
+        ]
+"""
+    )
+
+    plugins = discover_plugins(paths=[plugin_file])
+    assert plugins
+
+    results = await execute_plugins(plugins, {"example": {"title": "Configured"}})
+    assert len(results) == 1
+    assert results[0].title == "Configured"

--- a/google-news-drive-sync/tests/test_rss_fetcher.py
+++ b/google-news-drive-sync/tests/test_rss_fetcher.py
@@ -1,0 +1,59 @@
+import asyncio
+
+from src.rss_fetcher import fetch_rss_async
+
+
+class FakeResponse:
+    def __init__(self, status, payload):
+        self.status = status
+        self._payload = payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def text(self):
+        return self._payload
+
+
+class FakeSession:
+    def __init__(self, response):
+        self._response = response
+        self.calls = 0
+
+    def get(self, *args, **kwargs):
+        self.calls += 1
+        return self._response
+
+
+def test_fetch_rss_parses_feed():
+    feed = """
+    <rss><channel><title>Feed</title>
+        <item>
+            <title>Headline</title>
+            <link>https://example.com</link>
+            <description>Summary</description>
+            <pubDate>Mon, 01 Jan 2024 00:00:00 GMT</pubDate>
+        </item>
+    </channel></rss>
+    """
+    session = FakeSession(FakeResponse(200, feed))
+
+    articles = asyncio.run(fetch_rss_async(["https://feed"], session=session))
+
+    assert len(articles) == 1
+    article = articles[0]
+    assert article.title == "Headline"
+    assert article.url == "https://example.com"
+    assert article.source == "Feed"
+
+
+def test_fetch_rss_handles_http_errors(caplog):
+    session = FakeSession(FakeResponse(500, "error"))
+    with caplog.at_level("ERROR"):
+        articles = asyncio.run(fetch_rss_async(["https://feed"], session=session))
+
+    assert articles == []
+    assert "RSS request failed" in caplog.text

--- a/google-news-drive-sync/tests/test_scheduler.py
+++ b/google-news-drive-sync/tests/test_scheduler.py
@@ -1,25 +1,58 @@
-import time
+import threading
 
 import pytest
 
-from src.scheduler import schedule
+from src.scheduler import SchedulerHandle, schedule
 
 
-def test_schedule_runs_job():
+def test_schedule_runs_job_with_fallback():
     calls = []
+    done = threading.Event()
 
     def job():
-        calls.append(time.time())
-        if len(calls) >= 1:
-            thread.stop_event.set()  # type: ignore[attr-defined]
+        calls.append(object())
+        done.set()
 
-    thread = schedule(job, 0.001)
-    thread.join(timeout=1)
+    handle = schedule(job, interval_minutes=0.001, scheduler=None)
+    assert isinstance(handle, SchedulerHandle)
+    assert done.wait(timeout=1)
+    handle.shutdown()
+    if handle.thread is not None:
+        assert not handle.thread.is_alive()
 
-    assert calls
-    assert not thread.is_alive()
 
-
-def test_schedule_requires_positive_interval():
+def test_schedule_requires_configuration():
     with pytest.raises(ValueError):
-        schedule(lambda: None, 0)
+        schedule(lambda: None, interval_minutes=0)
+
+
+def test_schedule_with_custom_scheduler():
+    class FakeScheduler:
+        def __init__(self):
+            self.jobs = []
+            self.started = False
+            self.removed = None
+            self.shutdown_called = False
+
+        def add_job(self, func, trigger, **kwargs):
+            self.jobs.append((func, trigger, kwargs))
+
+        def start(self):
+            self.started = True
+
+        def remove_job(self, job_id):
+            self.removed = job_id
+
+        def shutdown(self, wait):
+            self.shutdown_called = True
+
+    fake = FakeScheduler()
+
+    handle = schedule(lambda: None, interval_minutes=1, scheduler=fake)
+
+    assert fake.jobs
+    assert fake.started
+    assert handle.scheduler is fake
+
+    handle.shutdown()
+    assert fake.shutdown_called

--- a/google-news-drive-sync/tests/test_server.py
+++ b/google-news-drive-sync/tests/test_server.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+
+from src.article_repository import ArticleRepository
+from src.monitor import MonitoringClient
+from src.news_fetcher import NewsArticle
+from src.server import create_app
+
+
+def populate(repo: ArticleRepository) -> None:
+    repo.persist(
+        [
+            NewsArticle(
+                title="Title",
+                description="Desc",
+                url="https://example.com/1",
+                published_at=datetime(2024, 1, 1),
+                source="SourceA",
+            )
+        ]
+    )
+
+
+def test_articles_endpoint(tmp_path):
+    repo = ArticleRepository(tmp_path / "articles.db")
+    populate(repo)
+    monitor = MonitoringClient()
+    monitor.record_articles("news_api", 1)
+    monitor.record_document_upload()
+    monitor.complete_run(status="success")
+
+    app = create_app(repository=repo, monitor=monitor)
+    client = TestClient(app)
+
+    response = client.get("/articles")
+    assert response.status_code == 200
+    data = response.json()
+    assert data[0]["title"] == "Title"
+
+    sources = client.get("/sources").json()
+    assert sources["sources"] == ["SourceA"]
+
+    status = client.get("/status").json()
+    assert status["metrics"]["articles"] == 1
+
+    metrics = client.get("/metrics")
+    assert "gnds_articles_processed_total" in metrics.text
+
+
+def test_healthcheck_without_monitor(tmp_path):
+    repo = ArticleRepository(tmp_path / "articles.db")
+    populate(repo)
+
+    app = create_app(repository=repo, monitor=None)
+    client = TestClient(app)
+
+    assert client.get("/health").json() == {"status": "ok"}

--- a/google-news-drive-sync/ui/index.html
+++ b/google-news-drive-sync/ui/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Google News Drive Sync Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/google-news-drive-sync/ui/package.json
+++ b/google-news-drive-sync/ui/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "google-news-drive-sync-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@headlessui/react": "^1.7.17",
+    "@heroicons/react": "^2.0.18",
+    "@tanstack/react-query": "^5.0.0",
+    "axios": "^1.5.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.3.3",
+    "typescript": "^5.2.2",
+    "vite": "^4.4.9"
+  }
+}

--- a/google-news-drive-sync/ui/postcss.config.cjs
+++ b/google-news-drive-sync/ui/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/google-news-drive-sync/ui/src/App.tsx
+++ b/google-news-drive-sync/ui/src/App.tsx
@@ -1,0 +1,85 @@
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+
+import ArticleList from './components/ArticleList';
+import SearchBar from './components/SearchBar';
+
+export interface Article {
+  id: string;
+  title: string;
+  description?: string | null;
+  url: string;
+  source?: string | null;
+  published_at?: string | null;
+}
+
+interface StatusResponse {
+  metrics: Record<string, unknown>;
+}
+
+const API_BASE = import.meta.env.VITE_API_BASE ?? 'http://localhost:8000';
+
+async function fetchArticles(params: Record<string, string | number | undefined>) {
+  const query = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && value !== '') {
+      query.set(key, String(value));
+    }
+  });
+  const response = await axios.get<Article[]>(`${API_BASE}/articles`, { params });
+  return response.data;
+}
+
+async function fetchStatus() {
+  const response = await axios.get<StatusResponse>(`${API_BASE}/status`);
+  return response.data;
+}
+
+export default function App() {
+  const [sourceFilter, setSourceFilter] = useState<string>('');
+  const [query, setQuery] = useState<string>('');
+
+  const { data: articles = [], isLoading } = useQuery({
+    queryKey: ['articles', sourceFilter, query],
+    queryFn: () => fetchArticles({ source: sourceFilter || undefined, q: query || undefined }),
+    refetchInterval: 120000,
+  });
+
+  const { data: status } = useQuery({
+    queryKey: ['status'],
+    queryFn: fetchStatus,
+    refetchInterval: 300000,
+  });
+
+  const sources = useMemo(() => {
+    if (!status?.metrics) return [] as string[];
+    const rawSources = (status.metrics['sources'] as string[]) ?? [];
+    return Array.from(new Set(rawSources)).sort();
+  }, [status]);
+
+  return (
+    <main>
+      <header className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-3xl font-semibold tracking-tight">Google News Drive Sync</h1>
+          <p className="text-slate-400">
+            Live dashboard of the latest articles ready for Drive synchronisation.
+          </p>
+        </div>
+        <div className="text-xs uppercase tracking-wide text-slate-400">
+          Articles processed: {status?.metrics?.articles ?? 0}
+        </div>
+      </header>
+
+      <SearchBar
+        sources={sources}
+        onFilterChange={setSourceFilter}
+        onQueryChange={setQuery}
+        selectedSource={sourceFilter}
+      />
+
+      <ArticleList articles={articles} loading={isLoading} />
+    </main>
+  );
+}

--- a/google-news-drive-sync/ui/src/components/ArticleList.tsx
+++ b/google-news-drive-sync/ui/src/components/ArticleList.tsx
@@ -1,0 +1,25 @@
+import type { Article } from '../App';
+import ArticlePreview from './ArticlePreview';
+
+interface Props {
+  articles: Article[];
+  loading?: boolean;
+}
+
+export default function ArticleList({ articles, loading = false }: Props) {
+  if (loading) {
+    return <p className="text-slate-400">Loading latest headlines…</p>;
+  }
+
+  if (!articles.length) {
+    return <p className="text-slate-400">No articles matched the current filters.</p>;
+  }
+
+  return (
+    <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+      {articles.map((article) => (
+        <ArticlePreview key={article.id} article={article} />
+      ))}
+    </section>
+  );
+}

--- a/google-news-drive-sync/ui/src/components/ArticlePreview.tsx
+++ b/google-news-drive-sync/ui/src/components/ArticlePreview.tsx
@@ -1,0 +1,46 @@
+import { CalendarDaysIcon, LinkIcon } from '@heroicons/react/24/outline';
+import type { Article } from '../App';
+
+interface Props {
+  article: Article;
+}
+
+function formatDate(value?: string | null) {
+  if (!value) return 'Unknown';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'Unknown';
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date);
+}
+
+export default function ArticlePreview({ article }: Props) {
+  return (
+    <article className="group relative flex flex-col gap-3 rounded-2xl border border-slate-700/40 bg-slate-900/60 p-5 shadow-xl backdrop-blur transition hover:border-sky-400/70 hover:bg-slate-900/80">
+      <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+        <span>{article.source ?? 'Unknown source'}</span>
+        <span className="inline-flex items-center gap-1">
+          <CalendarDaysIcon className="h-4 w-4" aria-hidden="true" />
+          {formatDate(article.published_at)}
+        </span>
+      </div>
+
+      <h2 className="text-xl font-semibold text-slate-100 group-hover:text-sky-200">
+        {article.title}
+      </h2>
+
+      {article.description && <p className="text-sm text-slate-300">{article.description}</p>}
+
+      <a
+        className="inline-flex items-center gap-2 self-start rounded-full border border-sky-500/60 px-4 py-2 text-sm font-medium text-sky-200 transition hover:border-sky-300 hover:text-sky-100"
+        href={article.url}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <LinkIcon className="h-4 w-4" aria-hidden="true" />
+        Read source
+      </a>
+    </article>
+  );
+}

--- a/google-news-drive-sync/ui/src/components/SearchBar.tsx
+++ b/google-news-drive-sync/ui/src/components/SearchBar.tsx
@@ -1,0 +1,66 @@
+import { MagnifyingGlassIcon } from '@heroicons/react/24/outline';
+import { Listbox, Transition } from '@headlessui/react';
+import { Fragment, useMemo } from 'react';
+
+interface Props {
+  sources: string[];
+  selectedSource: string;
+  onFilterChange(source: string): void;
+  onQueryChange(query: string): void;
+}
+
+export default function SearchBar({
+  sources,
+  selectedSource,
+  onFilterChange,
+  onQueryChange,
+}: Props) {
+  const options = useMemo(() => ['All sources', ...sources], [sources]);
+
+  return (
+    <section className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+      <div className="relative w-full max-w-xl">
+        <MagnifyingGlassIcon
+          className="pointer-events-none absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-slate-500"
+          aria-hidden="true"
+        />
+        <input
+          aria-label="Search articles"
+          className="w-full rounded-full border border-slate-700/40 bg-slate-900/70 py-3 pl-10 pr-4 text-slate-100 shadow-inner transition focus:border-sky-400/70 focus:bg-slate-900/90"
+          placeholder="Search headlines or descriptions"
+          onChange={(event) => onQueryChange(event.target.value)}
+        />
+      </div>
+
+      <Listbox value={selectedSource} onChange={onFilterChange}>
+        <div className="relative w-full max-w-xs">
+          <Listbox.Button className="w-full rounded-full border border-slate-700/40 bg-slate-900/70 px-4 py-3 text-left text-slate-100 shadow-inner transition focus:border-sky-400/70 focus:bg-slate-900/90">
+            <span>{selectedSource || 'All sources'}</span>
+          </Listbox.Button>
+          <Transition
+            as={Fragment}
+            leave="transition ease-in duration-100"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <Listbox.Options className="absolute z-10 mt-2 max-h-60 w-full overflow-auto rounded-2xl border border-slate-700/40 bg-slate-900/90 p-2 text-sm text-slate-100 shadow-xl backdrop-blur">
+              {options.map((option) => (
+                <Listbox.Option
+                  key={option}
+                  value={option === 'All sources' ? '' : option}
+                  className={({ active }) =>
+                    `cursor-pointer rounded-xl px-3 py-2 transition ${
+                      active ? 'bg-sky-500/20 text-sky-100' : 'text-slate-100'
+                    }`
+                  }
+                >
+                  {option}
+                </Listbox.Option>
+              ))}
+            </Listbox.Options>
+          </Transition>
+        </div>
+      </Listbox>
+    </section>
+  );
+}

--- a/google-news-drive-sync/ui/src/main.tsx
+++ b/google-news-drive-sync/ui/src/main.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import App from './App';
+import './styles.css';
+
+const queryClient = new QueryClient();
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </React.StrictMode>
+);

--- a/google-news-drive-sync/ui/src/styles.css
+++ b/google-news-drive-sync/ui/src/styles.css
@@ -1,0 +1,46 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  margin: 0;
+  font-family:
+    'Inter',
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    sans-serif;
+  background:
+    radial-gradient(circle at 0% 0%, rgba(59, 130, 246, 0.15), transparent 45%),
+    radial-gradient(circle at 100% 0%, rgba(16, 185, 129, 0.12), transparent 50%), #0b1120;
+  color: #e2e8f0;
+  min-height: 100vh;
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2.5rem clamp(1rem, 5vw, 3rem);
+}
+
+button:focus-visible,
+a:focus-visible,
+input:focus-visible {
+  outline: 2px solid #38bdf8;
+  outline-offset: 2px;
+}
+
+@media (prefers-color-scheme: light) {
+  body {
+    background:
+      radial-gradient(circle at 0% 0%, rgba(59, 130, 246, 0.25), transparent 45%),
+      radial-gradient(circle at 100% 0%, rgba(16, 185, 129, 0.18), transparent 50%), #f8fafc;
+    color: #0f172a;
+  }
+}

--- a/google-news-drive-sync/ui/tailwind.config.cjs
+++ b/google-news-drive-sync/ui/tailwind.config.cjs
@@ -1,0 +1,12 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{ts,tsx,js,jsx}'],
+  theme: {
+    extend: {
+      colors: {
+        slate: require('tailwindcss/colors').slate,
+        sky: require('tailwindcss/colors').sky,
+      },
+    },
+  },
+  plugins: [],
+};

--- a/google-news-drive-sync/ui/tsconfig.json
+++ b/google-news-drive-sync/ui/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/google-news-drive-sync/ui/vite.config.ts
+++ b/google-news-drive-sync/ui/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: '0.0.0.0',
+  },
+});


### PR DESCRIPTION
## Summary
- add article repository, plugin manager, and FastAPI server to power the new dashboard
- introduce a React/Tailwind UI for browsing articles with filtering and live metrics
- document stage 3 capabilities and configuration updates including plugin and server settings

## Testing
- python -m pytest tests/
- flake8 src/
- python -m ruff check src/ tests/


------
https://chatgpt.com/codex/tasks/task_e_68d5808c9ad083218a294c1d6b4c4f78