### PR TITLE
feat: harden dashboard security and plugin execution

### DIFF
--- a/google-news-drive-sync/config/config.yaml
+++ b/google-news-drive-sync/config/config.yaml
@@ -48,10 +48,20 @@ plugins:
   settings:
     sample:
       enabled: false
+  sandbox:
+    enabled: true
+    timeout_seconds: 30
+    max_workers: 4
 
 server:
   host: '127.0.0.1'
   port: 8000
+  auth:
+    api_keys:
+      - 'REPLACE_WITH_SECURE_KEY'
+  rate_limit:
+    requests_per_minute: 120
+    window_seconds: 60
 
 secrets:
   env_file: '../.env'

--- a/google-news-drive-sync/docs/architecture.md
+++ b/google-news-drive-sync/docs/architecture.md
@@ -47,11 +47,14 @@ Stage 3 completes the evolution into a user-facing system with pluggable source
 1. **Article Repository** – `src/article_repository.py` persists article metadata to SQLite so both the document formatter and
    dashboard can reuse the same canonical dataset.
 2. **Plugin Loader** – `src/plugin_manager.py` and `src/plugins/` dynamically discover Python-based news sources. Administrators
-   can add new sources by dropping modules onto the filesystem or referencing importable packages in configuration.
-3. **Monitoring Upgrades** – `src/monitor.py` now tracks pipeline runs, document uploads and renders Prometheus metrics for
-   `/metrics` scraping. Metrics are consumed by the dashboard and exported for observability stacks.
+   can add new sources by dropping modules onto the filesystem or referencing importable packages in configuration. Stage 3 adds
+   subprocess-based sandboxing with configurable timeouts to contain failures and untrusted code.
+3. **Monitoring Upgrades** – `src/monitor.py` now tracks pipeline runs, latency histograms, repository depth and document uploads,
+   rendering Prometheus metrics for `/metrics` scraping. Metrics are consumed by the dashboard and exported for observability
+   stacks.
 4. **FastAPI Server** – `src/server.py` exposes REST endpoints and health probes that surface aggregated articles, source
-   listings and monitoring data. `src/main.py` can launch the server in parallel with the scheduler via the `--serve` flag.
+   listings and monitoring data. Requests are authenticated via API keys and throttled with an in-memory rate limiter. `src.main`
+   can launch the server in parallel with the scheduler via the `--serve` flag.
 5. **Web Dashboard** – `ui/` hosts a React + Tailwind UI offering search, filtering, keyboard navigation and high-contrast
    theming for accessibility. Components consume the FastAPI endpoints and present a responsive news experience.
 

--- a/google-news-drive-sync/src/api_router.py
+++ b/google-news-drive-sync/src/api_router.py
@@ -133,11 +133,26 @@ async def fetch_all_articles(
         )
         if plugins:
             plugin_settings = plugin_cfg.get("settings", {})
+            sandbox_cfg = plugin_cfg.get("sandbox", {})
+            sandbox_enabled = sandbox_cfg.get("enabled", True)
+            timeout_value = sandbox_cfg.get("timeout_seconds", 30)
+            try:
+                timeout_seconds = float(timeout_value)
+            except (TypeError, ValueError):
+                timeout_seconds = 30.0
+            max_workers_cfg = sandbox_cfg.get("max_workers")
+            try:
+                max_workers = int(max_workers_cfg) if max_workers_cfg is not None else None
+            except (TypeError, ValueError):
+                max_workers = None
             plugin_articles = await execute_plugins(
                 plugins,
                 plugin_settings,
                 cache=cache,
                 monitor=monitor,
+                sandbox=sandbox_enabled,
+                timeout=timeout_seconds,
+                max_workers=max_workers,
             )
             articles.extend(plugin_articles)
 

--- a/google-news-drive-sync/src/plugin_manager.py
+++ b/google-news-drive-sync/src/plugin_manager.py
@@ -7,6 +7,11 @@ import importlib
 import importlib.util
 import inspect
 import logging
+import os
+import sys
+from concurrent.futures import ProcessPoolExecutor
+from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from types import ModuleType
 from typing import Any, Dict, Iterable, List, Sequence
@@ -15,6 +20,16 @@ from .news_fetcher import NewsArticle
 from .plugins import NewsPlugin, PluginError
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PluginSpec:
+    """Metadata required to safely reconstruct a plugin in a sandbox."""
+
+    label: str
+    module: str
+    qualname: str
+    module_path: str | None
 
 
 def _load_module(path: Path) -> ModuleType:
@@ -26,15 +41,23 @@ def _load_module(path: Path) -> ModuleType:
     return module
 
 
+def _annotate_plugin(plugin: NewsPlugin, module: ModuleType) -> NewsPlugin:
+    plugin._sandbox_module_file = getattr(module, "__file__", None)  # type: ignore[attr-defined]
+    return plugin
+
+
 def _iter_candidates(module: ModuleType) -> Iterable[NewsPlugin]:
     for attribute in module.__dict__.values():
-        if inspect.isclass(attribute) and issubclass(attribute, object):
-            if hasattr(attribute, "fetch") and hasattr(attribute, "name"):
-                instance = attribute()  # type: ignore[call-arg]
-                if isinstance(instance, NewsPlugin):
-                    yield instance
+        if (
+            inspect.isclass(attribute)
+            and hasattr(attribute, "fetch")
+            and hasattr(attribute, "name")
+        ):
+            instance = attribute()  # type: ignore[call-arg]
+            if isinstance(instance, NewsPlugin):
+                yield _annotate_plugin(instance, module)
         elif isinstance(attribute, NewsPlugin):
-            yield attribute
+            yield _annotate_plugin(attribute, module)
 
 
 def discover_plugins(
@@ -76,46 +99,199 @@ def discover_plugins(
     return list(unique.values())
 
 
+def _build_spec(plugin: NewsPlugin) -> PluginSpec:
+    module = plugin.__class__.__module__
+    qualname = plugin.__class__.__qualname__
+    module_file = getattr(plugin, "_sandbox_module_file", None)
+    label = getattr(plugin, "name", plugin.__class__.__name__)
+    return PluginSpec(label=label, module=module, qualname=qualname, module_path=module_file)
+
+
+def _serialise_article(article: Any) -> Dict[str, Any]:
+    if isinstance(article, NewsArticle):
+        payload = {
+            "title": article.title,
+            "description": article.description,
+            "url": article.url,
+            "published_at": article.published_at.isoformat() if article.published_at else None,
+            "source": article.source,
+        }
+        return payload
+    if hasattr(article, "title") and hasattr(article, "url"):
+        payload = {
+            "title": getattr(article, "title", ""),
+            "description": getattr(article, "description", None),
+            "url": getattr(article, "url", ""),
+            "published_at": None,
+            "source": getattr(article, "source", None),
+        }
+        published = getattr(article, "published_at", None)
+        if isinstance(published, datetime):
+            payload["published_at"] = published.isoformat()
+        return payload
+    if isinstance(article, dict):
+        payload = dict(article)
+        published = payload.get("published_at")
+        if isinstance(published, datetime):
+            payload["published_at"] = published.isoformat()
+        return payload
+    raise PluginError("Plugins must return NewsArticle instances or dictionaries")
+
+
+def _deserialize_article(payload: Dict[str, Any]) -> NewsArticle:
+    published = payload.get("published_at")
+    parsed: datetime | None = None
+    if isinstance(published, str):
+        try:
+            parsed = datetime.fromisoformat(published)
+        except ValueError:
+            parsed = None
+    elif isinstance(published, datetime):
+        parsed = published
+    return NewsArticle(
+        title=payload.get("title") or "",
+        description=payload.get("description"),
+        url=payload.get("url") or "",
+        published_at=parsed,
+        source=payload.get("source"),
+    )
+
+
+def _execute_in_subprocess(
+    spec: PluginSpec,
+    config: Dict[str, Any],
+    sys_path: List[str],
+) -> List[Dict[str, Any]]:
+    try:
+        sys.path = list(dict.fromkeys(sys_path + sys.path))
+        if spec.module_path:
+            module_dir = str(Path(spec.module_path).parent)
+            if module_dir and module_dir not in sys.path:
+                sys.path.insert(0, module_dir)
+        module = importlib.import_module(spec.module)
+        target: Any = module
+        for part in spec.qualname.split("."):
+            target = getattr(target, part)
+        instance = target()
+        result = instance.fetch(config, cache=None, monitor=None)
+        if inspect.isawaitable(result):
+            loop = asyncio.new_event_loop()
+            try:
+                asyncio.set_event_loop(loop)
+                value = loop.run_until_complete(result)
+            finally:
+                asyncio.set_event_loop(None)
+                loop.close()
+        else:
+            value = result
+        return [_serialise_article(item) for item in value]
+    except Exception as exc:  # pragma: no cover - executed in subprocess
+        raise PluginError(f"{spec.label} execution failed: {exc}") from exc
+
+
 async def execute_plugins(
     plugins: Iterable[NewsPlugin],
     config: Dict[str, Any],
     *,
     cache: Any | None = None,
     monitor: Any | None = None,
+    sandbox: bool = True,
+    timeout: float = 30.0,
+    max_workers: int | None = None,
 ) -> List[NewsArticle]:
     """Execute plugins concurrently and collect their results."""
 
-    tasks: List[asyncio.Task] = []
-    labels: List[str] = []
-    for plugin in plugins:
+    plugin_list = list(plugins)
+    if not plugin_list:
+        return []
+
+    specs = [_build_spec(plugin) for plugin in plugin_list]
+    settings: List[Dict[str, Any]] = []
+    for plugin in plugin_list:
         plugin_cfg: Dict[str, Any] = {}
         if isinstance(config, dict):
-            plugin_cfg = config.get(plugin.name, {})
-        result = plugin.fetch(plugin_cfg, cache=cache, monitor=monitor)
-        if inspect.isawaitable(result):
-            task = asyncio.create_task(result)
-        else:
+            plugin_cfg = config.get(getattr(plugin, "name", ""), {})
+        settings.append(plugin_cfg)
 
-            async def _wrap(value: Iterable[NewsArticle]) -> List[NewsArticle]:
-                return list(value)
-
-            task = asyncio.create_task(_wrap(result))
-        tasks.append(task)
-        labels.append(getattr(plugin, "name", plugin.__class__.__name__))
-
+    labels = [spec.label for spec in specs]
     articles: List[NewsArticle] = []
-    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    if not sandbox:
+        tasks: List[asyncio.Task] = []
+        for plugin, plugin_cfg, _label in zip(plugin_list, settings, labels, strict=False):
+            result = plugin.fetch(plugin_cfg, cache=cache, monitor=monitor)
+            if inspect.isawaitable(result):
+                task = asyncio.create_task(result)
+            else:
+
+                async def _wrap(value: Iterable[NewsArticle]) -> List[NewsArticle]:
+                    return list(value)
+
+                task = asyncio.create_task(_wrap(result))
+            tasks.append(task)
+
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        for label, result in zip(labels, results, strict=False):
+            if isinstance(result, Exception):
+                logger.exception("Plugin %s failed", label, exc_info=result)
+                if monitor is not None and hasattr(monitor, "record_error"):
+                    monitor.record_error(label, result)
+                continue
+            data = list(result)
+            if monitor is not None and hasattr(monitor, "record_articles"):
+                monitor.record_articles(label, len(data))
+            articles.extend(data)
+        return articles
+
+    sys_path = list(sys.path)
+    worker_count = max_workers or min(len(specs), os.cpu_count() or 1) or 1
+    loop = asyncio.get_running_loop()
+
+    async def _submit(
+        executor: ProcessPoolExecutor,
+        spec: PluginSpec,
+        plugin_cfg: Dict[str, Any],
+    ) -> List[Dict[str, Any]]:
+        future = loop.run_in_executor(
+            executor,
+            _execute_in_subprocess,
+            spec,
+            plugin_cfg,
+            sys_path,
+        )
+        return await asyncio.wait_for(future, timeout)
+
+    with ProcessPoolExecutor(max_workers=worker_count) as executor:
+        tasks = [
+            asyncio.create_task(_submit(executor, spec, cfg))
+            for spec, cfg in zip(specs, settings, strict=False)
+        ]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
     for label, result in zip(labels, results, strict=False):
+        if isinstance(result, asyncio.TimeoutError):
+            logger.warning("Plugin %s timed out after %.1fs", label, timeout)
+            error = PluginError(f"{label} timed out after {timeout} seconds")
+            if monitor is not None and hasattr(monitor, "record_error"):
+                monitor.record_error(label, error)
+            continue
         if isinstance(result, Exception):
             logger.exception("Plugin %s failed", label, exc_info=result)
             if monitor is not None and hasattr(monitor, "record_error"):
                 monitor.record_error(label, result)
             continue
-        data = list(result)
+        try:
+            deserialised = [_deserialize_article(item) for item in result]
+        except Exception as exc:  # pragma: no cover - defensive conversion
+            logger.exception("Failed to deserialize results from %s", label, exc_info=exc)
+            if monitor is not None and hasattr(monitor, "record_error"):
+                monitor.record_error(label, exc)
+            continue
         if monitor is not None and hasattr(monitor, "record_articles"):
-            monitor.record_articles(label, len(data))
-        articles.extend(data)
+            monitor.record_articles(label, len(deserialised))
+        articles.extend(deserialised)
+
     return articles
 
 
-__all__ = ["discover_plugins", "execute_plugins"]
+__all__ = ["discover_plugins", "execute_plugins", "PluginSpec"]

--- a/google-news-drive-sync/tests/test_monitor.py
+++ b/google-news-drive-sync/tests/test_monitor.py
@@ -8,6 +8,10 @@ def test_monitor_records_metrics():
     monitor.record_error("news_api", RuntimeError("boom"))
     monitor.record_document_upload()
     monitor.complete_run(status="success")
+    with monitor.track_latency("fetch"):
+        pass
+    monitor.record_latency("upload", 0.25)
+    monitor.record_queue_depth(3)
 
     snapshot = monitor.snapshot()
     assert snapshot.articles_processed == 5
@@ -15,7 +19,11 @@ def test_monitor_records_metrics():
     assert snapshot.source_counts["news_api"] == 5
     assert snapshot.documents_uploaded == 1
     assert snapshot.runs == 1
+    assert "fetch" in snapshot.latency
+    assert snapshot.queue_depth["latest"] == 3.0
     metrics = monitor.metrics()
     assert metrics["last_status"] == "success"
+    assert "upload" in metrics["latency"]
     payload = monitor.render_prometheus()
     assert "gnds_articles_processed_total" in payload
+    assert "gnds_latency_seconds_sum" in payload

--- a/google-news-drive-sync/tests/test_plugin_manager.py
+++ b/google-news-drive-sync/tests/test_plugin_manager.py
@@ -1,5 +1,6 @@
 import pytest
 
+from src.monitor import MonitoringClient
 from src.plugin_manager import discover_plugins, execute_plugins
 
 
@@ -36,3 +37,46 @@ class ExamplePlugin:
     results = await execute_plugins(plugins, {"example": {"title": "Configured"}})
     assert len(results) == 1
     assert results[0].title == "Configured"
+
+
+@pytest.mark.asyncio
+async def test_plugin_timeout_records_error(tmp_path):
+    plugin_file = tmp_path / "slow_plugin.py"
+    plugin_file.write_text(
+        """
+import asyncio
+from typing import Any, Dict
+
+from src.news_fetcher import NewsArticle
+
+
+class SlowPlugin:
+    name = "slow"
+
+    async def fetch(self, config: Dict[str, Any], *, cache=None, monitor=None):
+        await asyncio.sleep(0.2)
+        return [
+            NewsArticle(
+                title="Slow",
+                description=None,
+                url="https://example.com/slow",
+                published_at=None,
+                source="slow",
+            )
+        ]
+"""
+    )
+
+    plugins = discover_plugins(paths=[plugin_file])
+    monitor = MonitoringClient()
+
+    results = await execute_plugins(
+        plugins,
+        {},
+        monitor=monitor,
+        sandbox=True,
+        timeout=0.05,
+    )
+
+    assert results == []
+    assert monitor.snapshot().errors == 1


### PR DESCRIPTION
## Summary
- add API key enforcement, request rate limiting, and related configuration/documentation for the FastAPI dashboard
- extend pipeline monitoring with latency and queue-depth metrics while instrumenting the main orchestration flow
- sandbox plugin execution in subprocesses with timeouts and cover the new behaviour in unit tests

## Testing
- python -m pytest tests/
- python -m ruff check src/ tests/


------
https://chatgpt.com/codex/tasks/task_e_68d5900aacb08321bccd4a0898cc3271